### PR TITLE
Lock the manifest format: schema, export authority, digest, capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,20 @@ All notable changes to Lineage will be documented here.
 - Fix: `lineage package init` no longer resets an existing `lineage.yaml`
   to defaults when run again against an already-initialized package,
   preserving hand-edited version/description and any existing contents.
+- `lineage.yaml` now carries a `schema` field (manifest format version,
+  separate from the package's own `version`) and an optional, purely
+  declarative `capabilities` block (`filesystem.read`, `network`).
+  Existing manifests without either field keep working unchanged.
+- Manifest exports are now authoritative when declared: an
+  `exports.agents`/`exports.workflows` entry that's declared but missing
+  on disk fails discovery with a clear error; content present on disk but
+  not declared stays local but is excluded from what's advertised. An
+  empty/omitted export list still falls back to discovering everything on
+  disk, so undeclared packages are unaffected.
+- `requires.skills` is now enforced at `enable` and `run` time against the
+  full set of packages that would be enabled together — a missing
+  required skill fails with a clear error naming it, instead of silently
+  proceeding.
+- Every discovered package now carries a stable `sha256` content digest
+  (manifest + all content files, deterministic order), surfaced in
+  `--dry-run` output alongside any declared capabilities.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -168,9 +168,25 @@ func runEnable(args []string, home string, stdout, stderr io.Writer) error {
 		}
 	}
 
