### PR TITLE
Gate materialization behind an explicit confirmation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage.out
 .env
 .env.*
 !.env.example
+docs/v1-distribution-plan.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,8 @@ All notable changes to Lineage will be documented here.
   reflects the current enabled-package set exactly, via a per-provider
   `.lineage/materialized-<provider>.json` state file) and is skipped
   entirely on `--dry-run`.
+- `lineage run codex` materializes the same way, into
+  `.agents/skills/<pkg>-<skill>/` and a generated section in
+  `AGENTS.md`. Claude and Codex materialization stay isolated from
+  each other (separate state files, separate staged directories) so
+  running one provider never disturbs the other's staged content.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,3 +71,10 @@ All notable changes to Lineage will be documented here.
   `AGENTS.md`. Claude and Codex materialization stay isolated from
   each other (separate state files, separate staged directories) so
   running one provider never disturbs the other's staged content.
+- `lineage run` now shows what materialization would create or change
+  and asks for confirmation the first time a given package set would
+  actually write anything, instead of writing files as a silent side
+  effect. Approve with `y`/`yes`, or skip the prompt with `--yes`/`-y`
+  for scripts. Re-running with an unchanged package set doesn't
+  re-prompt. `lineage.Execute` now takes a `stdin io.Reader` to support
+  this.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,3 +59,10 @@ All notable changes to Lineage will be documented here.
   content. `internal/runtime` and the CLI's usage text consult it instead
   of hardcoding `claude`/`codex`, so adding a provider is a one-entry
   change in one file rather than a hunt through the core runtime.
+- `lineage run claude` now materializes enabled packages for Claude Code:
+  skills are staged into `.claude/skills/<pkg>-<skill>/` and a generated
+  section in `CLAUDE.md` lists active packages, agents, policies, and
+  workflows. Materialization is idempotent and reversible (re-running
+  reflects the current enabled-package set exactly, via a per-provider
+  `.lineage/materialized-<provider>.json` state file) and is skipped
+  entirely on `--dry-run`.

