### PR TITLE
Record the SafeJoin trust-boundary decision

### DIFF
--- a/docs/decisions/0010-path-safety-only-applies-to-package-controlled-input.md
+++ b/docs/decisions/0010-path-safety-only-applies-to-package-controlled-input.md
@@ -1,0 +1,21 @@
+# 0010 Path Safety Only Applies To Package-Controlled Input, Not User-Typed Paths
+
+Status: Accepted
+
+Date: 2026-08-19
+
+## Context
+
+Adding traversal protection for manifest-derived paths (entrypoints, and archive entries once import exists) raised an easy-to-get-wrong question: should the same guard also apply to paths the user types directly at the CLI, like `lineage enable ../sibling-package`? Blanket-rejecting `..` everywhere would break a legitimate use case (referencing a package outside the current project, e.g. in a monorepo) to guard against a threat that isn't there — the user typing their own CLI arguments is trusted first-party intent, not untrusted package content.
+
+## Decision
+
+`internal/packages.SafeJoin` is scoped specifically to paths that originate from *package-controlled* input: manifest fields (`entrypoints.claude`/`entrypoints.codex` today) and archive entries once Phase 3's import lands. It is never applied to a path the user supplies directly as a CLI argument (`lineage enable <ref>`, `lineage package validate <path>`) — those keep resolving exactly as typed, `..` included.
+
+## Consequences
+
+A new manifest field whose value becomes a filesystem path must be run through `SafeJoin` before use — that's the rule to apply, not "validate all paths." Conversely, CLI argument handling should never gain a traversal check on the theory that it's "safer" — doing so would silently break legitimate relative references the user is entitled to make. The dividing line is *who controls the string*, not *whether it looks like a path*.
+
+## Follow-Up
+
+Phase 3's `lineage package import <archive>` is the next place this rule applies: archive entry paths are package-controlled (effectively remote input) and must go through `SafeJoin` before anything gets written to disk, the same as entrypoints today.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -37,3 +37,4 @@ Each record should include:
 - [0007 Providers Are A Single Registry Entry](0007-providers-are-a-single-registry-entry.md)
 - [0008 Materialization Is Idempotent, Reversible, And Permission-Gated](0008-materialization-is-idempotent-and-permission-gated.md)
 - [0009 Secret Scanning Is A Documented Allow/Denylist, Not A General Engine](0009-secret-scanning-is-a-documented-list-not-an-engine.md)
+- [0010 Path Safety Only Applies To Package-Controlled Input, Not User-Typed Paths](0010-path-safety-only-applies-to-package-controlled-input.md)


### PR DESCRIPTION
## Summary

One more decision from Phase 2 worth its own record, on top of #44's five: `SafeJoin`'s path traversal guard applies only to package-controlled input (manifest fields today, archive entries once import exists), never to a path the user types directly at the CLI.

This is genuinely easy to get backwards. Blanket-rejecting `..` everywhere would break a legitimate use case — `lineage enable ../sibling-package` in a monorepo — to guard against a threat that isn't there, since CLI arguments are trusted first-party intent, not untrusted package content. Worth documenting explicitly so nobody "fixes" this into a CLI-argument traversal check, or forgets to apply `SafeJoin` to a new manifest path field.

## Linked Issue

Maintainer housekeeping; no product issue (decision-log entry, same precedent as #26/#44).

- [x] This PR targets `develop`.

## Package Impact

- [x] Documentation only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.

## Verification

Docs-only change; no code paths affected.

```text
go test ./...
```

## Notes For Reviewers

Pure documentation. Built from an isolated `git worktree` off `origin/develop` since the local checkout had unrelated in-progress uncommitted changes at the time.