### PR TITLE
Record decisions made while shipping Phase 2 of the distribution plan

### DIFF
--- a/docs/decisions/0005-manifest-is-authoritative-with-schema-and-digest.md
+++ b/docs/decisions/0005-manifest-is-authoritative-with-schema-and-digest.md
@@ -1,0 +1,23 @@
+# 0005 Manifest Is Authoritative, With Schema Versioning And A Content Digest
+
+Status: Accepted
+
+Date: 2026-08-19
+
+## Context
+
+Phase 1 made enabling a package materialize real content for a provider. Before Phase 3 (export/import) lets that content start moving between machines, the package format itself had several open questions that get expensive to answer once packages are actually being shared: whether `lineage.yaml` or the filesystem wins when they disagree about what a package exports, whether a future manifest change can signal "old parsers can't read this," and whether a package reference like `name@version` means anything verifiable.
+
+## Decision
+
+- The manifest is authoritative over the filesystem for declared exports. When `exports.agents`/`exports.workflows` is non-empty, every declared name must exist on disk (missing is a `Discover`-time error) and only declared names count as exported; anything present but undeclared stays local but is excluded. An empty/omitted list falls back to full filesystem discovery, so packages predating this decision are unaffected.
+- `lineage.yaml` carries a `schema` integer, separate from the package's own `version`. `schema` describes how to interpret the manifest; `version` describes the package. A missing `schema` (every manifest before this decision) defaults to 1; anything else is rejected as unsupported rather than silently misparsed.
+- Every discovered package carries a `sha256` content digest over the manifest and its standard content directories, computed in deterministic order, so `name@version` can be paired with "and this is exactly what that resolved to."
+
+## Consequences
+
+Package identity becomes verifiable instead of just a string. Contributors adding manifest fields must decide up front whether they're export-authoritative content or advisory metadata. A future incompatible manifest format has a clean way to say so (`schema: 2`) instead of a parser guessing.
+
+## Follow-Up
+
+The digest is not yet signed or attributable to a publisher — that's `docs/decisions` territory for whenever Phase 3's export/import and a trust model land. `lineage package validate` should stay the place that surfaces the digest and any manifest problems together, rather than each check living only as a library function.

--- a/docs/decisions/0006-capabilities-are-declared-not-enforced.md
+++ b/docs/decisions/0006-capabilities-are-declared-not-enforced.md
@@ -1,0 +1,21 @@
+# 0006 Capabilities Are Declared, Not Enforced, In V1
+
+Status: Accepted
+
+Date: 2026-08-19
+
+## Context
+
+A package with no executable code and no captured secrets can still instruct an agent to read files outside the workspace or reach an unexpected network endpoint. Actually gating that behavior — network egress control, filesystem scoping — is a real sandboxing project, not something to build incidentally while shipping the distribution layer. But if the manifest format ships without any place to declare intent, adding one later is a breaking change to every existing package.
+
+## Decision
+
+Add an optional `capabilities` block to the manifest (`filesystem.read`, `network`) that is purely declarative. `lineage package validate` and `--dry-run` print what a package declares wanting. Nothing in this version of Lineage enforces, blocks, or warns based on those values beyond printing them.
+
+## Consequences
+
+Receivers get visibility ("this package declares it wants network access to X") before enabling, which is real safety value on its own. It also means a `capabilities` block that looks unenforced is expected, not a bug — a contributor should not assume declaring a capability does anything beyond making it visible. Building real enforcement later is additive (interpret an existing field) rather than a manifest schema break.
+
+## Follow-Up
+
+Full capability enforcement is out of scope until there's a concrete sandboxing design to enforce against. When that work starts, it should treat this field as the existing contract to honor, not redesign.

