### PR TITLE
Add a single provider registry; stop hardcoding claude/codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,8 @@ All notable changes to Lineage will be documented here.
 - Fix: `lineage package init` no longer resets an existing `lineage.yaml`
   to defaults when run again against an already-initialized package,
   preserving hand-edited version/description and any existing contents.
+- `internal/provider` now has a single provider registry (`Known`, `Get`,
+  `IsKnown`) naming every supported provider and where it reads staged
+  content. `internal/runtime` and the CLI's usage text consult it instead
+  of hardcoding `claude`/`codex`, so adding a provider is a one-entry
+  change in one file rather than a hunt through the core runtime.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -182,7 +182,7 @@ func runEnable(args []string, home string, stdout, stderr io.Writer) error {
 func runProvider(ctx context.Context, args []string, home string, stdout, stderr io.Writer) error {
 	_ = ctx
 	if len(args) == 0 {
-		err := fmt.Errorf("usage: lineage run <claude|codex> [--dry-run] [-- provider args...]")
+		err := fmt.Errorf("usage: lineage run <%s> [--dry-run] [-- provider args...]", providerNameList())
 		fmt.Fprintln(stderr, err)
 		return err
 	}
@@ -228,7 +228,7 @@ func runInstallShims(home string, stdout, stderr io.Writer) error {
 }
 
 func printUsage(w io.Writer) {
-	fmt.Fprintln(w, strings.TrimSpace(`
+	fmt.Fprintln(w, strings.TrimSpace(fmt.Sprintf(`
 Lineage shareable agent runtime
 
 Usage:
@@ -236,9 +236,21 @@ Usage:
   lineage init workspace <name>
   lineage package init <name>
   lineage enable <package-path-or-id>
-  lineage run <claude|codex> [--dry-run] [-- provider args...]
+  lineage run <%s> [--dry-run] [-- provider args...]
   lineage install-shims
-`))
+`, providerNameList())))
+}
+
+// providerNameList returns every registered provider name, comma-separated,
+// for CLI usage messages — so adding a provider to internal/provider's
+// registry is enough to keep help text accurate, with no other file to edit.
+func providerNameList() string {
+	known := provider.Known()
+	names := make([]string, len(known))
+	for i, p := range known {
+		names[i] = p.Name
+	}
+	return strings.Join(names, "|")
 }
 
 // parseRunArgs splits the arguments following `lineage run <provider>` into

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -62,3 +62,37 @@ func TestEnableAndDryRun(t *testing.T) {
 		t.Fatalf("dry-run output = %s", stdout.String())
 	}
 }
