### PR TITLE
Add lineage package export command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,3 +78,9 @@ All notable changes to Lineage will be documented here.
   for scripts. Re-running with an unchanged package set doesn't
   re-prompt. `lineage.Execute` now takes a `stdin io.Reader` to support
   this.
+- Added `lineage package export <path> [-o file.tgz]`: produces a
+  deterministic tar.gz archive (manifest + content directories, sorted
+  order, normalized permissions and timestamps) after running the same
+  checks as `lineage package validate` and refusing to export if any
+  fail. Two exports of byte-identical package content always produce
+  byte-identical archive bytes.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -88,14 +88,19 @@ func runInit(args []string, home string, stdout, stderr io.Writer) error {
 }
 
 func runPackage(args []string, stdout, stderr io.Writer) error {
-	if len(args) != 2 {
-		err := fmt.Errorf("usage: lineage package init <name> | lineage package validate <path>")
+	if len(args) < 2 {
+		err := fmt.Errorf("usage: lineage package init <name> | lineage package validate <path> | lineage package export <path> [-o file.tgz]")
 		fmt.Fprintln(stderr, err)
 		return err
 	}
 
 	switch args[0] {
 	case "init":
+		if len(args) != 2 {
+			err := fmt.Errorf("usage: lineage package init <name>")
+			fmt.Fprintln(stderr, err)
+			return err
+		}
 		name := args[1]
 		dir := filepath.Clean(name)
 		if err := packages.InitPackage(dir, filepath.Base(name)); err != nil {
@@ -105,12 +110,70 @@ func runPackage(args []string, stdout, stderr io.Writer) error {
 		fmt.Fprintf(stdout, "initialized package %s\n", dir)
 		return nil
 	case "validate":
+		if len(args) != 2 {
+			err := fmt.Errorf("usage: lineage package validate <path>")
+			fmt.Fprintln(stderr, err)
+			return err
+		}
 		return runPackageValidate(filepath.Clean(args[1]), stdout, stderr)
+	case "export":
+		return runPackageExport(args[1:], stdout, stderr)
 	default:
 		err := fmt.Errorf("unknown package command %q", args[0])
 		fmt.Fprintln(stderr, err)
 		return err
 	}
+}
+
+func runPackageExport(args []string, stdout, stderr io.Writer) error {
+	if len(args) < 1 {
+		err := fmt.Errorf("usage: lineage package export <path> [-o file.tgz]")
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	dir := filepath.Clean(args[0])
+	outPath := ""
+	for i := 1; i < len(args); i++ {
+		if args[i] == "-o" && i+1 < len(args) {
+			outPath = args[i+1]
+			i++
+			continue
+		}
+		err := fmt.Errorf("usage: lineage package export <path> [-o file.tgz]")
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	if outPath == "" {
+		manifest, err := packages.LoadManifest(dir)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return err
+		}
+		outPath = fmt.Sprintf("%s-%s.tgz", manifest.Name, manifest.Version)
+	}
+
+	f, err := os.Create(outPath)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	if err := packages.Export(dir, f); err != nil {
+		f.Close()
+		os.Remove(outPath)
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(outPath)
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	fmt.Fprintf(stdout, "exported %s to %s\n", dir, outPath)
+	return nil
 }
 
 func runPackageValidate(dir string, stdout, stderr io.Writer) error {
@@ -306,9 +369,9 @@ func runProvider(ctx context.Context, args []string, home string, stdin io.Reade
 		fmt.Fprint(stdout, "\nProceed? [y/N] ")
 		if !confirm(stdin) {
 			fmt.Fprintln(stdout, "aborted: materialization was not approved")
-				return nil
-			}
+			return nil
 		}
+	}
 
 	if err := materialize.Apply(plan.ProjectRoot, adapter, plan.Packages); err != nil {
 		fmt.Fprintln(stderr, err)
@@ -362,6 +425,7 @@ Usage:
   lineage init workspace <name>
   lineage package init <name>
   lineage package validate <path>
+  lineage package export <path> [-o file.tgz]
   lineage enable <package-path-or-id>
   lineage run <%s> [--dry-run] [--yes] [-- provider args...]
   lineage install-shims

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -310,3 +310,47 @@ func TestRunDoesNotRePromptWhenUnchanged(t *testing.T) {
 		t.Fatalf("second run stdout = %q, want no re-prompt for an unchanged package set", stdout2.String())
 	}
 }
+
+func TestPackageExportWritesArchive(t *testing.T) {
+	root := t.TempDir()
+	pkgDir := filepath.Join(root, "export-me")
+	if err := packages.InitPackage(pkgDir, "export-me"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(pkgDir, "skills", "review"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "skills", "review", "SKILL.md"), []byte("# Review"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outPath := filepath.Join(root, "out.tgz")
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"package", "export", pkgDir, "-o", outPath}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("export error = %v stderr=%s", err, stderr.String())
+	}
+	if _, err := os.Stat(outPath); err != nil {
+		t.Fatalf("expected archive at %s: %v", outPath, err)
+	}
+}
+
+func TestPackageExportRefusesInvalidPackage(t *testing.T) {
+	root := t.TempDir()
+	pkgDir := filepath.Join(root, "broken")
+	if err := packages.InitPackage(pkgDir, "broken"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, ".env"), []byte("SECRET=1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outPath := filepath.Join(root, "out.tgz")
+	var stdout, stderr bytes.Buffer
+	err := Execute(nil, []string{"package", "export", pkgDir, "-o", outPath}, nil, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("export error = nil, want error for a package with a secret finding")
+	}
+	if _, statErr := os.Stat(outPath); !os.IsNotExist(statErr) {
+		t.Fatal("expected no archive left behind when export fails")
+	}
+}

--- a/internal/packages/discovery.go
+++ b/internal/packages/discovery.go
@@ -103,25 +103,21 @@ func validateEntrypoint(dir, provider, entrypoint string) error {
 	return nil
 }
 
-// ComputeDigest returns a stable "sha256:<hex>" content digest over a
-// package's manifest and every file in its standard content directories
-// (skills, workflows, agents, policies, references, adapters), hashed in
-// deterministic path order. Two packages with byte-identical content always
-// produce the same digest; any content change changes it. A symlink
-// anywhere in those directories is rejected rather than followed, since
-// package content is untrusted and a symlink could otherwise pull
-// arbitrary file content from outside the package into the digest.
-func ComputeDigest(dir string) (string, error) {
-	h := sha256.New()
+// contentDirNames are the standard package subdirectories that hold a
+// package's actual distributable payload — used consistently by digest
+// computation, export, and (once it exists) archive validation, so all
+// three agree on exactly what "the package's content" means.
+var contentDirNames = []string{"skills", "workflows", "agents", "policies", "references", "adapters"}
 
-	manifestData, err := os.ReadFile(filepath.Join(dir, ManifestFileName))
-	if err != nil {
-		return "", fmt.Errorf("read manifest for digest: %w", err)
-	}
-	h.Write(manifestData)
-
+// contentFiles returns every regular file under dir's standard content
+// directories, as paths relative to dir in deterministic (sorted,
+// forward-slashed) order. A symlink anywhere in those directories is
+// rejected rather than followed or silently skipped, since package content
+// is untrusted and a symlink could otherwise pull arbitrary file content
+// from outside the package into a digest or export archive.
+func contentFiles(dir string) ([]string, error) {
 	var files []string
-	for _, sub := range []string{"skills", "workflows", "agents", "policies", "references", "adapters"} {
+	for _, sub := range contentDirNames {
 		root := filepath.Join(dir, sub)
 		walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
@@ -132,7 +128,7 @@ func ComputeDigest(dir string) (string, error) {
 				if relErr != nil {
 					rel = path
 				}
-				return fmt.Errorf("refusing to include symlink %s in digest", rel)
+				return fmt.Errorf("refusing to include symlink %s", rel)
 			}
 			if d.IsDir() {
 				return nil
@@ -145,10 +141,30 @@ func ComputeDigest(dir string) (string, error) {
 			return nil
 		})
 		if walkErr != nil {
-			return "", walkErr
+			return nil, walkErr
 		}
 	}
 	sort.Strings(files)
+	return files, nil
+}
+
+// ComputeDigest returns a stable "sha256:<hex>" content digest over a
+// package's manifest and every file in its standard content directories,
+// hashed in deterministic path order. Two packages with byte-identical
+// content always produce the same digest; any content change changes it.
+func ComputeDigest(dir string) (string, error) {
+	h := sha256.New()
+
+	manifestData, err := os.ReadFile(filepath.Join(dir, ManifestFileName))
+	if err != nil {
+		return "", fmt.Errorf("read manifest for digest: %w", err)
+	}
+	h.Write(manifestData)
+
+	files, err := contentFiles(dir)
+	if err != nil {
+		return "", fmt.Errorf("read content for digest: %w", err)
+	}
 
 	for _, rel := range files {
 		data, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(rel)))

--- a/internal/packages/export.go
+++ b/internal/packages/export.go
@@ -1,0 +1,85 @@
+package packages
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// deterministicTime is used for every tar entry's ModTime so that exporting
+// byte-identical package content twice — on any machine, at any time —
+// produces a byte-identical archive. Real timestamps would make the archive
+// (and therefore its own hash) depend on when it happened to be built.
+var deterministicTime = time.Unix(0, 0).UTC()
+
+// Export writes package dir as a deterministic, reproducible tar.gz archive
+// to w: the manifest plus every file in the package's standard content
+// directories, in sorted path order, with normalized permissions and a
+// fixed modification time. Two exports of byte-identical package content
+// always produce byte-identical archive bytes.
+//
+// Export refuses to run against a package that fails Validate — exporting
+// is exactly the moment package content starts moving to another machine,
+// so it must not ship something with an unresolved secret finding, a
+// traversing entrypoint, or a declared-but-missing export.
+func Export(dir string, w io.Writer) error {
+	report, err := Validate(dir)
+	if err != nil {
+		return err
+	}
+	if !report.Passed() {
+		return fmt.Errorf("package failed validation, refusing to export (%d error(s)); run `lineage package validate` for details", len(report.Errors))
+	}
+
+	files, err := contentFiles(dir)
+	if err != nil {
+		return fmt.Errorf("read content for export: %w", err)
+	}
+
+	gz := gzip.NewWriter(w)
+	gz.Header.ModTime = deterministicTime
+	tw := tar.NewWriter(gz)
+
+	if err := addTarFile(tw, filepath.Join(dir, ManifestFileName), ManifestFileName); err != nil {
+		return err
+	}
+	for _, rel := range files {
+		if err := addTarFile(tw, filepath.Join(dir, filepath.FromSlash(rel)), rel); err != nil {
+			return err
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		return fmt.Errorf("finalize archive: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return fmt.Errorf("finalize archive compression: %w", err)
+	}
+	return nil
+}
+
+func addTarFile(tw *tar.Writer, absPath, name string) error {
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", name, err)
+	}
+
+	hdr := &tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     name,
+		Size:     int64(len(data)),
+		Mode:     0o644,
+		ModTime:  deterministicTime,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return fmt.Errorf("write archive header for %s: %w", name, err)
+	}
+	if _, err := tw.Write(data); err != nil {
+		return fmt.Errorf("write archive content for %s: %w", name, err)
+	}
+	return nil
+}

--- a/internal/packages/export_test.go
+++ b/internal/packages/export_test.go
@@ -1,0 +1,100 @@
+package packages
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"path/filepath"
+	"testing"
+)
+
+func TestExportIsDeterministic(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "export-pack")
+	if err := InitPackage(root, "export-pack"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, "skills", "review", "SKILL.md"), "# Review")
+
+	var first, second bytes.Buffer
+	if err := Export(root, &first); err != nil {
+		t.Fatalf("Export() #1 error = %v", err)
+	}
+	if err := Export(root, &second); err != nil {
+		t.Fatalf("Export() #2 error = %v", err)
+	}
+
+	if !bytes.Equal(first.Bytes(), second.Bytes()) {
+		t.Fatal("Export() produced different bytes for identical content across two runs")
+	}
+}
+
+func TestExportRefusesWhenValidationFails(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "broken-pack")
+	if err := InitPackage(root, "broken-pack"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, ".env"), "API_KEY=whatever")
+
+	var buf bytes.Buffer
+	if err := Export(root, &buf); err == nil {
+		t.Fatal("Export() error = nil, want error for a package that fails validation")
+	}
+}
+
+func TestExportIncludesManifestAndContentSortedOrder(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "content-pack")
+	if err := InitPackage(root, "content-pack"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, "skills", "zzz-last", "SKILL.md"), "# Last")
+	mustWrite(t, filepath.Join(root, "skills", "aaa-first", "SKILL.md"), "# First")
+
+	var buf bytes.Buffer
+	if err := Export(root, &buf); err != nil {
+		t.Fatalf("Export() error = %v", err)
+	}
+
+	names := readTarNames(t, buf.Bytes())
+	if len(names) < 3 {
+		t.Fatalf("archive entries = %#v, want at least manifest + 2 skill files", names)
+	}
+	if names[0] != ManifestFileName {
+		t.Fatalf("archive entries = %#v, want manifest first", names)
+	}
+	firstIdx, lastIdx := -1, -1
+	for i, n := range names {
+		if n == filepath.ToSlash(filepath.Join("skills", "aaa-first", "SKILL.md")) {
+			firstIdx = i
+		}
+		if n == filepath.ToSlash(filepath.Join("skills", "zzz-last", "SKILL.md")) {
+			lastIdx = i
+		}
+	}
+	if firstIdx == -1 || lastIdx == -1 || firstIdx > lastIdx {
+		t.Fatalf("archive entries = %#v, want aaa-first before zzz-last", names)
+	}
+}
+
+func readTarNames(t *testing.T, data []byte) []string {
+	t.Helper()
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("gzip.NewReader() error = %v", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	var names []string
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar read error = %v", err)
+		}
+		names = append(names, hdr.Name)
+	}
+	return names
+}