--- a/docs/decisions/0007-providers-are-a-single-registry-entry.md
+++ b/docs/decisions/0007-providers-are-a-single-registry-entry.md
@@ -1,0 +1,21 @@
+# 0007 Providers Are A Single Registry Entry
+
+Status: Accepted
+
+Date: 2026-08-19
+
+## Context
+
+0002 established that the core stays provider-agnostic and provider-specific behavior belongs behind explicit boundaries. In practice, `claude` and `codex` had drifted into two places that special-cased their names as string literals: `internal/runtime.BuildPlan`'s provider check and the CLI's usage text. The actual provider-specific behavior (binary resolution, launch, materialization target) was already generic — only the "which providers exist" question was hardcoded, and hardcoded twice.
+
+## Decision
+
+`internal/provider` owns a single registry: `[]Provider{Name, SkillsDir, ContextFile}`, with `Known()`, `Get()`, `IsKnown()` as the only way anything else learns a provider exists. `internal/runtime`, `internal/materialize`, and the CLI's usage/error text all consult this registry instead of naming `claude`/`codex` directly.
+
+## Consequences
+
+Adding a third provider is a one-entry change in one file. CLI help text and error messages can never drift from what's actually registered, since they're generated from the same source. This is the concrete mechanism behind 0002's principle for the provider boundary specifically — 0002 stays the higher-level statement, this record is what "provider-agnostic" means operationally for `internal/provider`.
+
+## Follow-Up
+
+When a real third provider is added, this decision is the thing to validate: if adding it touches more than `internal/provider`'s registry entry (plus a provider-specific adapter implementation if behavior genuinely diverges), the boundary has leaked and should be tightened again.

--- a/docs/decisions/0008-materialization-is-idempotent-and-permission-gated.md
+++ b/docs/decisions/0008-materialization-is-idempotent-and-permission-gated.md
@@ -1,0 +1,22 @@
+# 0008 Materialization Is Idempotent, Reversible, And Permission-Gated
+
+Status: Accepted
+
+Date: 2026-08-19
+
+## Context
+
+Making `lineage run` actually stage a package's content for a provider (skills into `.claude/skills/`, a generated section in `CLAUDE.md`) is the core of what makes "enable" mean something. That also means `lineage run` writes to the receiver's project for the first time. Two failure modes needed a decision up front: repeated or shrinking runs silently drifting (duplicated entries, orphaned files from a disabled package), and materialization happening as an unannounced side effect of what looks like "just launching the agent."
+
+## Decision
+
+- Materialization tracks exactly what it wrote per provider in `.lineage/materialized-<provider>.json`. Every `Apply` call reconciles against that record — the desired set for the current package list, not a diff against whatever happens to be on disk — so re-running never duplicates and a package that's no longer enabled has its output removed.
+- `lineage run` computes whether materializing would change anything (`NeedsApproval`) and, if so, shows the same summary `--dry-run` would and asks for confirmation before writing. Approval is remembered implicitly: an unchanged package set doesn't re-prompt. `--yes`/`-y` skips the prompt for scripts. Declining aborts the entire run, including launching the provider — there is no silent "launch without materializing" fallback.
+
+## Consequences
+
+A receiver never discovers unexpected files in their project from `lineage run` without having seen what was about to happen first. Provider adapters don't need their own approval or cleanup logic — anything built as an `internal/provider.Provider` entry inherits both behaviors from `internal/materialize` for free. The cost is one interactive prompt on first use per project/provider pair, and CLI automation must remember `--yes`.
+
+## Follow-Up
+
+`lineage disable <ref>` (Phase 5 of the distribution plan) can reuse `Apply` directly with a shortened package list — the reconciliation behavior already supports it, no new removal API needed. Setup actions beyond materialization (declared tracker/template files, permission-gated receiver setup — Phase 2 territory) should gate through the same confirmation pattern rather than inventing a second one.