-	if !contains(cfg.EnabledPackages, storedRef) {
-		cfg.EnabledPackages = append(cfg.EnabledPackages, storedRef)
+	newEnabled := cfg.EnabledPackages
+	if !contains(newEnabled, storedRef) {
+		newEnabled = append(append([]string{}, newEnabled...), storedRef)
 	}
+
+	// Validate against the full set that would be enabled after this
+	// change, not just the package being added: a required skill can
+	// legitimately come from a different already-enabled package.
+	resolvedForValidation, err := packages.ResolveEnabled(home, cfg.Workspace, projectRoot, newEnabled)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	if err := packages.ValidateDependencies(resolvedForValidation); err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	cfg.EnabledPackages = newEnabled
 	if err := config.SaveProjectConfig(configPath, cfg); err != nil {
 		fmt.Fprintln(stderr, err)
 		return err

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -62,3 +62,49 @@ func TestEnableAndDryRun(t *testing.T) {
 		t.Fatalf("dry-run output = %s", stdout.String())
 	}
 }
+
+func TestEnableRejectsUnsatisfiedRequiredSkill(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	pkgDir := filepath.Join(project, "needs-review-basics")
+	if err := packages.InitPackage(pkgDir, "needs-review-basics"); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := packages.LoadManifest(pkgDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest.Requires.Skills = []string{"review-basics"}
+	if err := packages.SaveManifest(pkgDir, manifest); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldHome := os.Getenv(config.HomeEnv)
+	t.Setenv(config.HomeEnv, home)
+	defer t.Setenv(config.HomeEnv, oldHome)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = Execute(nil, []string{"enable", "./needs-review-basics"}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("enable error = nil, want error for unsatisfied requires.skills")
+	}
+	if !strings.Contains(stderr.String(), "review-basics") {
+		t.Fatalf("stderr = %q, want it to name the missing skill", stderr.String())
+	}
+
+	if _, statErr := os.Stat(config.ProjectConfigPath(project)); !os.IsNotExist(statErr) {
+		t.Fatal("expected no config written when enable fails validation")
+	}
+}

--- a/internal/packages/dependencies.go
+++ b/internal/packages/dependencies.go
@@ -1,0 +1,26 @@
+package packages
+
+import "fmt"
+
+// ValidateDependencies checks that every package's Requires.Skills is
+// satisfied somewhere across pkgs — its own skills, or another package's.
+// It's meant to run against the full set of packages that will be enabled
+// together (not one package in isolation), since a required skill can
+// legitimately be provided by a different enabled package.
+func ValidateDependencies(pkgs []Package) error {
+	available := map[string]bool{}
+	for _, pkg := range pkgs {
+		for _, skill := range pkg.Skills {
+			available[skill] = true
+		}
+	}
+
+	for _, pkg := range pkgs {
+		for _, required := range pkg.Manifest.Requires.Skills {
+			if !available[required] {
+				return fmt.Errorf("package %q requires skill %q, which is not provided by any enabled package", pkg.Manifest.Name, required)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/packages/dependencies_test.go
+++ b/internal/packages/dependencies_test.go
@@ -1,0 +1,36 @@
+package packages
+
+import "testing"
+
+func TestValidateDependenciesSatisfiedByOwnSkill(t *testing.T) {
+	pkg := Package{
+		Manifest: Manifest{Name: "self-sufficient", Requires: Requires{Skills: []string{"review"}}},
+		Skills:   []string{"review"},
+	}
+	if err := ValidateDependencies([]Package{pkg}); err != nil {
+		t.Fatalf("ValidateDependencies() error = %v", err)
+	}
+}
+
+func TestValidateDependenciesSatisfiedByAnotherPackage(t *testing.T) {
+	dependent := Package{
+		Manifest: Manifest{Name: "dependent", Requires: Requires{Skills: []string{"security-basics"}}},
+	}
+	provider := Package{
+		Manifest: Manifest{Name: "provider"},
+		Skills:   []string{"security-basics"},
+	}
+	if err := ValidateDependencies([]Package{dependent, provider}); err != nil {
+		t.Fatalf("ValidateDependencies() error = %v", err)
+	}
+}
+
+func TestValidateDependenciesMissingSkillFails(t *testing.T) {
+	dependent := Package{
+		Manifest: Manifest{Name: "dependent", Requires: Requires{Skills: []string{"nonexistent"}}},
+	}
+	err := ValidateDependencies([]Package{dependent})
+	if err == nil {
+		t.Fatal("ValidateDependencies() error = nil, want error for missing required skill")
+	}
+}

--- a/internal/packages/discovery.go
+++ b/internal/packages/discovery.go
@@ -1,7 +1,10 @@
 package packages
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -15,6 +18,10 @@ type Package struct {
 	Workflows []string
 	Agents    []string
 	Policies  []string
+	// Digest is a sha256 content digest over the manifest and every file in
+	// the package's standard content directories, in deterministic order.
+	// Identical package content always produces the same digest.
+	Digest string
 }
 
 func Discover(dir string) (Package, error) {
@@ -27,11 +34,102 @@ func Discover(dir string) (Package, error) {
 		Path:     dir,
 		Manifest: manifest,
 	}
+
+	workflows, err := applyExportAuthority("workflow", manifest.Exports.Workflows, discoverNamesWithFile(filepath.Join(dir, "workflows"), "WORKFLOW.md"))
+	if err != nil {
+		return Package{}, fmt.Errorf("%s: %w", dir, err)
+	}
+	pkg.Workflows = workflows
+
+	agents, err := applyExportAuthority("agent", manifest.Exports.Agents, discoverEntryNames(filepath.Join(dir, "agents")))
+	if err != nil {
+		return Package{}, fmt.Errorf("%s: %w", dir, err)
+	}
+	pkg.Agents = agents
+
 	pkg.Skills = discoverSkillNames(filepath.Join(dir, "skills"))
-	pkg.Workflows = discoverNamesWithFile(filepath.Join(dir, "workflows"), "WORKFLOW.md")
-	pkg.Agents = discoverEntryNames(filepath.Join(dir, "agents"))
 	pkg.Policies = discoverEntryNames(filepath.Join(dir, "policies"))
+
+	digest, err := ComputeDigest(dir)
+	if err != nil {
+		return Package{}, fmt.Errorf("%s: %w", dir, err)
+	}
+	pkg.Digest = digest
+
 	return pkg, nil
+}
+
+// applyExportAuthority implements "manifest is authoritative, filesystem is
+// payload": when the manifest explicitly declares a non-empty export list,
+// every declared name must actually be discoverable on disk (a missing one
+// is a validation error), and only declared names count as part of the
+// package's exported set — anything discovered but not declared is allowed
+// to exist locally but is excluded from the result. An empty/omitted
+// declaration means "not yet declared", not "declares nothing": it falls
+// back to whatever's discovered on disk, matching pre-schema behavior so
+// existing packages that never declared exports keep working unchanged.
+func applyExportAuthority(kind string, declared, discovered []string) ([]string, error) {
+	if len(declared) == 0 {
+		return discovered, nil
+	}
+
+	discoveredSet := make(map[string]bool, len(discovered))
+	for _, name := range discovered {
+		discoveredSet[name] = true
+	}
+
+	result := make([]string, 0, len(declared))
+	for _, name := range declared {
+		if !discoveredSet[name] {
+			return nil, fmt.Errorf("manifest declares %s %q but it was not found", kind, name)
+		}
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+// ComputeDigest returns a stable "sha256:<hex>" content digest over a
+// package's manifest and every file in its standard content directories
+// (skills, workflows, agents, policies, references, adapters), hashed in
+// deterministic path order. Two packages with byte-identical content always
+// produce the same digest; any content change changes it.
+func ComputeDigest(dir string) (string, error) {
+	h := sha256.New()
+
+	manifestData, err := os.ReadFile(filepath.Join(dir, ManifestFileName))
+	if err != nil {
+		return "", fmt.Errorf("read manifest for digest: %w", err)
+	}
+	h.Write(manifestData)
+
+	var files []string
+	for _, sub := range []string{"skills", "workflows", "agents", "policies", "references", "adapters"} {
+		root := filepath.Join(dir, sub)
+		_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			rel, relErr := filepath.Rel(dir, path)
+			if relErr != nil {
+				return nil
+			}
+			files = append(files, filepath.ToSlash(rel))
+			return nil
+		})
+	}
+	sort.Strings(files)
+
+	for _, rel := range files {
+		data, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(rel)))
+		if err != nil {
+			return "", fmt.Errorf("read %s for digest: %w", rel, err)
+		}
+		h.Write([]byte(rel))
+		h.Write(data)
+	}
+
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // InitPackage scaffolds a package directory: a lineage.yaml manifest plus

--- a/internal/packages/discovery_test.go
+++ b/internal/packages/discovery_test.go
@@ -28,6 +28,88 @@ func TestManifestRoundTripAndDiscovery(t *testing.T) {
 	assertEqualSlices(t, pkg.Workflows, []string{"ship"})
 	assertEqualSlices(t, pkg.Agents, []string{"reviewer.md"})
 	assertEqualSlices(t, pkg.Policies, []string{"safe.md"})
+	if pkg.Digest == "" {
+		t.Fatal("Digest is empty, want a computed digest")
+	}
+}
+
+func TestDiscoverHonorsDeclaredExports(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "declared-pack")
+	if err := InitPackage(root, "declared-pack"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, "agents", "reviewer.md"), "# Reviewer")
+	mustWrite(t, filepath.Join(root, "agents", "internal-only.md"), "# Not exported")
+	mustWrite(t, filepath.Join(root, "workflows", "ship", "WORKFLOW.md"), "# Ship")
+
+	manifest, err := LoadManifest(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest.Exports.Agents = []string{"reviewer.md"}
+	if err := SaveManifest(root, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg, err := Discover(root)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	// Declared and present: kept. Present but undeclared: excluded, even
+	// though it exists on disk.
+	assertEqualSlices(t, pkg.Agents, []string{"reviewer.md"})
+	// Workflows were never declared, so discovery falls back to whatever's
+	// on disk (backward compatible).
+	assertEqualSlices(t, pkg.Workflows, []string{"ship"})
+}
+
+func TestDiscoverRejectsDeclaredButMissingExport(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "broken-pack")
+	if err := InitPackage(root, "broken-pack"); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest, err := LoadManifest(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest.Exports.Agents = []string{"missing-reviewer.md"}
+	if err := SaveManifest(root, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Discover(root); err == nil {
+		t.Fatal("Discover() error = nil, want error for declared-but-missing export")
+	}
+}
+
+func TestComputeDigestStableAndSensitiveToContent(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "digest-pack")
+	if err := InitPackage(root, "digest-pack"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, "skills", "review", "SKILL.md"), "# Review")
+
+	first, err := ComputeDigest(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := ComputeDigest(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatalf("ComputeDigest() not stable: %q vs %q", first, second)
+	}
+
+	mustWrite(t, filepath.Join(root, "skills", "review", "SKILL.md"), "# Review, edited")
+	third, err := ComputeDigest(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if third == first {
+		t.Fatal("ComputeDigest() unchanged after content edit, want a different digest")
+	}
 }
 
 func TestResolveReferenceOrder(t *testing.T) {

--- a/internal/packages/manifest.go
+++ b/internal/packages/manifest.go
@@ -10,13 +10,20 @@ import (
 
 const ManifestFileName = "lineage.yaml"
 
+// CurrentSchema is the only lineage.yaml schema this build understands.
+// schema describes how to interpret the manifest; version describes the
+// package itself — the two change independently.
+const CurrentSchema = 1
+
 type Manifest struct {
-	Name        string      `yaml:"name"`
-	Version     string      `yaml:"version"`
-	Description string      `yaml:"description"`
-	Exports     Exports     `yaml:"exports"`
-	Requires    Requires    `yaml:"requires"`
-	Entrypoints Entrypoints `yaml:"entrypoints"`
+	Schema       int          `yaml:"schema"`
+	Name         string       `yaml:"name"`
+	Version      string       `yaml:"version"`
+	Description  string       `yaml:"description"`
+	Exports      Exports      `yaml:"exports"`
+	Requires     Requires     `yaml:"requires"`
+	Entrypoints  Entrypoints  `yaml:"entrypoints"`
+	Capabilities Capabilities `yaml:"capabilities"`
 }
 
 type Exports struct {
@@ -33,8 +40,21 @@ type Entrypoints struct {
 	Codex  string `yaml:"codex"`
 }
 
+// Capabilities is a purely declarative statement of what a package wants
+// access to — printed by lineage package validate and the enable-time plan
+// so a receiver can see it before enabling, not enforced by this build.
+type Capabilities struct {
+	Filesystem FilesystemCapabilities `yaml:"filesystem"`
+	Network    []string               `yaml:"network"`
+}
+
+type FilesystemCapabilities struct {
+	Read []string `yaml:"read"`
+}
+
 func DefaultManifest(name string) Manifest {
 	return Manifest{
+		Schema:      CurrentSchema,
 		Name:        name,
 		Version:     "0.1.0",
 		Description: "A shareable Lineage agent package.",
@@ -46,6 +66,10 @@ func DefaultManifest(name string) Manifest {
 			Skills: []string{},
 		},
 		Entrypoints: Entrypoints{},
+		Capabilities: Capabilities{
+			Filesystem: FilesystemCapabilities{Read: []string{}},
+			Network:    []string{},
+		},
 	}
 }
 
@@ -65,6 +89,14 @@ func LoadManifest(dir string) (Manifest, error) {
 	}
 	if manifest.Version == "" {
 		manifest.Version = "0.1.0"
+	}
+	// schema 0 means the manifest predates the schema field; treat that as
+	// schema 1, the only schema that ever existed before it was added.
+	if manifest.Schema == 0 {
+		manifest.Schema = CurrentSchema
+	}
+	if manifest.Schema != CurrentSchema {
+		return Manifest{}, fmt.Errorf("manifest %s declares schema %d, but this build only understands schema %d", path, manifest.Schema, CurrentSchema)
 	}
 	return manifest, nil
 }

--- a/internal/packages/manifest_test.go
+++ b/internal/packages/manifest_test.go
@@ -1,0 +1,51 @@
+package packages
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadManifestDefaultsMissingSchemaToCurrent(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ManifestFileName), "name: legacy-pack\nversion: 1.0.0\n")
+
+	manifest, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("LoadManifest() error = %v", err)
+	}
+	if manifest.Schema != CurrentSchema {
+		t.Fatalf("Schema = %d, want %d (defaulted)", manifest.Schema, CurrentSchema)
+	}
+}
+
+func TestLoadManifestRejectsUnsupportedSchema(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ManifestFileName), "schema: 99\nname: future-pack\nversion: 1.0.0\n")
+
+	if _, err := LoadManifest(dir); err == nil {
+		t.Fatal("LoadManifest() error = nil, want error for unsupported schema")
+	}
+}
+
+func TestDefaultManifestRoundTripsCapabilities(t *testing.T) {
+	dir := t.TempDir()
+	manifest := DefaultManifest("cap-pack")
+	manifest.Capabilities = Capabilities{
+		Filesystem: FilesystemCapabilities{Read: []string{"workspace"}},
+		Network:    []string{"github.com"},
+	}
+	if err := SaveManifest(dir, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Capabilities.Filesystem.Read) != 1 || loaded.Capabilities.Filesystem.Read[0] != "workspace" {
+		t.Fatalf("Capabilities.Filesystem.Read = %#v", loaded.Capabilities.Filesystem.Read)
+	}
+	if len(loaded.Capabilities.Network) != 1 || loaded.Capabilities.Network[0] != "github.com" {
+		t.Fatalf("Capabilities.Network = %#v", loaded.Capabilities.Network)
+	}
+}

--- a/internal/runtime/plan.go
+++ b/internal/runtime/plan.go
@@ -34,6 +34,9 @@ func BuildPlan(providerName, cwd, home string, args []string) (Plan, error) {
 	if err != nil {
 		return Plan{}, err
 	}
+	if err := packages.ValidateDependencies(resolved); err != nil {
+		return Plan{}, err
+	}
 
 	providerPlan, err := provider.Resolve(providerName, home, found.Config, args)
 	if err != nil {
@@ -68,10 +71,14 @@ func (p Plan) DryRunString() string {
 	for _, pkg := range p.Packages {
 		fmt.Fprintf(&b, "  - %s@%s\n", pkg.Manifest.Name, pkg.Manifest.Version)
 		fmt.Fprintf(&b, "    path: %s\n", filepath.Clean(pkg.Path))
+		fmt.Fprintf(&b, "    digest: %s\n", emptyValue(pkg.Digest))
 		fmt.Fprintf(&b, "    skills: %s\n", listValue(pkg.Skills))
 		fmt.Fprintf(&b, "    workflows: %s\n", listValue(pkg.Workflows))
 		fmt.Fprintf(&b, "    agents: %s\n", listValue(pkg.Agents))
 		fmt.Fprintf(&b, "    policies: %s\n", listValue(pkg.Policies))
+		fmt.Fprintf(&b, "    capabilities:\n")
+		fmt.Fprintf(&b, "      filesystem.read: %s\n", listValue(pkg.Manifest.Capabilities.Filesystem.Read))
+		fmt.Fprintf(&b, "      network: %s\n", listValue(pkg.Manifest.Capabilities.Network))
 	}
 	return b.String()
 }

--- a/internal/runtime/plan_test.go
+++ b/internal/runtime/plan_test.go
@@ -44,7 +44,7 @@ func TestBuildPlanDryRun(t *testing.T) {
 	}
 
 	dryRun := plan.DryRunString()
-	for _, needle := range []string{"provider: claude", "workspace: makers", "agent-pack@0.1.0", "skills: review", "workflows: ship"} {
+	for _, needle := range []string{"provider: claude", "workspace: makers", "agent-pack@0.1.0", "skills: review", "workflows: ship", "digest: sha256:", "capabilities:", "filesystem.read: none", "network: none"} {
 		if !strings.Contains(dryRun, needle) {
 			t.Fatalf("DryRunString() missing %q:\n%s", needle, dryRun)
 		}


### PR DESCRIPTION
## Summary

Phase 2 of the v1 distribution plan: settle the parts of the package format that get expensive to change once packages start moving between machines (export/import), before that lands.

- `schema: 1` in `lineage.yaml`, distinct from the package's own `version`. Missing `schema` (all existing manifests) defaults to 1; anything else is rejected as unsupported, so a future format break has a clean signal instead of silent misinterpretation.
- **Manifest is authoritative, filesystem is payload**: a declared-but-missing `exports.agents`/`exports.workflows` entry is now a `Discover`-time error. Content present on disk but not declared stays local but is excluded from the package's exported set. An empty/omitted export list still falls back to full filesystem discovery — existing packages that never declared exports (like the sample `resume-workflow`) are unaffected.
- `requires.skills` is now enforced at `enable` and `run` time, checked against the **full set** of packages that would be enabled together (not just the package being added), since a required skill can legitimately come from a different enabled package.
- Every discovered package now carries a stable `sha256` content digest (manifest + every file in `skills/workflows/agents/policies/references/adapters`, deterministic order), surfaced in `--dry-run` output.
- An optional, purely *declarative* `capabilities` block (`filesystem.read`, `network`) — parsed and printed in `--dry-run`, not enforced. Declaring the field now avoids a breaking manifest change later when real enforcement gets built.

## Linked Issue

Closes #30

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`.

## Package Impact

- [x] Package format or manifest behavior
- [x] Package discovery or enablement
- [ ] Provider launch/shim behavior
- [ ] Setup or permission flow
- [ ] Documentation only
- [ ] Tests only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [ ] Path handling prevents traversal outside the intended workspace/package root where applicable. (Path traversal hardening is #10, next in the phase.)
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- `TestLoadManifestDefaultsMissingSchemaToCurrent`, `TestLoadManifestRejectsUnsupportedSchema`, `TestDefaultManifestRoundTripsCapabilities` (new, `manifest_test.go`)
- `TestDiscoverHonorsDeclaredExports`, `TestDiscoverRejectsDeclaredButMissingExport`, `TestComputeDigestStableAndSensitiveToContent` (new, `discovery_test.go`)
- `TestValidateDependenciesSatisfiedByOwnSkill`, `TestValidateDependenciesSatisfiedByAnotherPackage`, `TestValidateDependenciesMissingSkillFails` (new, `dependencies_test.go`)
- `TestEnableRejectsUnsatisfiedRequiredSkill` (new, `internal/cli/cli_test.go`) — proves `enable` fails closed and writes no config when validation fails
- `TestBuildPlanDryRun` extended to assert digest/capabilities appear in `--dry-run` output

```text
go build ./...
go test ./...
```
All pass, including existing `TestManifestRoundTripAndDiscovery` and the sample `examples/resume-workflow` package, unchanged. Also manually smoke-tested: `enable`+`run --dry-run` against the real sample package end-to-end, including its existing `requires.skills: [resume-review]` actually being validated for the first time.

## Notes For Reviewers

`internal/runtime/plan.go` still has the pre-#32 hardcoded `claude`/`codex` check (this branch predates that PR merging) — no functional conflict, just a rebase away from using `provider.Get` once #32 lands.