### PR TITLE
Add materializer core and Claude Code adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,3 +59,10 @@ All notable changes to Lineage will be documented here.
   content. `internal/runtime` and the CLI's usage text consult it instead
   of hardcoding `claude`/`codex`, so adding a provider is a one-entry
   change in one file rather than a hunt through the core runtime.
+- `lineage run claude` now materializes enabled packages for Claude Code:
+  skills are staged into `.claude/skills/<pkg>-<skill>/` and a generated
+  section in `CLAUDE.md` lists active packages, agents, policies, and
+  workflows. Materialization is idempotent and reversible (re-running
+  reflects the current enabled-package set exactly, via a per-provider
+  `.lineage/materialized-<provider>.json` state file) and is skipped
+  entirely on `--dry-run`.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/lineage-dev/lineage/internal/config"
+	"github.com/lineage-dev/lineage/internal/materialize"
 	"github.com/lineage-dev/lineage/internal/packages"
 	"github.com/lineage-dev/lineage/internal/provider"
 	"github.com/lineage-dev/lineage/internal/runtime"
@@ -279,6 +280,17 @@ func runProvider(ctx context.Context, args []string, home string, stdout, stderr
 		fmt.Fprint(stdout, plan.DryRunString())
 		return nil
 	}
+
+	adapter, err := provider.Get(providerName)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	if err := materialize.Apply(plan.ProjectRoot, adapter, plan.Packages); err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
 	if err := provider.Launch(plan.ProviderPlan); err != nil {
 		fmt.Fprintln(stderr, err)
 		return err

--- a/internal/materialize/materialize.go
+++ b/internal/materialize/materialize.go
@@ -1,0 +1,226 @@
+// Package materialize stages enabled packages' content where a wrapped
+// agent provider actually reads it, instead of leaving discovery results
+// stranded in `lineage run --dry-run` output. It is provider-neutral: all
+// provider-specific paths come from a provider.Provider value supplied by the
+// caller.
+package materialize
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/lineage-dev/lineage/internal/packages"
+	"github.com/lineage-dev/lineage/internal/provider"
+)
+
+const (
+	stateDirName = ".lineage"
+	beginMarker  = "<!-- lineage:begin -->"
+	endMarker    = "<!-- lineage:end -->"
+)
+
+// state is the record of exactly what the last Apply call wrote for one
+// provider, so a later call can remove entries that are no longer desired
+// (a package got disabled, a skill got removed) instead of only ever adding.
+type state struct {
+	SkillDirs []string `json:"skill_dirs"` // relative to project root, sorted
+}
+
+func statePath(projectRoot, providerName string) string {
+	return filepath.Join(projectRoot, stateDirName, "materialized-"+providerName+".json")
+}
+
+// Apply stages every skill from pkgs into adapter.SkillsDir and refreshes
+// the generated section of adapter.ContextFile describing active packages,
+// agents, policies, and workflows.
+//
+// It is idempotent and reversible: calling it again with a different (or
+// empty) set of packages removes whatever a previous call staged that is no
+// longer desired. This is tracked via a small per-provider state file
+// (.lineage/materialized-<provider>.json) rather than guessed from disk
+// contents, so cleanup is exact even if the package set shrinks between
+// runs.
+func Apply(projectRoot string, adapter provider.Provider, pkgs []packages.Package) error {
+	prev, err := loadState(projectRoot, adapter.Name)
+	if err != nil {
+		return err
+	}
+
+	desired := map[string]string{} // relative skill dir -> absolute source dir
+	for _, pkg := range pkgs {
+		for _, skill := range pkg.Skills {
+			rel := filepath.Join(adapter.SkillsDir, pkg.Manifest.Name+"-"+skill)
+			desired[rel] = filepath.Join(pkg.Path, "skills", skill)
+		}
+	}
+
+	for _, rel := range prev.SkillDirs {
+		if _, ok := desired[rel]; ok {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(projectRoot, rel)); err != nil {
+			return fmt.Errorf("remove stale materialized skill %s: %w", rel, err)
+		}
+	}
+
+	written := make([]string, 0, len(desired))
+	for rel, src := range desired {
+		dest := filepath.Join(projectRoot, rel)
+		if err := os.RemoveAll(dest); err != nil {
+			return fmt.Errorf("clear %s before staging: %w", rel, err)
+		}
+		if err := copyDir(src, dest); err != nil {
+			return fmt.Errorf("stage skill into %s: %w", rel, err)
+		}
+		written = append(written, rel)
+	}
+	sort.Strings(written)
+
+	if err := writeSummary(filepath.Join(projectRoot, adapter.ContextFile), pkgs); err != nil {
+		return fmt.Errorf("update %s: %w", adapter.ContextFile, err)
+	}
+
+	return saveState(projectRoot, adapter.Name, state{SkillDirs: written})
+}
+
+func loadState(projectRoot, providerName string) (state, error) {
+	data, err := os.ReadFile(statePath(projectRoot, providerName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return state{}, nil
+		}
+		return state{}, err
+	}
+	var s state
+	if err := json.Unmarshal(data, &s); err != nil {
+		return state{}, fmt.Errorf("parse %s: %w", statePath(projectRoot, providerName), err)
+	}
+	return s, nil
+}
+
+func saveState(projectRoot, providerName string, s state) error {
+	path := statePath(projectRoot, providerName)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func writeSummary(path string, pkgs []packages.Package) error {
+	block := renderSummaryBlock(pkgs)
+
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	next := block
+	if err == nil {
+		next = replaceBlock(string(existing), block)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(next), 0o644)
+}
+
+func renderSummaryBlock(pkgs []packages.Package) string {
+	var b strings.Builder
+	b.WriteString(beginMarker + "\n")
+	b.WriteString("Lineage-managed section. Do not edit by hand; it is regenerated on every `lineage run`.\n\n")
+	b.WriteString("Active Lineage packages:\n\n")
+	if len(pkgs) == 0 {
+		b.WriteString("none\n")
+	}
+	for _, pkg := range pkgs {
+		fmt.Fprintf(&b, "- %s@%s", pkg.Manifest.Name, pkg.Manifest.Version)
+		if pkg.Manifest.Description != "" {
+			fmt.Fprintf(&b, " - %s", pkg.Manifest.Description)
+		}
+		b.WriteString("\n")
+		if len(pkg.Agents) > 0 {
+			fmt.Fprintf(&b, "  agents: %s\n", strings.Join(pkg.Agents, ", "))
+		}
+		if len(pkg.Policies) > 0 {
+			fmt.Fprintf(&b, "  policies: %s\n", strings.Join(pkg.Policies, ", "))
+		}
+		if len(pkg.Workflows) > 0 {
+			fmt.Fprintf(&b, "  workflows: %s\n", strings.Join(pkg.Workflows, ", "))
+		}
+	}
+	b.WriteString(endMarker + "\n")
+	return b.String()
+}
+
+// replaceBlock swaps the content between beginMarker and endMarker for
+// block, appending block to the end of existing content if no markers are
+// present yet.
+func replaceBlock(existing, block string) string {
+	beginIdx := strings.Index(existing, beginMarker)
+	endIdx := strings.Index(existing, endMarker)
+	if beginIdx == -1 || endIdx == -1 || endIdx < beginIdx {
+		trimmed := strings.TrimRight(existing, "\n")
+		if trimmed == "" {
+			return block
+		}
+		return trimmed + "\n\n" + block
+	}
+	after := strings.TrimPrefix(existing[endIdx+len(endMarker):], "\n")
+	return existing[:beginIdx] + block + after
+}
+
+func copyDir(src, dest string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dest, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to materialize symlink %s", path)
+		}
+		return copyFile(path, target)
+	})
+}
+
+func copyFile(src, dest string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/internal/materialize/materialize_test.go
+++ b/internal/materialize/materialize_test.go
@@ -1,0 +1,170 @@
+package materialize
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lineage-dev/lineage/internal/packages"
+	"github.com/lineage-dev/lineage/internal/provider"
+)
+
+func TestApplyStagesSkillsAndWritesContextFile(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildTestPackage(t, "review-pack", "review")
+
+	adapter := provider.Provider{Name: "claude", SkillsDir: filepath.Join(".claude", "skills"), ContextFile: "CLAUDE.md"}
+	if err := Apply(root, adapter, []packages.Package{pkg}); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	skillFile := filepath.Join(root, ".claude", "skills", "review-pack-review", "SKILL.md")
+	if _, err := os.Stat(skillFile); err != nil {
+		t.Fatalf("expected staged skill at %s: %v", skillFile, err)
+	}
+
+	contextData, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	content := string(contextData)
+	if !containsAll(content, beginMarker, endMarker, "review-pack@0.1.0") {
+		t.Fatalf("CLAUDE.md missing expected content:\n%s", content)
+	}
+}
+
+func TestApplyIsIdempotent(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildTestPackage(t, "review-pack", "review")
+	adapter := provider.Provider{Name: "claude", SkillsDir: filepath.Join(".claude", "skills"), ContextFile: "CLAUDE.md"}
+
+	if err := Apply(root, adapter, []packages.Package{pkg}); err != nil {
+		t.Fatalf("Apply() #1 error = %v", err)
+	}
+	first, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+
+	if err := Apply(root, adapter, []packages.Package{pkg}); err != nil {
+		t.Fatalf("Apply() #2 error = %v", err)
+	}
+	second, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+
+	if string(first) != string(second) {
+		t.Fatalf("CLAUDE.md changed between identical Apply calls:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(root, ".claude", "skills"))
+	if err != nil {
+		t.Fatalf("read skills dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("skills dir has %d entries, want 1 (no duplication): %v", len(entries), entries)
+	}
+}
+
+func TestApplyRemovesStaleSkillsWhenPackageDisabled(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildTestPackage(t, "review-pack", "review")
+	adapter := provider.Provider{Name: "claude", SkillsDir: filepath.Join(".claude", "skills"), ContextFile: "CLAUDE.md"}
+
+	if err := Apply(root, adapter, []packages.Package{pkg}); err != nil {
+		t.Fatalf("Apply() #1 error = %v", err)
+	}
+	stagedDir := filepath.Join(root, ".claude", "skills", "review-pack-review")
+	if _, err := os.Stat(stagedDir); err != nil {
+		t.Fatalf("expected staged skill: %v", err)
+	}
+
+	if err := Apply(root, adapter, nil); err != nil {
+		t.Fatalf("Apply() #2 error = %v", err)
+	}
+	if _, err := os.Stat(stagedDir); !os.IsNotExist(err) {
+		t.Fatalf("expected stale skill dir removed, stat err = %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	if !containsAll(string(content), "none") {
+		t.Fatalf("expected CLAUDE.md to report no active packages, got:\n%s", content)
+	}
+}
+
+func TestApplyPreservesUserContentAroundMarkers(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildTestPackage(t, "review-pack", "review")
+	adapter := provider.Provider{Name: "claude", SkillsDir: filepath.Join(".claude", "skills"), ContextFile: "CLAUDE.md"}
+
+	mustWriteMaterialize(t, filepath.Join(root, "CLAUDE.md"), "# My project notes\n\nHand-written content.\n")
+
+	if err := Apply(root, adapter, []packages.Package{pkg}); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	if !containsAll(string(content), "Hand-written content.", beginMarker, endMarker) {
+		t.Fatalf("expected hand-written content preserved alongside generated block, got:\n%s", content)
+	}
+}
+
+func TestApplyRefusesSymlinkedSkillContent(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildTestPackage(t, "review-pack", "review")
+
+	target := filepath.Join(t.TempDir(), "outside.txt")
+	if err := os.WriteFile(target, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(pkg.Path, "skills", "review", "link.txt")); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+
+	adapter := provider.Provider{Name: "claude", SkillsDir: filepath.Join(".claude", "skills"), ContextFile: "CLAUDE.md"}
+	if err := Apply(root, adapter, []packages.Package{pkg}); err == nil {
+		t.Fatal("Apply() error = nil, want error for symlinked package content")
+	}
+}
+
+func buildTestPackage(t *testing.T, name, skill string) packages.Package {
+	t.Helper()
+	pkgDir := filepath.Join(t.TempDir(), name)
+	if err := packages.InitPackage(pkgDir, name); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteMaterialize(t, filepath.Join(pkgDir, "skills", skill, "SKILL.md"), "# "+skill)
+
+	pkg, err := packages.Discover(pkgDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pkg
+}
+
+func mustWriteMaterialize(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func containsAll(haystack string, needles ...string) bool {
+	for _, needle := range needles {
+		if !strings.Contains(haystack, needle) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Enabling a package currently only lists its skills/agents/policies in `lineage run --dry-run` output — the wrapped provider never actually sees them. This adds a provider-neutral materializer (`internal/materialize`) plus the first concrete adapter (Claude Code), from Phase 1 of `docs/v1-distribution-plan.md`.

- `internal/materialize`: stages each enabled package's skills where the provider reads them and maintains a generated, clearly-marked section in the provider's own context file. Idempotent and reversible via a small per-provider state file (`.lineage/materialized-<provider>.json`) recording exactly what a previous call wrote, so a shrinking package set is cleaned up exactly.
- `internal/provider.Adapter`: the provider-specific half (skills directory + context file path), keeping `internal/materialize` itself provider-neutral.
- Claude Code adapter: stages skills into `.claude/skills/<pkg>-<skill>/` (matches Claude Code's documented skill discovery convention) and maintains a generated section in `CLAUDE.md`.
- Wired into `lineage run claude` right before `provider.Launch`; explicitly skipped on `--dry-run` so a preview has no side effects.

## Linked Issue

Closes #18

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`.

## Package Impact

- [x] Package discovery or enablement
- [x] Provider launch/shim behavior
- [ ] Package format or manifest behavior
- [ ] Setup or permission flow
- [ ] Documentation only
- [ ] Tests only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted (symlinked skill content is rejected rather than followed).
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary (`provider.Adapter`).

## Verification

```text
go build ./...
go test ./...
```
All packages pass, including new tests for idempotency, stale-entry cleanup, symlink rejection, and preserving hand-written `CLAUDE.md` content around the generated markers. Also manually smoke-tested end-to-end against a fake `claude` binary: `--dry-run` writes nothing, a real run stages the skill and writes `CLAUDE.md`, and re-running doesn't duplicate anything.

## Notes For Reviewers

Full path-traversal/secret-scanning hardening is tracked separately (issue #10, Phase 3) — this PR only refuses to follow symlinks out of a package, since skill names here come from `packages.Discover`'s already-verified directory listing rather than arbitrary input. Codex's equivalent adapter is a separate follow-up (#19) reusing this same `internal/materialize` core.