--- a/docs/decisions/0009-secret-scanning-is-a-documented-list-not-an-engine.md
+++ b/docs/decisions/0009-secret-scanning-is-a-documented-list-not-an-engine.md
@@ -1,0 +1,21 @@
+# 0009 Secret Scanning Is A Documented Allow/Denylist, Not A General Engine
+
+Status: Accepted
+
+Date: 2026-08-19
+
+## Context
+
+The README, `SECURITY.md`, and the `lineage-package-safety` skill all state that Lineage shouldn't make it easy to accidentally distribute credentials, but none of it was backed by code. A full secret-scanning engine (entropy analysis, broad pattern libraries, ML-based detection) is a substantial project with a real false-positive-rate tuning problem, and building one wasn't a prerequisite for making the existing safety principles true rather than aspirational.
+
+## Decision
+
+`internal/packages.ScanForSecrets` checks a small, explicit, documented set of signals: denylisted filenames (`.env`, `.npmrc`, SSH private key names, `.pem`/`.key`/`.pfx`/`.p12`) and a short list of high-confidence content patterns (private key headers, AWS access key ID shape, GitHub token prefixes). Findings report a file path and a human-readable reason only — the matched value itself is never included in a finding, so scan output is always safe to print or log.
+
+## Consequences
+
+The scan is precise (low false-positive rate) rather than exhaustive — it will not catch every possible secret shape, and that's an accepted tradeoff for v1, not an oversight. It's also trivially extensible: adding a new pattern is a one-line change to a reviewable list, not a retrain or a new subsystem. `lineage package validate` and the future export gate (Phase 3) both consume this as one input among several, not as a claim of complete secret safety.
+
+## Follow-Up
+
+If false negatives against real-world packages become a recurring problem, extend the documented list rather than reaching for a general entropy-based scanner as the first response — that changes the false-positive tradeoff this decision deliberately made.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -32,3 +32,8 @@ Each record should include:
 - [0002 Keep Core Provider-Agnostic](0002-keep-core-provider-agnostic.md)
 - [0003 Use Goal-Based Milestones](0003-use-goal-based-milestones.md)
 - [0004 Require Issue Links And Test Plans For PRs](0004-require-issue-links-and-test-plans-for-prs.md)
+- [0005 Manifest Is Authoritative, With Schema Versioning And A Content Digest](0005-manifest-is-authoritative-with-schema-and-digest.md)
+- [0006 Capabilities Are Declared, Not Enforced, In V1](0006-capabilities-are-declared-not-enforced.md)
+- [0007 Providers Are A Single Registry Entry](0007-providers-are-a-single-registry-entry.md)
+- [0008 Materialization Is Idempotent, Reversible, And Permission-Gated](0008-materialization-is-idempotent-and-permission-gated.md)
+- [0009 Secret Scanning Is A Documented Allow/Denylist, Not A General Engine](0009-secret-scanning-is-a-documented-list-not-an-engine.md)


### PR DESCRIPTION
## Summary

Adds five ADRs for decisions made while implementing Phase 2 (manifest format lock-in, secret scanning, permission-gated materialization, package validate) that meet the log's own bar — expensive to reverse, shape package semantics, or explain why one path was chosen over another:

- **0005** — manifest authority, schema versioning, content digest: the format lock-in that had to land before export/import.
- **0006** — capabilities are declared, not enforced, in v1: explains why the `capabilities` manifest block exists with no enforcement code behind it yet.
- **0007** — providers are a single registry entry: the concrete mechanism behind 0002's existing "keep core provider-agnostic" principle.
- **0008** — materialization is idempotent, reversible, and permission-gated: the state-tracking + confirmation-prompt design for the first thing `lineage run` actually writes into a receiver's project.
- **0009** — secret scanning is a documented allow/denylist, not a general engine: the scope boundary that keeps it precise instead of noisy.

`docs/decisions/README.md`'s index updated to list all five.

## Linked Issue

Maintainer housekeeping; no product issue (matches #26's precedent for decision-log entries).

- [x] This PR targets `develop`.

## Package Impact

- [x] Documentation only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.

## Verification

Docs-only change; no code paths affected.

```text
go test ./...
```

## Notes For Reviewers

Pure documentation, no code changes.