+
+func TestRunUnknownProviderListsKnownProviders(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+	oldHome := os.Getenv(config.HomeEnv)
+	t.Setenv(config.HomeEnv, home)
+	defer t.Setenv(config.HomeEnv, oldHome)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = Execute(nil, []string{"run", "does-not-exist"}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("Execute(run does-not-exist) error = nil, want error")
+	}
+	if !strings.Contains(stderr.String(), "claude") || !strings.Contains(stderr.String(), "codex") {
+		t.Fatalf("stderr = %q, want it to list known providers", stderr.String())
+	}
+}
+
+func TestUsageListsKnownProvidersNotHardcoded(t *testing.T) {
+	var stdout bytes.Buffer
+	printUsage(&stdout)
+	out := stdout.String()
+	if !strings.Contains(out, "claude") || !strings.Contains(out, "codex") {
+		t.Fatalf("usage = %q, want it to mention every registered provider", out)
+	}
+}

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -1,0 +1,51 @@
+package provider
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// Provider is the complete, self-contained description of one supported
+// agent provider: its name, and where package materialization stages
+// content for it (a skills directory and a generated-context file, both
+// relative to the project root). Adding a new provider means adding one
+// entry to registry below — no other package (internal/runtime,
+// internal/packages, internal/cli) should ever special-case a provider
+// name. Providers sit on top of the provider-neutral core, not inside it.
+type Provider struct {
+	Name        string
+	SkillsDir   string
+	ContextFile string
+}
+
+var registry = []Provider{
+	{Name: "claude", SkillsDir: filepath.Join(".claude", "skills"), ContextFile: "CLAUDE.md"},
+	{Name: "codex", SkillsDir: filepath.Join(".agents", "skills"), ContextFile: "AGENTS.md"},
+}
+
+// Known returns every registered provider, in registration order.
+func Known() []Provider {
+	return append([]Provider(nil), registry...)
+}
+
+// IsKnown reports whether name is a registered provider.
+func IsKnown(name string) bool {
+	_, err := Get(name)
+	return err == nil
+}
+
+// Get returns the registered Provider for name, or an error naming every
+// known provider if name isn't registered.
+func Get(name string) (Provider, error) {
+	for _, p := range registry {
+		if p.Name == name {
+			return p, nil
+		}
+	}
+	names := make([]string, 0, len(registry))
+	for _, p := range registry {
+		names = append(names, p.Name)
+	}
+	return Provider{}, fmt.Errorf("unknown provider %q (known providers: %s)", name, strings.Join(names, ", "))
+}

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -1,0 +1,45 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestKnownIncludesClaudeAndCodex(t *testing.T) {
+	names := map[string]bool{}
+	for _, p := range Known() {
+		names[p.Name] = true
+	}
+	if !names["claude"] || !names["codex"] {
+		t.Fatalf("Known() = %v, want claude and codex present", names)
+	}
+}
+
+func TestGetKnownProvider(t *testing.T) {
+	p, err := Get("codex")
+	if err != nil {
+		t.Fatalf("Get(codex) error = %v", err)
+	}
+	if p.SkillsDir == "" || p.ContextFile != "AGENTS.md" {
+		t.Fatalf("Get(codex) = %#v", p)
+	}
+}
+
+func TestGetUnknownProviderListsKnownNames(t *testing.T) {
+	_, err := Get("nope")
+	if err == nil {
+		t.Fatal("Get(nope) error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "claude") || !strings.Contains(err.Error(), "codex") {
+		t.Fatalf("Get(nope) error = %q, want it to list known providers", err.Error())
+	}
+}
+
+func TestIsKnown(t *testing.T) {
+	if !IsKnown("claude") {
+		t.Fatal("IsKnown(claude) = false, want true")
+	}
+	if IsKnown("nope") {
+		t.Fatal("IsKnown(nope) = true, want false")
+	}
+}

--- a/internal/runtime/plan.go
+++ b/internal/runtime/plan.go
@@ -21,8 +21,8 @@ type Plan struct {
 }
 
 func BuildPlan(providerName, cwd, home string, args []string) (Plan, error) {
-	if providerName != "claude" && providerName != "codex" {
-		return Plan{}, fmt.Errorf("unknown provider %q", providerName)
+	if _, err := provider.Get(providerName); err != nil {
+		return Plan{}, err
 	}
 
 	found, err := config.FindProjectConfig(cwd)


### PR DESCRIPTION
## Summary

Claude and Codex should each be just another entry in a provider registry, not names special-cased across the core runtime. Before this, `internal/runtime.BuildPlan` hardcoded `providerName != "claude" && providerName != "codex"`, and the CLI's usage text repeated the same pair as a string literal — the only two places outside `internal/provider` that knew provider names existed at all. The real provider-specific logic (`Resolve`, `Launch`, `findRealBinary`) was already fully generic.

- `internal/provider.registry` (`registry.go`): a single `[]Provider{Name, SkillsDir, ContextFile}` list plus `Known()` / `Get()` / `IsKnown()`. This is the one place that knows provider names exist — `internal/runtime` and `internal/packages` stay fully provider-neutral.
- `internal/runtime.BuildPlan` now calls `provider.Get(providerName)` instead of the hardcoded check.
- CLI usage/error text (`printUsage`, `run`'s no-args error) now lists whatever's actually registered via `provider.Known()`, so it can't drift from what's really supported.
- `SkillsDir`/`ContextFile` fields are included now (matching what `internal/materialize`'s adapter needs in #22/#24) so there's one registry going forward instead of two parallel ones once that PR merges — I'll fold #22/#24's `Adapter`/`AdapterFor` into this after it merges.

## Linked Issue

Closes #8

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`.

## Package Impact

- [x] Provider launch/shim behavior
- [ ] Package format or manifest behavior
- [ ] Package discovery or enablement
- [ ] Setup or permission flow
- [ ] Documentation only
- [ ] Tests only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary (this PR strengthens that boundary).

## Verification

Relevant test cases:

- `TestKnownIncludesClaudeAndCodex`, `TestGetKnownProvider`, `TestGetUnknownProviderListsKnownNames`, `TestIsKnown` (new, `internal/provider/registry_test.go`)
- `TestRunUnknownProviderListsKnownProviders`, `TestUsageListsKnownProvidersNotHardcoded` (new, `internal/cli/cli_test.go`)
- Existing `TestRunPlanRejectsUnknownProvider`-style coverage in `internal/runtime/plan_test.go` still passes unchanged, confirming no behavior change for the happy path.

```text
go build ./...
go test ./...
```

## Notes For Reviewers

No behavior change for `claude`/`codex` users — same two providers, same error message shape, just sourced from one place. Once #22 merges, its `internal/provider/adapter.go` (`Adapter`, `ClaudeAdapter`, `CodexAdapter`, `AdapterFor`) becomes redundant with this registry; I'll open a small follow-up to delete it and point `internal/materialize` at `provider.Get`/`provider.Known` directly.