--- a/cmd/lineage/main.go
+++ b/cmd/lineage/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	if err := cli.Execute(context.Background(), os.Args[1:], os.Stdout, os.Stderr); err != nil {
+	if err := cli.Execute(context.Background(), os.Args[1:], os.Stdin, os.Stdout, os.Stderr); err != nil {
 		os.Exit(1)
 	}
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -17,7 +18,7 @@ import (
 	"github.com/lineage-dev/lineage/internal/shim"
 )
 
-func Execute(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+func Execute(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	if len(args) == 0 {
 		printUsage(stdout)
 		return nil
@@ -37,7 +38,7 @@ func Execute(ctx context.Context, args []string, stdout, stderr io.Writer) error
 	case "enable":
 		return runEnable(args[1:], home, stdout, stderr)
 	case "run":
-		return runProvider(ctx, args[1:], home, stdout, stderr)
+		return runProvider(ctx, args[1:], home, stdin, stdout, stderr)
 	case "install-shims":
 		return runInstallShims(home, stdout, stderr)
 	case "help", "-h", "--help":
@@ -254,16 +255,16 @@ func runEnable(args []string, home string, stdout, stderr io.Writer) error {
 	return nil
 }
 
-func runProvider(ctx context.Context, args []string, home string, stdout, stderr io.Writer) error {
+func runProvider(ctx context.Context, args []string, home string, stdin io.Reader, stdout, stderr io.Writer) error {
 	_ = ctx
 	if len(args) == 0 {
-		err := fmt.Errorf("usage: lineage run <%s> [--dry-run] [-- provider args...]", providerNameList())
+		err := fmt.Errorf("usage: lineage run <%s> [--dry-run] [--yes] [-- provider args...]", providerNameList())
 		fmt.Fprintln(stderr, err)
 		return err
 	}
 
 	providerName := args[0]
-	dryRun, providerArgs := parseRunArgs(args[1:])
+	dryRun, autoApprove, providerArgs := parseRunArgs(args[1:])
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -286,6 +287,29 @@ func runProvider(ctx context.Context, args []string, home string, stdout, stderr
 		fmt.Fprintln(stderr, err)
 		return err
 	}
+
+	// Materialization writes files into the receiver's project (staged
+	// skills, a generated section in the provider's context file). Gate
+	// that write behind an explicit confirmation the first time it would
+	// change anything, so it's never a surprise side effect of `lineage
+	// run` - similar in spirit to how --dry-run already previews the
+	// launch plan. Once a given package set is approved and materialized,
+	// re-running with the same set doesn't need to ask again.
+	needsApproval, err := materialize.NeedsApproval(plan.ProjectRoot, adapter, plan.Packages)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	if needsApproval && !autoApprove {
+		fmt.Fprintf(stdout, "lineage will make the following changes for %s:\n\n", providerName)
+		fmt.Fprint(stdout, plan.DryRunString())
+		fmt.Fprint(stdout, "\nProceed? [y/N] ")
+		if !confirm(stdin) {
+			fmt.Fprintln(stdout, "aborted: materialization was not approved")
+			return nil
+		}
+	}
+
 	if err := materialize.Apply(plan.ProjectRoot, adapter, plan.Packages); err != nil {
 		fmt.Fprintln(stderr, err)
 		return err
@@ -296,6 +320,22 @@ func runProvider(ctx context.Context, args []string, home string, stdout, stderr
 		return err
 	}
 	return nil
+}
+
+// confirm reads a single line from stdin and reports whether it's an
+// affirmative answer ("y" or "yes", case-insensitive). Anything else,
+// including EOF or a nil reader, is treated as a decline - approval must be
+// explicit.
+func confirm(stdin io.Reader) bool {
+	if stdin == nil {
+		return false
+	}
+	line, err := bufio.NewReader(stdin).ReadString('\n')
+	if err != nil && line == "" {
+		return false
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes"
 }
 
 func runInstallShims(home string, stdout, stderr io.Writer) error {
@@ -323,7 +363,7 @@ Usage:
   lineage package init <name>
   lineage package validate <path>
   lineage enable <package-path-or-id>
-  lineage run <%s> [--dry-run] [-- provider args...]
+  lineage run <%s> [--dry-run] [--yes] [-- provider args...]
   lineage install-shims
 `, providerNameList())))
 }
@@ -341,14 +381,14 @@ func providerNameList() string {
 }
 
 // parseRunArgs splits the arguments following `lineage run <provider>` into
-// lineage's own --dry-run flag and the args that should be forwarded to the
-// wrapped provider. A bare "--" marks the boundary explicitly: everything
-// before it is scanned for lineage flags, everything after it is passed
-// through to the provider verbatim, even if it happens to collide with a
-// lineage flag name (for example a provider's own --dry-run flag). Without
-// "--", the whole argument list is scanned for lineage flags, matching the
-// simple common case of `lineage run claude --dry-run`.
-func parseRunArgs(args []string) (dryRun bool, providerArgs []string) {
+// lineage's own --dry-run/--yes flags and the args that should be forwarded
+// to the wrapped provider. A bare "--" marks the boundary explicitly:
+// everything before it is scanned for lineage flags, everything after it is
+// passed through to the provider verbatim, even if it happens to collide
+// with a lineage flag name (for example a provider's own --dry-run flag).
+// Without "--", the whole argument list is scanned for lineage flags,
+// matching the simple common case of `lineage run claude --dry-run`.
+func parseRunArgs(args []string) (dryRun, autoApprove bool, providerArgs []string) {
 	providerArgs = []string{}
 
 	sep := -1
@@ -371,10 +411,14 @@ func parseRunArgs(args []string) (dryRun bool, providerArgs []string) {
 			dryRun = true
 			continue
 		}
+		if arg == "--yes" || arg == "-y" {
+			autoApprove = true
+			continue
+		}
 		providerArgs = append(providerArgs, arg)
 	}
 	providerArgs = append(providerArgs, passthrough...)
-	return dryRun, providerArgs
+	return dryRun, autoApprove, providerArgs
 }
 
 func contains(values []string, target string) bool {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/lineage-dev/lineage/internal/config"
+	"github.com/lineage-dev/lineage/internal/materialize"
 	"github.com/lineage-dev/lineage/internal/packages"
 	"github.com/lineage-dev/lineage/internal/provider"
 	"github.com/lineage-dev/lineage/internal/runtime"
@@ -279,6 +280,17 @@ func runProvider(ctx context.Context, args []string, home string, stdout, stderr
 		fmt.Fprint(stdout, plan.DryRunString())
 		return nil
 	}
+
+	adapter, err := provider.Get(providerName)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	if err := materialize.Apply(plan.ProjectRoot, adapter, plan.Packages); err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
 	if err := provider.Launch(plan.ProviderPlan); err != nil {
 		fmt.Fprintln(stderr, err)
 		return err

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -37,7 +37,7 @@ func TestEnableAndDryRun(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	if err := Execute(nil, []string{"enable", "./agent-pack"}, &stdout, &stderr); err != nil {
+	if err := Execute(nil, []string{"enable", "./agent-pack"}, nil, &stdout, &stderr); err != nil {
 		t.Fatalf("enable error = %v stderr=%s", err, stderr.String())
 	}
 
@@ -52,7 +52,7 @@ func TestEnableAndDryRun(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	if err := Execute(nil, []string{"run", "codex", "--dry-run"}, &stdout, &stderr); err != nil {
+	if err := Execute(nil, []string{"run", "codex", "--dry-run"}, nil, &stdout, &stderr); err != nil {
 		t.Fatalf("dry-run error = %v stderr=%s", err, stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "provider: codex") {
@@ -82,6 +82,7 @@ func TestEnableRejectsUnsatisfiedRequiredSkill(t *testing.T) {
 	if err := os.MkdirAll(project, 0o755); err != nil {
 		t.Fatal(err)
 	}
+
 	oldHome := os.Getenv(config.HomeEnv)
 	t.Setenv(config.HomeEnv, home)
 	defer t.Setenv(config.HomeEnv, oldHome)
@@ -95,7 +96,7 @@ func TestEnableRejectsUnsatisfiedRequiredSkill(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	err = Execute(nil, []string{"enable", "./needs-review-basics"}, &stdout, &stderr)
+	err = Execute(nil, []string{"enable", "./needs-review-basics"}, nil, &stdout, &stderr)
 	if err == nil {
 		t.Fatal("enable error = nil, want error for unsatisfied requires.skills")
 	}
@@ -122,7 +123,7 @@ func TestPackageValidatePasses(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	if err := Execute(nil, []string{"package", "validate", pkgDir}, &stdout, &stderr); err != nil {
+	if err := Execute(nil, []string{"package", "validate", pkgDir}, nil, &stdout, &stderr); err != nil {
 		t.Fatalf("validate error = %v stderr=%s", err, stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "result: PASS") {
@@ -149,7 +150,7 @@ func TestPackageValidateFailsAndReportsErrors(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	err = Execute(nil, []string{"package", "validate", pkgDir}, &stdout, &stderr)
+	err = Execute(nil, []string{"package", "validate", pkgDir}, nil, &stdout, &stderr)
 	if err == nil {
 		t.Fatal("validate error = nil, want error for a failing package")
 	}
@@ -177,7 +178,7 @@ func TestRunUnknownProviderListsKnownProviders(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	err = Execute(nil, []string{"run", "does-not-exist"}, &stdout, &stderr)
+	err = Execute(nil, []string{"run", "does-not-exist"}, nil, &stdout, &stderr)
 	if err == nil {
 		t.Fatal("Execute(run does-not-exist) error = nil, want error")
 	}
@@ -192,5 +193,120 @@ func TestUsageListsKnownProvidersNotHardcoded(t *testing.T) {
 	out := stdout.String()
 	if !strings.Contains(out, "claude") || !strings.Contains(out, "codex") {
 		t.Fatalf("usage = %q, want it to mention every registered provider", out)
+	}
+}
+
+func setUpEnabledProject(t *testing.T) (project, home string) {
+	t.Helper()
+	tmp := t.TempDir()
+	home = filepath.Join(tmp, "home")
+	project = filepath.Join(tmp, "project")
+	pkgDir := filepath.Join(project, "agent-pack")
+	if err := packages.InitPackage(pkgDir, "agent-pack"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(pkgDir, "skills", "hello"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "skills", "hello", "SKILL.md"), []byte("# Hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldHome := os.Getenv(config.HomeEnv)
+	t.Setenv(config.HomeEnv, home)
+	t.Cleanup(func() { os.Setenv(config.HomeEnv, oldHome) })
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(oldWd) })
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"enable", "./agent-pack"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("enable error = %v stderr=%s", err, stderr.String())
+	}
+
+	cfg, err := config.LoadProjectConfig(config.ProjectConfigPath(project))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Providers = map[string]config.Provider{"claude": {Binary: "/bin/echo"}}
+	if err := config.SaveProjectConfig(config.ProjectConfigPath(project), cfg); err != nil {
+		t.Fatal(err)
+	}
+	return project, home
+}
+
+func TestRunDeclinedApprovalSkipsMaterialization(t *testing.T) {
+	project, _ := setUpEnabledProject(t)
+
+	var stdout, stderr bytes.Buffer
+	stdin := strings.NewReader("n\n")
+	if err := Execute(nil, []string{"run", "claude"}, stdin, &stdout, &stderr); err != nil {
+		t.Fatalf("run error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Proceed?") {
+		t.Fatalf("stdout = %q, want an approval prompt", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "aborted") {
+		t.Fatalf("stdout = %q, want an abort notice", stdout.String())
+	}
+	if _, err := os.Stat(filepath.Join(project, ".claude")); !os.IsNotExist(err) {
+		t.Fatal("expected no materialization when approval is declined")
+	}
+}
+
+func TestRunApprovedMaterializes(t *testing.T) {
+	project, _ := setUpEnabledProject(t)
+
+	var stdout, stderr bytes.Buffer
+	stdin := strings.NewReader("y\n")
+	if err := Execute(nil, []string{"run", "claude"}, stdin, &stdout, &stderr); err != nil {
+		t.Fatalf("run error = %v stderr=%s", err, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(project, ".claude", "skills", "agent-pack-hello", "SKILL.md")); err != nil {
+		t.Fatalf("expected materialized skill, stat err = %v", err)
+	}
+}
+
+func TestRunYesFlagSkipsPrompt(t *testing.T) {
+	project, _ := setUpEnabledProject(t)
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"run", "claude", "--yes"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("run error = %v stderr=%s", err, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Proceed?") {
+		t.Fatalf("stdout = %q, want no prompt with --yes", stdout.String())
+	}
+	if _, err := os.Stat(filepath.Join(project, ".claude", "skills", "agent-pack-hello")); err != nil {
+		t.Fatalf("expected materialized skill with --yes, stat err = %v", err)
+	}
+}
+
+func TestRunDoesNotRePromptWhenUnchanged(t *testing.T) {
+	_, _ = setUpEnabledProject(t)
+
+	var stdout1, stderr1 bytes.Buffer
+	if err := Execute(nil, []string{"run", "claude", "--yes"}, nil, &stdout1, &stderr1); err != nil {
+		t.Fatalf("first run error = %v stderr=%s", err, stderr1.String())
+	}
+
+	// No stdin at all this time - if a second, identical run tried to
+	// prompt, confirm() would read from a nil reader and decline, and the
+	// materialized skill would get removed. It must not, since nothing
+	// about the enabled package set changed.
+	var stdout2, stderr2 bytes.Buffer
+	if err := Execute(nil, []string{"run", "claude"}, nil, &stdout2, &stderr2); err != nil {
+		t.Fatalf("second run error = %v stderr=%s", err, stderr2.String())
+	}
+	if strings.Contains(stdout2.String(), "Proceed?") {
+		t.Fatalf("second run stdout = %q, want no re-prompt for an unchanged package set", stdout2.String())
 	}
 }

--- a/internal/cli/regression_test.go
+++ b/internal/cli/regression_test.go
@@ -54,7 +54,7 @@ func TestEnableFromSubdirectoryUsesProjectRoot(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	if err := Execute(nil, []string{"enable", "./local-pack"}, &stdout, &stderr); err != nil {
+	if err := Execute(nil, []string{"enable", "./local-pack"}, nil, &stdout, &stderr); err != nil {
 		t.Fatalf("enable error = %v stderr=%s", err, stderr.String())
 	}
 
@@ -114,7 +114,7 @@ func TestEnableFromProjectRootIsUnaffected(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	if err := Execute(nil, []string{"enable", "./agent-pack"}, &stdout, &stderr); err != nil {
+	if err := Execute(nil, []string{"enable", "./agent-pack"}, nil, &stdout, &stderr); err != nil {
 		t.Fatalf("enable error = %v stderr=%s", err, stderr.String())
 	}
 
@@ -169,7 +169,7 @@ func TestRunPassesFlagsAfterDoubleDashToProvider(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	// Everything after "--" is meant for the provider, including a literal
 	// "--dry-run" flag that the wrapped agent itself understands.
-	if err := Execute(nil, []string{"run", "claude", "--", "--dry-run"}, &stdout, &stderr); err != nil {
+	if err := Execute(nil, []string{"run", "claude", "--", "--dry-run"}, nil, &stdout, &stderr); err != nil {
 		t.Fatalf("run error = %v stderr=%s", err, stderr.String())
 	}
 
@@ -187,16 +187,35 @@ func TestRunPassesFlagsAfterDoubleDashToProvider(t *testing.T) {
 // covering both the no-"--" shorthand and the explicit separator form.
 func TestParseRunArgs(t *testing.T) {
 	cases := []struct {
-		name        string
-		args        []string
-		wantDryRun  bool
-		wantForward []string
+		name            string
+		args            []string
+		wantDryRun      bool
+		wantAutoApprove bool
+		wantForward     []string
 	}{
 		{
 			name:        "dry-run without separator",
 			args:        []string{"--dry-run"},
 			wantDryRun:  true,
 			wantForward: []string{},
+		},
+		{
+			name:            "yes without separator",
+			args:            []string{"--yes"},
+			wantAutoApprove: true,
+			wantForward:     []string{},
+		},
+		{
+			name:            "short -y flag",
+			args:            []string{"-y"},
+			wantAutoApprove: true,
+			wantForward:     []string{},
+		},
+		{
+			name:            "provider's own --yes after separator is preserved",
+			args:            []string{"--", "--yes"},
+			wantAutoApprove: false,
+			wantForward:     []string{"--yes"},
 		},
 		{
 			name:        "plain args without separator",
@@ -226,9 +245,12 @@ func TestParseRunArgs(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			dryRun, forward := parseRunArgs(tc.args)
+			dryRun, autoApprove, forward := parseRunArgs(tc.args)
 			if dryRun != tc.wantDryRun {
 				t.Fatalf("dryRun = %v, want %v", dryRun, tc.wantDryRun)
+			}
+			if autoApprove != tc.wantAutoApprove {
+				t.Fatalf("autoApprove = %v, want %v", autoApprove, tc.wantAutoApprove)
 			}
 			if len(forward) != len(tc.wantForward) {
 				t.Fatalf("forward = %#v, want %#v", forward, tc.wantForward)

--- a/internal/materialize/materialize.go
+++ b/internal/materialize/materialize.go
@@ -52,13 +52,7 @@ func Apply(projectRoot string, adapter provider.Provider, pkgs []packages.Packag
 		return err
 	}
 
-	desired := map[string]string{} // relative skill dir -> absolute source dir
-	for _, pkg := range pkgs {
-		for _, skill := range pkg.Skills {
-			rel := filepath.Join(adapter.SkillsDir, pkg.Manifest.Name+"-"+skill)
-			desired[rel] = filepath.Join(pkg.Path, "skills", skill)
-		}
-	}
+	desired := desiredSkillDirs(adapter, pkgs)
 
 	for _, rel := range prev.SkillDirs {
 		if _, ok := desired[rel]; ok {
@@ -87,6 +81,54 @@ func Apply(projectRoot string, adapter provider.Provider, pkgs []packages.Packag
 	}
 
 	return saveState(projectRoot, adapter.Name, state{SkillDirs: written})
+}
+
+// NeedsApproval reports whether calling Apply with pkgs would change
+// anything on disk for this provider — a first-time materialization, or a
+// package/skill set that differs from what the last Apply call recorded.
+// It's used to gate materialization behind an explicit confirmation
+// without re-prompting on every run once a given package set has already
+// been approved and materialized.
+func NeedsApproval(projectRoot string, adapter provider.Provider, pkgs []packages.Package) (bool, error) {
+	prev, err := loadState(projectRoot, adapter.Name)
+	if err != nil {
+		return false, err
+	}
+
+	desired := desiredSkillDirs(adapter, pkgs)
+	desiredDirs := make([]string, 0, len(desired))
+	for rel := range desired {
+		desiredDirs = append(desiredDirs, rel)
+	}
+	sort.Strings(desiredDirs)
+
+	prevDirs := append([]string(nil), prev.SkillDirs...)
+	sort.Strings(prevDirs)
+
+	return !equalStrings(desiredDirs, prevDirs), nil
+}
+
+func desiredSkillDirs(adapter provider.Provider, pkgs []packages.Package) map[string]string {
+	desired := map[string]string{} // relative skill dir -> absolute source dir
+	for _, pkg := range pkgs {
+		for _, skill := range pkg.Skills {
+			rel := filepath.Join(adapter.SkillsDir, pkg.Manifest.Name+"-"+skill)
+			desired[rel] = filepath.Join(pkg.Path, "skills", skill)
+		}
+	}
+	return desired
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func loadState(projectRoot, providerName string) (state, error) {

--- a/internal/materialize/materialize.go
+++ b/internal/materialize/materialize.go
@@ -1,0 +1,226 @@
+// Package materialize stages enabled packages' content where a wrapped
+// agent provider actually reads it, instead of leaving discovery results
+// stranded in `lineage run --dry-run` output. It is provider-neutral: all
+// provider-specific paths come from a provider.Provider value supplied by the
+// caller.
+package materialize
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/lineage-dev/lineage/internal/packages"
+	"github.com/lineage-dev/lineage/internal/provider"
+)
+
+const (
+	stateDirName = ".lineage"
+	beginMarker  = "<!-- lineage:begin -->"
+	endMarker    = "<!-- lineage:end -->"
+)
+
+// state is the record of exactly what the last Apply call wrote for one
+// provider, so a later call can remove entries that are no longer desired
+// (a package got disabled, a skill got removed) instead of only ever adding.
+type state struct {
+	SkillDirs []string `json:"skill_dirs"` // relative to project root, sorted
+}
+
+func statePath(projectRoot, providerName string) string {
+	return filepath.Join(projectRoot, stateDirName, "materialized-"+providerName+".json")
+}
+
+// Apply stages every skill from pkgs into adapter.SkillsDir and refreshes
+// the generated section of adapter.ContextFile describing active packages,
+// agents, policies, and workflows.
+//
+// It is idempotent and reversible: calling it again with a different (or
+// empty) set of packages removes whatever a previous call staged that is no
+// longer desired. This is tracked via a small per-provider state file
+// (.lineage/materialized-<provider>.json) rather than guessed from disk
+// contents, so cleanup is exact even if the package set shrinks between
+// runs.
+func Apply(projectRoot string, adapter provider.Provider, pkgs []packages.Package) error {
+	prev, err := loadState(projectRoot, adapter.Name)
+	if err != nil {
+		return err
+	}
+
+	desired := map[string]string{} // relative skill dir -> absolute source dir
+	for _, pkg := range pkgs {
+		for _, skill := range pkg.Skills {
+			rel := filepath.Join(adapter.SkillsDir, pkg.Manifest.Name+"-"+skill)
+			desired[rel] = filepath.Join(pkg.Path, "skills", skill)
+		}
+	}
+
+	for _, rel := range prev.SkillDirs {
+		if _, ok := desired[rel]; ok {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(projectRoot, rel)); err != nil {
+			return fmt.Errorf("remove stale materialized skill %s: %w", rel, err)
+		}
+	}
+
+	written := make([]string, 0, len(desired))
+	for rel, src := range desired {
+		dest := filepath.Join(projectRoot, rel)
+		if err := os.RemoveAll(dest); err != nil {
+			return fmt.Errorf("clear %s before staging: %w", rel, err)
+		}
+		if err := copyDir(src, dest); err != nil {
+			return fmt.Errorf("stage skill into %s: %w", rel, err)
+		}
+		written = append(written, rel)
+	}
+	sort.Strings(written)
+
+	if err := writeSummary(filepath.Join(projectRoot, adapter.ContextFile), pkgs); err != nil {
+		return fmt.Errorf("update %s: %w", adapter.ContextFile, err)
+	}
+
+	return saveState(projectRoot, adapter.Name, state{SkillDirs: written})
+}
+
+func loadState(projectRoot, providerName string) (state, error) {
+	data, err := os.ReadFile(statePath(projectRoot, providerName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return state{}, nil
+		}
+		return state{}, err
+	}
+	var s state
+	if err := json.Unmarshal(data, &s); err != nil {
+		return state{}, fmt.Errorf("parse %s: %w", statePath(projectRoot, providerName), err)
+	}
+	return s, nil
+}
+
+func saveState(projectRoot, providerName string, s state) error {
+	path := statePath(projectRoot, providerName)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func writeSummary(path string, pkgs []packages.Package) error {
+	block := renderSummaryBlock(pkgs)
+
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	next := block
+	if err == nil {
+		next = replaceBlock(string(existing), block)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(next), 0o644)
+}
+
+func renderSummaryBlock(pkgs []packages.Package) string {
+	var b strings.Builder
+	b.WriteString(beginMarker + "\n")
+	b.WriteString("Lineage-managed section. Do not edit by hand; it is regenerated on every `lineage run`.\n\n")
+	b.WriteString("Active Lineage packages:\n\n")
+	if len(pkgs) == 0 {
+		b.WriteString("none\n")
+	}
+	for _, pkg := range pkgs {
+		fmt.Fprintf(&b, "- %s@%s", pkg.Manifest.Name, pkg.Manifest.Version)
+		if pkg.Manifest.Description != "" {
+			fmt.Fprintf(&b, " - %s", pkg.Manifest.Description)
+		}
+		b.WriteString("\n")
+		if len(pkg.Agents) > 0 {
+			fmt.Fprintf(&b, "  agents: %s\n", strings.Join(pkg.Agents, ", "))
+		}
+		if len(pkg.Policies) > 0 {
+			fmt.Fprintf(&b, "  policies: %s\n", strings.Join(pkg.Policies, ", "))
+		}
+		if len(pkg.Workflows) > 0 {
+			fmt.Fprintf(&b, "  workflows: %s\n", strings.Join(pkg.Workflows, ", "))
+		}
+	}
+	b.WriteString(endMarker + "\n")
+	return b.String()
+}
+
+// replaceBlock swaps the content between beginMarker and endMarker for
+// block, appending block to the end of existing content if no markers are
+// present yet.
+func replaceBlock(existing, block string) string {
+	beginIdx := strings.Index(existing, beginMarker)
+	endIdx := strings.Index(existing, endMarker)
+	if beginIdx == -1 || endIdx == -1 || endIdx < beginIdx {
+		trimmed := strings.TrimRight(existing, "\n")
+		if trimmed == "" {
+			return block
+		}
+		return trimmed + "\n\n" + block
+	}
+	after := strings.TrimPrefix(existing[endIdx+len(endMarker):], "\n")
+	return existing[:beginIdx] + block + after
+}
+
+func copyDir(src, dest string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dest, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to materialize symlink %s", path)
+		}
+		return copyFile(path, target)
+	})
+}
+
+func copyFile(src, dest string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/internal/materialize/materialize_test.go
+++ b/internal/materialize/materialize_test.go
@@ -1,0 +1,170 @@
+package materialize
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lineage-dev/lineage/internal/packages"
+	"github.com/lineage-dev/lineage/internal/provider"
+)
+
+func TestApplyStagesSkillsAndWritesContextFile(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildTestPackage(t, "review-pack", "review")
+
+	adapter := provider.Provider{Name: "claude", SkillsDir: filepath.Join(".claude", "skills"), ContextFile: "CLAUDE.md"}
+	if err := Apply(root, adapter, []packages.Package{pkg}); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	skillFile := filepath.Join(root, ".claude", "skills", "review-pack-review", "SKILL.md")
+	if _, err := os.Stat(skillFile); err != nil {
+		t.Fatalf("expected staged skill at %s: %v", skillFile, err)
+	}
+
+	contextData, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	content := string(contextData)
+	if !containsAll(content, beginMarker, endMarker, "review-pack@0.1.0") {
+		t.Fatalf("CLAUDE.md missing expected content:\n%s", content)
+	}
+}
+
+func TestApplyIsIdempotent(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildTestPackage(t, "review-pack", "review")
+	adapter := provider.Provider{Name: "claude", SkillsDir: filepath.Join(".claude", "skills"), ContextFile: "CLAUDE.md"}
+
+	if err := Apply(root, adapter, []packages.Package{pkg}); err != nil {
+		t.Fatalf("Apply() #1 error = %v", err)
+	}
+	first, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+
+	if err := Apply(root, adapter, []packages.Package{pkg}); err != nil {
+		t.Fatalf("Apply() #2 error = %v", err)
+	}
+	second, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+
+	if string(first) != string(second) {
+		t.Fatalf("CLAUDE.md changed between identical Apply calls:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(root, ".claude", "skills"))
+	if err != nil {
+		t.Fatalf("read skills dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("skills dir has %d entries, want 1 (no duplication): %v", len(entries), entries)
+	}
+}
+
+func TestApplyRemovesStaleSkillsWhenPackageDisabled(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildTestPackage(t, "review-pack", "review")
+	adapter := provider.Provider{Name: "claude", SkillsDir: filepath.Join(".claude", "skills"), ContextFile: "CLAUDE.md"}
+
+	if err := Apply(root, adapter, []packages.Package{pkg}); err != nil {
+		t.Fatalf("Apply() #1 error = %v", err)
+	}
+	stagedDir := filepath.Join(root, ".claude", "skills", "review-pack-review")
+	if _, err := os.Stat(stagedDir); err != nil {
+		t.Fatalf("expected staged skill: %v", err)
+	}
+
+	if err := Apply(root, adapter, nil); err != nil {
+		t.Fatalf("Apply() #2 error = %v", err)
+	}
+	if _, err := os.Stat(stagedDir); !os.IsNotExist(err) {
+		t.Fatalf("expected stale skill dir removed, stat err = %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	if !containsAll(string(content), "none") {
+		t.Fatalf("expected CLAUDE.md to report no active packages, got:\n%s", content)
+	}
+}
+
+func TestApplyPreservesUserContentAroundMarkers(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildTestPackage(t, "review-pack", "review")
+	adapter := provider.Provider{Name: "claude", SkillsDir: filepath.Join(".claude", "skills"), ContextFile: "CLAUDE.md"}
+
+	mustWriteMaterialize(t, filepath.Join(root, "CLAUDE.md"), "# My project notes\n\nHand-written content.\n")
+
+	if err := Apply(root, adapter, []packages.Package{pkg}); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	if !containsAll(string(content), "Hand-written content.", beginMarker, endMarker) {
+		t.Fatalf("expected hand-written content preserved alongside generated block, got:\n%s", content)
+	}
+}
+
+func TestApplyRefusesSymlinkedSkillContent(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildTestPackage(t, "review-pack", "review")
+
+	target := filepath.Join(t.TempDir(), "outside.txt")
+	if err := os.WriteFile(target, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(pkg.Path, "skills", "review", "link.txt")); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+
+	adapter := provider.Provider{Name: "claude", SkillsDir: filepath.Join(".claude", "skills"), ContextFile: "CLAUDE.md"}
+	if err := Apply(root, adapter, []packages.Package{pkg}); err == nil {
+		t.Fatal("Apply() error = nil, want error for symlinked package content")
+	}
+}
+
+func buildTestPackage(t *testing.T, name, skill string) packages.Package {
+	t.Helper()
+	pkgDir := filepath.Join(t.TempDir(), name)
+	if err := packages.InitPackage(pkgDir, name); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteMaterialize(t, filepath.Join(pkgDir, "skills", skill, "SKILL.md"), "# "+skill)
+
+	pkg, err := packages.Discover(pkgDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pkg
+}
+
+func mustWriteMaterialize(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func containsAll(haystack string, needles ...string) bool {
+	for _, needle := range needles {
+		if !strings.Contains(haystack, needle) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/materialize/materialize_test.go
+++ b/internal/materialize/materialize_test.go
@@ -14,8 +14,11 @@ func TestApplyStagesSkillsAndWritesContextFile(t *testing.T) {
 	root := t.TempDir()
 	pkg := buildTestPackage(t, "review-pack", "review")
 
-	adapter := provider.Provider{Name: "claude", SkillsDir: filepath.Join(".claude", "skills"), ContextFile: "CLAUDE.md"}
-	if err := Apply(root, adapter, []packages.Package{pkg}); err != nil {
+	claude, err := provider.Get("claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(root, claude, []packages.Package{pkg}); err != nil {
 		t.Fatalf("Apply() error = %v", err)
 	}
 
@@ -31,6 +34,68 @@ func TestApplyStagesSkillsAndWritesContextFile(t *testing.T) {
 	content := string(contextData)
 	if !containsAll(content, beginMarker, endMarker, "review-pack@0.1.0") {
 		t.Fatalf("CLAUDE.md missing expected content:\n%s", content)
+	}
+}
+
+func TestApplyStagesSkillsForCodexAdapter(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildTestPackage(t, "review-pack", "review")
+	codex, err := provider.Get("codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Apply(root, codex, []packages.Package{pkg}); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	skillFile := filepath.Join(root, ".agents", "skills", "review-pack-review", "SKILL.md")
+	if _, err := os.Stat(skillFile); err != nil {
+		t.Fatalf("expected staged skill at %s: %v", skillFile, err)
+	}
+
+	contextData, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	content := string(contextData)
+	if !containsAll(content, beginMarker, endMarker, "review-pack@0.1.0") {
+		t.Fatalf("AGENTS.md missing expected content:\n%s", content)
+	}
+}
+
+func TestApplyKeepsProvidersIsolated(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildTestPackage(t, "review-pack", "review")
+	claude, err := provider.Get("claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	codex, err := provider.Get("codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Apply(root, claude, []packages.Package{pkg}); err != nil {
+		t.Fatalf("Apply(claude) error = %v", err)
+	}
+	if err := Apply(root, codex, []packages.Package{pkg}); err != nil {
+		t.Fatalf("Apply(codex) error = %v", err)
+	}
+
+	// Disabling everything for one provider must not touch the other
+	// provider's staged content or state.
+	if err := Apply(root, codex, nil); err != nil {
+		t.Fatalf("Apply(codex, none) error = %v", err)
+	}
+
+	claudeSkill := filepath.Join(root, ".claude", "skills", "review-pack-review")
+	if _, err := os.Stat(claudeSkill); err != nil {
+		t.Fatalf("expected claude skill to remain staged: %v", err)
+	}
+	codexSkill := filepath.Join(root, ".agents", "skills", "review-pack-review")
+	if _, err := os.Stat(codexSkill); !os.IsNotExist(err) {
+		t.Fatalf("expected codex skill removed, stat err = %v", err)
 	}
 }
 

--- a/internal/materialize/materialize_test.go
+++ b/internal/materialize/materialize_test.go
@@ -10,6 +10,57 @@ import (
 	"github.com/lineage-dev/lineage/internal/provider"
 )
 
+func TestNeedsApprovalOnFirstRun(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildTestPackage(t, "review-pack", "review")
+	adapter := provider.Provider{Name: "claude", SkillsDir: filepath.Join(".claude", "skills"), ContextFile: "CLAUDE.md"}
+
+	needs, err := NeedsApproval(root, adapter, []packages.Package{pkg})
+	if err != nil {
+		t.Fatalf("NeedsApproval() error = %v", err)
+	}
+	if !needs {
+		t.Fatal("NeedsApproval() = false on first run, want true")
+	}
+}
+
+func TestNeedsApprovalFalseAfterMatchingApply(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildTestPackage(t, "review-pack", "review")
+	adapter := provider.Provider{Name: "claude", SkillsDir: filepath.Join(".claude", "skills"), ContextFile: "CLAUDE.md"}
+
+	if err := Apply(root, adapter, []packages.Package{pkg}); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	needs, err := NeedsApproval(root, adapter, []packages.Package{pkg})
+	if err != nil {
+		t.Fatalf("NeedsApproval() error = %v", err)
+	}
+	if needs {
+		t.Fatal("NeedsApproval() = true for an already-materialized, unchanged package set, want false")
+	}
+}
+
+func TestNeedsApprovalTrueWhenPackageSetChanges(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildTestPackage(t, "review-pack", "review")
+	adapter := provider.Provider{Name: "claude", SkillsDir: filepath.Join(".claude", "skills"), ContextFile: "CLAUDE.md"}
+
+	if err := Apply(root, adapter, []packages.Package{pkg}); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	other := buildTestPackage(t, "other-pack", "other-skill")
+	needs, err := NeedsApproval(root, adapter, []packages.Package{pkg, other})
+	if err != nil {
+		t.Fatalf("NeedsApproval() error = %v", err)
+	}
+	if !needs {
+		t.Fatal("NeedsApproval() = false after adding a new package, want true")
+	}
+}
+
 func TestApplyStagesSkillsAndWritesContextFile(t *testing.T) {
 	root := t.TempDir()
 	pkg := buildTestPackage(t, "review-pack", "review")


### PR DESCRIPTION
## Summary

Stacked on #22/#24. Materialization writes files into the receiver's project (staged skills, a generated section in `CLAUDE.md`/`AGENTS.md`), but `lineage run` did it silently. This gives that write step the same explicit surfacing `--dry-run` already gives the launch plan:

- `materialize.NeedsApproval(projectRoot, adapter, pkgs)` reports whether `Apply` would actually change anything for this provider — first-time materialization, or a package/skill set that differs from what the last `Apply` call recorded. Reuses `Apply`'s existing per-provider state file rather than adding new bookkeeping.
- `lineage run` shows the same summary `--dry-run` would and asks `Proceed? [y/N]` before materializing, but only when `NeedsApproval` says something would actually change — re-running with an unchanged package set doesn't re-prompt.
- `--yes`/`-y` skips the prompt for scripts/CI.
- Declining aborts the whole run (no materialization, no provider launch) rather than silently launching an un-augmented provider — approval is never bypassable by a decline.
- `cli.Execute` gains a `stdin io.Reader` parameter to support this (`main.go` now passes `os.Stdin`); every existing call site updated.

## Linked Issue

Closes #2

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`.

## Package Impact

- [x] Setup or permission flow
- [x] Provider launch/shim behavior
- [ ] Package format or manifest behavior
- [ ] Package discovery or enablement
- [ ] Documentation only
- [ ] Tests only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- `TestNeedsApprovalOnFirstRun`, `TestNeedsApprovalFalseAfterMatchingApply`, `TestNeedsApprovalTrueWhenPackageSetChanges` (new, `materialize_test.go`)
- `TestRunDeclinedApprovalSkipsMaterialization`, `TestRunApprovedMaterializes`, `TestRunYesFlagSkipsPrompt`, `TestRunDoesNotRePromptWhenUnchanged` (new, `internal/cli/cli_test.go`)

```text
go build ./...
go test ./...
```
All pass. Also manually smoke-tested end-to-end against a fake `claude` binary: decline writes nothing and doesn't launch the provider, approve materializes and launches, and a follow-up run with `/dev/null` stdin proceeds without prompting since nothing changed.

## Notes For Reviewers

Base includes #22/#24's commits since this branch stacks on the materializer work; only the last commit here is new. `Execute`'s signature change is the one public-API break in this PR — every internal call site is updated, but it's worth flagging since `CONTRIBUTING.md` asks to preserve the CLI contract unless a task explicitly needs to change it (this one does: there's no other way to feed a testable, real interactive confirmation through the existing stdout/stderr-only signature).