### PR TITLE
Add project decision log

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ The source follows the standard Go layout:
 - `internal/` contains runtime, package, config, provider, and shim code.
 - `.agents/skills` contains repository-native contributor skills for consistent agent-assisted development.
 
+Important project decisions are recorded in [docs/decisions](docs/decisions/README.md).
+
 ## License
 
 MIT

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,3 +37,7 @@ The receiver should be able to inspect these contents before enabling a package.
 ## Safety Model
 
 Packages are local files, but they are still untrusted input. Lineage should validate manifests, normalize paths, avoid secret capture, and require explicit permission before any setup flow creates or changes files.
+
+## Decision Records
+
+Architecture decisions are tracked in the [decision log](decisions/README.md).

--- a/docs/decisions/0000-template.md
+++ b/docs/decisions/0000-template.md
@@ -1,0 +1,21 @@
+# NNNN Decision Title
+
+Status: Proposed
+
+Date: YYYY-MM-DD
+
+## Context
+
+What problem, uncertainty, or tradeoff forced this decision?
+
+## Decision
+
+What did we decide?
+
+## Consequences
+
+What becomes easier, harder, safer, or riskier because of this decision?
+
+## Follow-Up
+
+What should be revisited, measured, or built next?

--- a/docs/decisions/0001-use-go-for-local-runtime.md
+++ b/docs/decisions/0001-use-go-for-local-runtime.md
@@ -1,0 +1,23 @@
+# 0001 Use Go For The Local Runtime
+
+Status: Accepted
+
+Date: 2026-08-19
+
+## Context
+
+Lineage is a local runtime that should be easy to install, quick to start, and able to manage files, subprocesses, package archives, and provider shims across platforms.
+
+## Decision
+
+Use Go for the core CLI/runtime.
+
+## Consequences
+
+This gives Lineage a portable single-binary path, strong filesystem/process support, fast startup, and a straightforward test story with `go test ./...`.
+
+It also means contributors should avoid adding runtime dependencies unless they clearly improve local reliability or safety.
+
+## Follow-Up
+
+Keep the source layout idiomatic: `cmd/` for entrypoints and `internal/` for runtime packages.

--- a/docs/decisions/0002-keep-core-provider-agnostic.md
+++ b/docs/decisions/0002-keep-core-provider-agnostic.md
@@ -1,0 +1,21 @@
+# 0002 Keep Core Provider-Agnostic
+
+Status: Accepted
+
+Date: 2026-08-19
+
+## Context
+
+Lineage packages need to distribute agent environments while different providers may expose different commands, config locations, session concepts, and native extension points.
+
+## Decision
+
+Keep the core package, config, runtime, validation, and materialization semantics provider-agnostic. Provider-specific behavior belongs behind explicit adapter or shim boundaries.
+
+## Consequences
+
+This protects Lineage from baking one provider's assumptions into the package format. It also makes provider work slightly more deliberate: new provider behavior must state which boundary it belongs behind.
+
+## Follow-Up
+
+Provider adapter PRs should explain which files, environment variables, or command arguments they touch and why that behavior does not belong in core package semantics.

--- a/docs/decisions/0003-use-goal-based-milestones.md
+++ b/docs/decisions/0003-use-goal-based-milestones.md
@@ -1,0 +1,23 @@
+# 0003 Use Goal-Based Milestones
+
+Status: Accepted
+
+Date: 2026-08-19
+
+## Context
+
+Lineage is early and benefits from lean startup-style learning loops. Date-based milestones can make the project look organized while hiding whether the important product risks are actually being reduced.
+
+## Decision
+
+Use goal-based milestones rather than time-based milestones.
+
+## Consequences
+
+Milestones represent outcomes such as safe package round trips, receiver setup, runtime foundations, or provider confidence. A milestone is complete when the goal is proven well enough to trust, not when a calendar date arrives.
+
+This keeps planning lightweight and makes the GitHub Project board easier to scan.
+
+## Follow-Up
+
+When a milestone feels too broad, split it by learning goal instead of by date.

--- a/docs/decisions/0004-require-issue-links-and-test-plans-for-prs.md
+++ b/docs/decisions/0004-require-issue-links-and-test-plans-for-prs.md
@@ -1,0 +1,21 @@
+# 0004 Require Issue Links And Test Plans For PRs
+
+Status: Accepted
+
+Date: 2026-08-19
+
+## Context
+
+As contributors join, PRs need enough context to review safely. Lineage changes can affect local files, package safety, provider launch behavior, and user trust.
+
+## Decision
+
+Require PRs into `develop` to link an issue and include relevant test cases or a clear explanation for why automated tests do not apply.
+
+## Consequences
+
+This makes review easier and keeps implementation tied to agreed work. It also creates a small amount of ceremony, but that ceremony is intentional: it protects the package distribution layer from unreviewable changes.
+
+## Follow-Up
+
+Keep the `PR Policy` check small. If it becomes frustrating or noisy, improve the check rather than removing the requirement.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,34 @@
+# Decision Log
+
+This folder records important product and technical decisions for Lineage.
+
+Use this log when a decision will be expensive to reverse, affects contributors, shapes package semantics, or clarifies why the project chose one path over another.
+
+## Format
+
+Decision records use short ADR-style files:
+
+```text
+NNNN-short-title.md
+```
+
+Each record should include:
+
+- Status
+- Context
+- Decision
+- Consequences
+- Follow-up
+
+## Status Values
+
+- `Proposed`: under discussion.
+- `Accepted`: current project direction.
+- `Superseded`: replaced by a newer decision.
+
+## Decisions
+
+- [0001 Use Go For The Local Runtime](0001-use-go-for-local-runtime.md)
+- [0002 Keep Core Provider-Agnostic](0002-keep-core-provider-agnostic.md)
+- [0003 Use Goal-Based Milestones](0003-use-goal-based-milestones.md)
+- [0004 Require Issue Links And Test Plans For PRs](0004-require-issue-links-and-test-plans-for-prs.md)


### PR DESCRIPTION
## Summary

Adds a lightweight ADR-style decision log under `docs/decisions`, including a template and initial accepted decisions for Lineage's runtime language, provider boundaries, milestone style, and PR policy.

## Linked Issue

Closes #25

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [ ] Package format or manifest behavior
- [ ] Package discovery or enablement
- [ ] Provider launch/shim behavior
- [ ] Setup or permission flow
- [x] Documentation only
- [ ] Tests only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

List the relevant test cases added or updated, then paste the commands or checks you ran.

Relevant test cases:

- Documentation-only change; verified existing suite still passes.

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- Documentation-only decision log; no runtime behavior changed.

## Notes For Reviewers

This is intentionally lightweight so contributors can maintain it without turning decisions into a heavy process.
