### PR TITLE
Fix enable project-root resolution, run -- passthrough, package init clobber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,14 @@ All notable changes to Lineage will be documented here.
 - Package initialization and discovery.
 - Provider launch planning and local shims.
 - Open-source contribution templates and repository skills.
+- Fix: `lineage enable` now walks up to an existing project root (like
+  `lineage run` already does) instead of creating a second, shadow
+  `.lineage/config.yaml` when run from a subdirectory; relative package
+  refs are re-expressed against the project root so they keep resolving
+  correctly.
+- Fix: `lineage run <provider> ... -- <args>` now truly passes everything
+  after `--` through to the wrapped provider, even a literal `--dry-run`,
+  instead of always intercepting it as lineage's own flag.
+- Fix: `lineage package init` no longer resets an existing `lineage.yaml`
+  to defaults when run again against an already-initialized package,
+  preserving hand-edited version/description and any existing contents.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -113,28 +114,68 @@ func runEnable(args []string, home string, stdout, stderr io.Writer) error {
 		fmt.Fprintln(stderr, err)
 		return err
 	}
+
+	// Reuse the project config an enclosing `lineage run` would find (it
+	// walks up parent directories), rather than always looking at cwd. This
+	// keeps `enable` and `run` agreeing on where "the project" is: enabling
+	// a package from inside a subdirectory of an already-initialized
+	// project must update that project's existing root config, not fork a
+	// second, shadow .lineage/config.yaml next to cwd.
+	projectRoot := cwd
 	configPath := config.ProjectConfigPath(cwd)
 	cfg := config.DefaultProjectConfig()