### PR DESCRIPTION
## Summary

Phase 3 of the v1 distribution plan. Right now a package only ever exists as a local directory — there's no way to hand someone a package as a single artifact, which is the biggest literal gap between "Lineage" the name and what it currently does.

- `packages.Export(dir, w)` writes a deterministic tar.gz: manifest plus every file in the package's standard content directories, sorted path order, normalized mode (`0644`) and a fixed modification time on every entry *and* the gzip header itself. Two exports of byte-identical content always produce byte-identical archive bytes.
- Export refuses to run against a package that fails `Validate` (#43) — export is exactly the moment content starts moving to another machine, so it must not ship something with an unresolved secret finding, a traversing entrypoint, or a declared-but-missing export.
- `contentFiles(dir)` — the file-walking half of `ComputeDigest` — is now shared between digest computation and export, so both agree on exactly what "the package's content" means without duplicating the symlink-rejecting walk.
- `lineage package export <path> [-o file.tgz]`; defaults the output filename to `<name>-<version>.tgz`, cleans up a partial file if export fails partway through.

Also fixes a pre-existing `gofmt` indentation glitch in `cli.go` left over from an earlier manual conflict resolution (unrelated to this PR's own changes, just noticed it while I was in the file).

## Linked Issue

Closes #4

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`.

## Package Impact

- [x] Package format or manifest behavior
- [ ] Package discovery or enablement
- [ ] Provider launch/shim behavior
- [ ] Setup or permission flow
- [ ] Documentation only
- [ ] Tests only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- `TestExportIsDeterministic`, `TestExportRefusesWhenValidationFails`, `TestExportIncludesManifestAndContentSortedOrder` (new, `internal/packages/export_test.go`)
- `TestPackageExportWritesArchive`, `TestPackageExportRefusesInvalidPackage` (new, `internal/cli/cli_test.go`)

```text
go build ./...
go test ./...
```
All pass. Also manually smoke-tested against the real `examples/resume-workflow` package: exported twice, diffed the two `.tgz` files with the system `diff` — byte-identical — and listed contents with real `tar -tzf` to confirm the archive is well-formed, not just internally self-consistent.

## Notes For Reviewers

Import (#1) is next and will consume this same format — archive entries go through `SafeJoin` (#40) before anything gets written to disk, the same way entrypoints do today, since an archive is untrusted input the same way a manifest is.