-	if loaded, err := config.LoadProjectConfig(configPath); err == nil {
-		cfg = loaded
-	} else if !os.IsNotExist(err) {
+	if found, err := config.FindProjectConfig(cwd); err == nil {
+		projectRoot = found.Root
+		configPath = found.Path
+		cfg = found.Config
+	} else if !errors.Is(err, config.ErrProjectConfigNotFound) {
 		fmt.Fprintln(stderr, err)
 		return err
 	}
 
 	ref := args[0]
-	if _, err := packages.ResolveReference(home, cfg.Workspace, cwd, ref); err != nil {
+
+	// A "./" or "../" style ref is relative to where the user typed it
+	// (cwd), matching the documented `lineage enable ./resume-workflow`
+	// usage. A bare name is a lookup by id against the project/user/
+	// workspace package search path, which is anchored at the project
+	// root. Resolve each the way it's meant, so a relative ref keeps
+	// pointing at the exact directory the user meant even when cwd is a
+	// subdirectory of a project that was already initialized higher up.
+	resolveRoot := projectRoot
+	if filepath.IsAbs(ref) || strings.HasPrefix(ref, ".") {
+		resolveRoot = cwd
+	}
+	resolvedPath, err := packages.ResolveReference(home, cfg.Workspace, resolveRoot, ref)
+	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return err
 	}
-	if !contains(cfg.EnabledPackages, ref) {
-		cfg.EnabledPackages = append(cfg.EnabledPackages, ref)
+
+	// The config we're about to save lives at the project root, and
+	// `lineage run` later resolves every enabled_packages entry relative to
+	// that same root. Store relative refs re-expressed against projectRoot
+	// so they still resolve correctly, instead of the literal string the
+	// user typed relative to cwd.
+	storedRef := ref
+	if strings.HasPrefix(ref, ".") && resolveRoot != projectRoot {
+		if rel, relErr := filepath.Rel(projectRoot, resolvedPath); relErr == nil {
+			rel = filepath.ToSlash(rel)
+			if !strings.HasPrefix(rel, ".") {
+				rel = "./" + rel
+			}
+			storedRef = rel
+		}
+	}
+
+	if !contains(cfg.EnabledPackages, storedRef) {
+		cfg.EnabledPackages = append(cfg.EnabledPackages, storedRef)
 	}
 	if err := config.SaveProjectConfig(configPath, cfg); err != nil {
 		fmt.Fprintln(stderr, err)
 		return err
 	}
-	fmt.Fprintf(stdout, "enabled package %s in %s\n", ref, configPath)
+	fmt.Fprintf(stdout, "enabled package %s in %s\n", storedRef, configPath)
 	return nil
 }
 
@@ -147,18 +188,7 @@ func runProvider(ctx context.Context, args []string, home string, stdout, stderr
 	}
 
 	providerName := args[0]
-	dryRun := false
-	providerArgs := []string{}
-	for _, arg := range args[1:] {
-		if arg == "--dry-run" {
-			dryRun = true
-			continue
-		}
-		if arg == "--" {
-			continue
-		}
-		providerArgs = append(providerArgs, arg)
-	}
+	dryRun, providerArgs := parseRunArgs(args[1:])
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -209,6 +239,43 @@ Usage:
   lineage run <claude|codex> [--dry-run] [-- provider args...]
   lineage install-shims
 `))
+}
+
+// parseRunArgs splits the arguments following `lineage run <provider>` into
+// lineage's own --dry-run flag and the args that should be forwarded to the
+// wrapped provider. A bare "--" marks the boundary explicitly: everything
+// before it is scanned for lineage flags, everything after it is passed
+// through to the provider verbatim, even if it happens to collide with a
+// lineage flag name (for example a provider's own --dry-run flag). Without
+// "--", the whole argument list is scanned for lineage flags, matching the
+// simple common case of `lineage run claude --dry-run`.
+func parseRunArgs(args []string) (dryRun bool, providerArgs []string) {
+	providerArgs = []string{}
+
+	sep := -1
+	for i, arg := range args {
+		if arg == "--" {
+			sep = i
+			break
+		}
+	}
+
+	scan := args
+	var passthrough []string
+	if sep >= 0 {
+		scan = args[:sep]
+		passthrough = args[sep+1:]
+	}
+
+	for _, arg := range scan {
+		if arg == "--dry-run" {
+			dryRun = true
+			continue
+		}
+		providerArgs = append(providerArgs, arg)
+	}
+	providerArgs = append(providerArgs, passthrough...)
+	return dryRun, providerArgs
 }
 
 func contains(values []string, target string) bool {

--- a/internal/cli/regression_test.go
+++ b/internal/cli/regression_test.go
@@ -1,0 +1,243 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lineage-dev/lineage/internal/config"
+	"github.com/lineage-dev/lineage/internal/packages"
+)
+
+// TestEnableFromSubdirectoryUsesProjectRoot guards against a regression
+// where `lineage enable` used cwd directly instead of walking up to find an
+// already-initialized project, the same way `lineage run` does. Enabling a
+// package from any subdirectory of a project must update that project's
+// existing root config (not fork a second, shadow .lineage/config.yaml),
+// and a relative ref must be re-expressed relative to the project root so
+// `lineage run` (which resolves enabled_packages against the root) still
+// finds the exact directory the user pointed at.
+func TestEnableFromSubdirectoryUsesProjectRoot(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	sub := filepath.Join(project, "packages", "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Project already has an initialized root config (e.g. from a previous
+	// `lineage enable` at the root, or just `lineage init`).
+	rootConfigPath := config.ProjectConfigPath(project)
+	if err := config.SaveProjectConfig(rootConfigPath, config.DefaultProjectConfig()); err != nil {
+		t.Fatal(err)
+	}
+
+	// A package that happens to live under the subdirectory.
+	pkgDir := filepath.Join(sub, "local-pack")
+	if err := packages.InitPackage(pkgDir, "local-pack"); err != nil {
+		t.Fatal(err)
+	}
+
+	oldHome := os.Getenv(config.HomeEnv)
+	t.Setenv(config.HomeEnv, home)
+	defer t.Setenv(config.HomeEnv, oldHome)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+	if err := os.Chdir(sub); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"enable", "./local-pack"}, &stdout, &stderr); err != nil {
+		t.Fatalf("enable error = %v stderr=%s", err, stderr.String())
+	}
+
+	// No shadow config should have been created in the subdirectory.
+	if _, err := os.Stat(config.ProjectConfigPath(sub)); err == nil {
+		t.Fatalf("a second, shadow .lineage/config.yaml was created at %s; `lineage enable` should reuse the project root config discovered via FindProjectConfig, the same way `lineage run` does", config.ProjectConfigPath(sub))
+	}
+
+	// The ROOT config should list the package, re-expressed relative to the
+	// project root (not the literal "./local-pack" the user typed, which
+	// would resolve to the wrong directory from the root).
+	rootCfg, err := config.LoadProjectConfig(rootConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRef := "./packages/sub/local-pack"
+	if !contains(rootCfg.EnabledPackages, wantRef) {
+		t.Fatalf("root config EnabledPackages = %#v; want it to contain %q", rootCfg.EnabledPackages, wantRef)
+	}
+
+	// And it must actually resolve back to the package the user pointed at,
+	// the way `lineage run` will resolve it (against the project root).
+	for _, storedRef := range rootCfg.EnabledPackages {
+		resolved, err := packages.ResolveReference(home, rootCfg.Workspace, project, storedRef)
+		if err != nil {
+			t.Fatalf("ResolveReference(%q) error = %v", storedRef, err)
+		}
+		if resolved != pkgDir {
+			t.Fatalf("ResolveReference(%q) = %q, want %q", storedRef, resolved, pkgDir)
+		}
+	}
+}
+
+// TestEnableFromProjectRootIsUnaffected guards against a regression in the
+// common case (enabling from the project root itself): the ref should be
+// stored exactly as typed, matching the pre-existing documented usage
+// (`lineage enable ./resume-workflow`).
+func TestEnableFromProjectRootIsUnaffected(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	pkgDir := filepath.Join(project, "agent-pack")
+	if err := packages.InitPackage(pkgDir, "agent-pack"); err != nil {
+		t.Fatal(err)
+	}
+
+	oldHome := os.Getenv(config.HomeEnv)
+	t.Setenv(config.HomeEnv, home)
+	defer t.Setenv(config.HomeEnv, oldHome)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"enable", "./agent-pack"}, &stdout, &stderr); err != nil {
+		t.Fatalf("enable error = %v stderr=%s", err, stderr.String())
+	}
+
+	cfg, err := config.LoadProjectConfig(config.ProjectConfigPath(project))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(cfg.EnabledPackages, "./agent-pack") {
+		t.Fatalf("EnabledPackages = %#v, want it to contain ./agent-pack unchanged", cfg.EnabledPackages)
+	}
+}
+
+// TestRunPassesFlagsAfterDoubleDashToProvider guards against a regression
+// where arguments after the `--` separator were still scanned for
+// lineage's own flag names. Everything after `--` belongs to the wrapped
+// provider and must be passed through verbatim, even if it collides with a
+// lineage-level flag such as --dry-run.
+func TestRunPassesFlagsAfterDoubleDashToProvider(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake provider binary that records the args it was invoked with.
+	marker := filepath.Join(tmp, "invoked-args.txt")
+	fakeBinary := filepath.Join(tmp, "fake-claude.sh")
+	script := "#!/bin/sh\necho \"$@\" > " + marker + "\n"
+	if err := os.WriteFile(fakeBinary, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.DefaultProjectConfig()
+	cfg.Providers = map[string]config.Provider{"claude": {Binary: fakeBinary}}
+	if err := config.SaveProjectConfig(config.ProjectConfigPath(project), cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	oldHome := os.Getenv(config.HomeEnv)
+	t.Setenv(config.HomeEnv, home)
+	defer t.Setenv(config.HomeEnv, oldHome)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	// Everything after "--" is meant for the provider, including a literal
+	// "--dry-run" flag that the wrapped agent itself understands.
+	if err := Execute(nil, []string{"run", "claude", "--", "--dry-run"}, &stdout, &stderr); err != nil {
+		t.Fatalf("run error = %v stderr=%s", err, stderr.String())
+	}
+
+	data, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("provider binary was never invoked (lineage likely intercepted --dry-run as its own flag instead of passing it through): %v", err)
+	}
+	got := strings.TrimSpace(string(data))
+	if got != "--dry-run" {
+		t.Fatalf("provider invoked with args %q, want %q", got, "--dry-run")
+	}
+}
+
+// TestParseRunArgs exercises the lineage-flag / provider-arg split directly,
+// covering both the no-"--" shorthand and the explicit separator form.
+func TestParseRunArgs(t *testing.T) {
+	cases := []struct {
+		name        string
+		args        []string
+		wantDryRun  bool
+		wantForward []string
+	}{
+		{
+			name:        "dry-run without separator",
+			args:        []string{"--dry-run"},
+			wantDryRun:  true,
+			wantForward: []string{},
+		},
+		{
+			name:        "plain args without separator",
+			args:        []string{"--model", "sonnet"},
+			wantDryRun:  false,
+			wantForward: []string{"--model", "sonnet"},
+		},
+		{
+			name:        "dry-run before separator, passthrough after",
+			args:        []string{"--dry-run", "--", "--model", "sonnet"},
+			wantDryRun:  true,
+			wantForward: []string{"--model", "sonnet"},
+		},
+		{
+			name:        "provider's own --dry-run after separator is preserved",
+			args:        []string{"--model", "sonnet", "--", "--dry-run"},
+			wantDryRun:  false,
+			wantForward: []string{"--model", "sonnet", "--dry-run"},
+		},
+		{
+			name:        "bare separator with nothing after",
+			args:        []string{"--dry-run", "--"},
+			wantDryRun:  true,
+			wantForward: []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dryRun, forward := parseRunArgs(tc.args)
+			if dryRun != tc.wantDryRun {
+				t.Fatalf("dryRun = %v, want %v", dryRun, tc.wantDryRun)
+			}
+			if len(forward) != len(tc.wantForward) {
+				t.Fatalf("forward = %#v, want %#v", forward, tc.wantForward)
+			}
+			for i := range forward {
+				if forward[i] != tc.wantForward[i] {
+					t.Fatalf("forward = %#v, want %#v", forward, tc.wantForward)
+				}
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,13 @@ type FoundProjectConfig struct {
 	Config ProjectConfig
 }
 
+// ErrProjectConfigNotFound is returned by FindProjectConfig when no
+// .lineage/config.yaml exists at the start directory or any parent.
+// Callers that can legitimately initialize a new project config (such as
+// `lineage enable`) should check for this with errors.Is and fall back to
+// creating one, rather than treating every non-nil error the same way.
+var ErrProjectConfigNotFound = errors.New("no " + DirName + "/" + ConfigFileName + " found in this directory or any parent")
+
 func DefaultProjectConfig() ProjectConfig {
 	return ProjectConfig{
 		EnabledPackages:     []string{},
@@ -58,7 +65,7 @@ func FindProjectConfig(start string) (FoundProjectConfig, error) {
 
 		parent := filepath.Dir(current)
 		if parent == current {
-			return FoundProjectConfig{}, fmt.Errorf("missing %s; run lineage enable <package-path-or-id> from a project first", filepath.Join(DirName, ConfigFileName))
+			return FoundProjectConfig{}, fmt.Errorf("%w; run lineage enable <package-path-or-id> from a project first", ErrProjectConfigNotFound)
 		}
 		current = parent
 	}

--- a/internal/packages/discovery.go
+++ b/internal/packages/discovery.go
@@ -34,10 +34,24 @@ func Discover(dir string) (Package, error) {
 	return pkg, nil
 }
 
+// InitPackage scaffolds a package directory: a lineage.yaml manifest plus
+// the standard skills/workflows/agents/policies/references/adapters
+// subdirectories. It is safe to call more than once against the same
+// directory. If a manifest already exists there, InitPackage leaves it
+// untouched rather than resetting it to defaults, so re-running `lineage
+// package init` never silently discards a maintainer's version bump,
+// description edit, or other manifest changes.
 func InitPackage(dir, name string) error {
-	manifest := DefaultManifest(name)
-	if err := SaveManifest(dir, manifest); err != nil {
-		return err
+	manifestPath := filepath.Join(dir, ManifestFileName)
+	switch _, err := os.Stat(manifestPath); {
+	case err == nil:
+		// Manifest already present; nothing to do here.
+	case os.IsNotExist(err):
+		if err := SaveManifest(dir, DefaultManifest(name)); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("check existing manifest %s: %w", manifestPath, err)
 	}
 
 	for _, child := range []string{"skills", "workflows", "agents", "policies", "references", "adapters"} {

--- a/internal/packages/regression_test.go
+++ b/internal/packages/regression_test.go
@@ -1,0 +1,61 @@
+package packages
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPackageInitIsIdempotentAndPreservesManifest guards against a
+// regression called out by the project's own guidance (docs/testing.md,
+// .agents/skills/lineage-go-engineering/SKILL.md: "running the same command
+// twice should not duplicate config or corrupt files"). Re-running
+// `lineage package init` against a package directory that already has a
+// manifest must not silently discard hand-edited fields such as version
+// and description, or any custom skill content already added.
+func TestPackageInitIsIdempotentAndPreservesManifest(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "mypack")
+	if err := InitPackage(dir, "mypack"); err != nil {
+		t.Fatalf("InitPackage() error = %v", err)
+	}
+
+	// Simulate a maintainer hand-editing the manifest after the initial init.
+	manifest, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest.Version = "2.5.0"
+	manifest.Description = "Hand-edited description, please keep me"
+	if err := SaveManifest(dir, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	// Also simulate a custom skill someone added inside the package.
+	customSkill := filepath.Join(dir, "skills", "custom-skill", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(customSkill), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(customSkill, []byte("# custom"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-running init against the same directory (e.g. by mistake, or as
+	// part of a script) must not destroy the hand-edited manifest fields.
+	if err := InitPackage(dir, "mypack"); err != nil {
+		t.Fatalf("InitPackage() second call error = %v", err)
+	}
+
+	got, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Version != "2.5.0" {
+		t.Fatalf("Version = %q after re-init, want preserved %q (InitPackage overwrote an existing lineage.yaml with defaults)", got.Version, "2.5.0")
+	}
+	if got.Description != "Hand-edited description, please keep me" {
+		t.Fatalf("Description = %q after re-init, want preserved value", got.Description)
+	}
+	if _, err := os.Stat(customSkill); err != nil {
+		t.Fatalf("custom skill file lost after re-init: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Three regressions in the CLI, each fixed with a dedicated test:

- `lineage enable` now walks up to an existing project root the same way `lineage run` already does, instead of forking a shadow `.lineage/config.yaml` when run from a subdirectory. Relative refs are re-expressed against the project root so they keep resolving correctly.
- `lineage run <provider> ... -- <args>` now genuinely forwards everything after `--` to the wrapped provider, even a literal `--dry-run`, instead of always intercepting it as lineage's own flag.
- `lineage package init` no longer resets an existing `lineage.yaml` to defaults when run again against an already-initialized package, preserving hand-edited version/description and contents.

## Linked Issue

Closes #14, Closes #15, Closes #16

- [x] The linked issues are assigned to me.
- [x] This PR targets `develop`.

## Package Impact

- [x] Package discovery or enablement
- [x] Provider launch/shim behavior
- [ ] Package format or manifest behavior
- [ ] Setup or permission flow
- [ ] Documentation only
- [x] Tests only (regression coverage added alongside each fix)

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

```text
go build ./...
go test ./...
```
All packages pass, including 5 new regression tests (`internal/cli/regression_test.go`, `internal/packages/regression_test.go`) alongside the existing 11.

## Notes For Reviewers

No behavior change beyond the three fixes above; no new dependencies or config schema changes.