### PR TITLE
Add lineage workflow run for minimal workflow execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,9 +81,9 @@ All notable changes to Lineage will be documented here.
 - Added `lineage package export <path> [-o file.tgz]`: produces a
   deterministic tar.gz archive (manifest + content directories, sorted
   order, normalized permissions and timestamps) after running the same
-	  checks as `lineage package validate` and refusing to export if any
-	  fail. Two exports of byte-identical package content always produce
-	  byte-identical archive bytes.
+  checks as `lineage package validate` and refusing to export if any
+  fail. Two exports of byte-identical package content always produce
+  byte-identical archive bytes.
 - Added `lineage package import <file.tgz> [--as name]`: extracts an
   exported archive into the user packages directory. The archive is
   treated as untrusted input — every entry path is checked against
@@ -93,3 +93,19 @@ All notable changes to Lineage will be documented here.
   than installed. Never overwrites an existing package; use `--as` to
   import under a different name. Export followed by import reproduces
   the original package exactly, verified by matching content digests.
+- `WORKFLOW.md` can now declare an ordered `steps` list (YAML
+  frontmatter, the same convention `SKILL.md` already uses) naming
+  skills within the same package. `lineage package validate` checks
+  every step resolves to a real skill.
+- Added `lineage workflow run <workflow-name> <provider> [--dry-run]
+  [--yes] [-- provider args...]`: finds which enabled package declares
+  the workflow and materializes *only* its steps — not the full
+  enabled package set — in order, then hands off to the provider. The
+  provider's generated context file explicitly lists the active
+  workflow and its ordered steps. Same permission-gate/`--dry-run`
+  behavior as `lineage run`; a plain `lineage run` afterward correctly
+  restores the full enabled package set, since both share the same
+  per-provider materialization state.
+- Fixed a rendering bug where `lineage help`/usage output for several
+  commands contained literal tab characters instead of consistent
+  indentation.

--- a/examples/resume-workflow/skills/gather-notes/SKILL.md
+++ b/examples/resume-workflow/skills/gather-notes/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: gather-notes
+description: Collect the target role and source material needed before reviewing a resume.
+---
+
+# Gather Notes
+
+Confirm the target role and ask the receiver to fill in `references/source-notes-template.csv` with the role, measurable achievements, and constraints to avoid. Do not proceed to review until the essentials are present, or the receiver confirms none exist.

--- a/examples/resume-workflow/workflows/resume-review/WORKFLOW.md
+++ b/examples/resume-workflow/workflows/resume-review/WORKFLOW.md
@@ -1,3 +1,9 @@
+---
+steps:
+  - gather-notes
+  - resume-review
+---
+
 # Resume Review Workflow
 
 1. Confirm the target role and available source material.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -39,6 +39,8 @@ func Execute(ctx context.Context, args []string, stdin io.Reader, stdout, stderr
 		return runEnable(args[1:], home, stdout, stderr)
 	case "run":
 		return runProvider(ctx, args[1:], home, stdin, stdout, stderr)
+	case "workflow":
+		return runWorkflow(args[1:], home, stdin, stdout, stderr)
 	case "install-shims":
 		return runInstallShims(home, stdout, stderr)
 	case "help", "-h", "--help":
@@ -430,6 +432,104 @@ func runProvider(ctx context.Context, args []string, home string, stdin io.Reade
 	return nil
 }
 
+func runWorkflow(args []string, home string, stdin io.Reader, stdout, stderr io.Writer) error {
+	usage := fmt.Errorf("usage: lineage workflow run <workflow-name> <%s> [--dry-run] [--yes] [-- provider args...]", providerNameList())
+	if len(args) < 3 || args[0] != "run" {
+		fmt.Fprintln(stderr, usage)
+		return usage
+	}
+
+	workflowName := args[1]
+	providerName := args[2]
+	dryRun, autoApprove, providerArgs := parseRunArgs(args[3:])
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	found, err := config.FindProjectConfig(cwd)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	resolved, err := packages.ResolveEnabled(home, found.Config.Workspace, found.Root, found.Config.EnabledPackages)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	if err := packages.ValidateDependencies(resolved); err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	ownerPkg, wf, err := packages.FindWorkflow(resolved, workflowName)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	adapter, err := provider.Get(providerName)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	providerPlan, err := provider.Resolve(providerName, home, found.Config, providerArgs)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	if dryRun {
+		fmt.Fprint(stdout, workflowPlanString(wf, ownerPkg, providerName, providerPlan))
+		return nil
+	}
+
+	// Same permission gate as `lineage run`, scoped to just this workflow's
+	// steps rather than the whole enabled package set - see
+	// materialize.ApplyWorkflow.
+	needsApproval, err := materialize.NeedsApprovalForWorkflow(found.Root, adapter, ownerPkg, wf)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	if needsApproval && !autoApprove {
+		fmt.Fprintf(stdout, "lineage will make the following changes to run workflow %q for %s:\n\n", wf.Name, providerName)
+		fmt.Fprint(stdout, workflowPlanString(wf, ownerPkg, providerName, providerPlan))
+		fmt.Fprint(stdout, "\nProceed? [y/N] ")
+		if !confirm(stdin) {
+			fmt.Fprintln(stdout, "aborted: materialization was not approved")
+			return nil
+		}
+	}
+
+	if err := materialize.ApplyWorkflow(found.Root, adapter, ownerPkg, wf); err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	if err := provider.Launch(providerPlan); err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	return nil
+}
+
+func workflowPlanString(wf packages.Workflow, pkg packages.Package, providerName string, providerPlan provider.Plan) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Lineage workflow plan\n")
+	fmt.Fprintf(&b, "workflow: %s\n", wf.Name)
+	fmt.Fprintf(&b, "package: %s@%s\n", pkg.Manifest.Name, pkg.Manifest.Version)
+	fmt.Fprintf(&b, "provider: %s\n", providerName)
+	fmt.Fprintf(&b, "real_binary: %s\n", emptyValue(providerPlan.Binary))
+	fmt.Fprintf(&b, "steps:\n")
+	for i, step := range wf.Steps {
+		fmt.Fprintf(&b, "  %d. %s\n", i+1, step)
+	}
+	return b.String()
+}
+
 // confirm reads a single line from stdin and reports whether it's an
 // affirmative answer ("y" or "yes", case-insensitive). Anything else,
 // including EOF or a nil reader, is treated as a decline - approval must be
@@ -468,14 +568,15 @@ Lineage shareable agent runtime
 Usage:
   lineage init user
   lineage init workspace <name>
-	  lineage package init <name>
-	  lineage package validate <path>
-	  lineage package export <path> [-o file.tgz]
-	  lineage package import <file.tgz> [--as name]
-	  lineage enable <package-path-or-id>
-	  lineage run <%s> [--dry-run] [--yes] [-- provider args...]
-	  lineage install-shims
-`, providerNameList())))
+  lineage package init <name>
+  lineage package validate <path>
+  lineage package export <path> [-o file.tgz]
+  lineage package import <file.tgz> [--as name]
+  lineage enable <package-path-or-id>
+  lineage run <%s> [--dry-run] [--yes] [-- provider args...]
+  lineage workflow run <workflow-name> <%s> [--dry-run] [--yes] [-- provider args...]
+  lineage install-shims
+`, providerNameList(), providerNameList())))
 }
 
 // providerNameList returns every registered provider name, comma-separated,

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -405,3 +405,103 @@ func TestPackageExportThenImportRoundTrip(t *testing.T) {
 		t.Fatalf("imported digest = %q, want %q", imported.Digest, original.Digest)
 	}
 }
+
+func setUpEnabledWorkflowProject(t *testing.T) (project, home string) {
+	t.Helper()
+	tmp := t.TempDir()
+	home = filepath.Join(tmp, "home")
+	project = filepath.Join(tmp, "project")
+	pkgDir := filepath.Join(project, "wf-pack")
+	if err := packages.InitPackage(pkgDir, "wf-pack"); err != nil {
+		t.Fatal(err)
+	}
+	for _, skill := range []string{"gather", "review"} {
+		if err := os.MkdirAll(filepath.Join(pkgDir, "skills", skill), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pkgDir, "skills", skill, "SKILL.md"), []byte("# "+skill), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(pkgDir, "workflows", "review-flow"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wfContent := "---\nsteps:\n  - gather\n  - review\n---\n\n# Review Flow\n"
+	if err := os.WriteFile(filepath.Join(pkgDir, "workflows", "review-flow", "WORKFLOW.md"), []byte(wfContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldHome := os.Getenv(config.HomeEnv)
+	t.Setenv(config.HomeEnv, home)
+	t.Cleanup(func() { os.Setenv(config.HomeEnv, oldHome) })
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(oldWd) })
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"enable", "./wf-pack"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("enable error = %v stderr=%s", err, stderr.String())
+	}
+
+	cfg, err := config.LoadProjectConfig(config.ProjectConfigPath(project))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Providers = map[string]config.Provider{"claude": {Binary: "/bin/echo"}}
+	if err := config.SaveProjectConfig(config.ProjectConfigPath(project), cfg); err != nil {
+		t.Fatal(err)
+	}
+	return project, home
+}
+
+func TestWorkflowRunDryRunShowsOrderedSteps(t *testing.T) {
+	setUpEnabledWorkflowProject(t)
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"workflow", "run", "review-flow", "claude", "--dry-run"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("workflow run error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "1. gather") || !strings.Contains(stdout.String(), "2. review") {
+		t.Fatalf("dry-run output = %s, want ordered steps", stdout.String())
+	}
+}
+
+func TestWorkflowRunMaterializesOnlyItsSteps(t *testing.T) {
+	project, _ := setUpEnabledWorkflowProject(t)
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"workflow", "run", "review-flow", "claude", "--yes"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("workflow run error = %v stderr=%s", err, stderr.String())
+	}
+	for _, skill := range []string{"gather", "review"} {
+		if _, err := os.Stat(filepath.Join(project, ".claude", "skills", "wf-pack-"+skill)); err != nil {
+			t.Fatalf("expected %s staged: %v", skill, err)
+		}
+	}
+
+	content, err := os.ReadFile(filepath.Join(project, "CLAUDE.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), "Active workflow: review-flow") {
+		t.Fatalf("CLAUDE.md = %s, want the active workflow sequence", content)
+	}
+}
+
+func TestWorkflowRunUnknownWorkflowFails(t *testing.T) {
+	setUpEnabledWorkflowProject(t)
+
+	var stdout, stderr bytes.Buffer
+	err := Execute(nil, []string{"workflow", "run", "does-not-exist", "claude", "--dry-run"}, nil, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("workflow run error = nil, want error for an unknown workflow")
+	}
+}

--- a/internal/materialize/materialize.go
+++ b/internal/materialize/materialize.go
@@ -47,6 +47,31 @@ func statePath(projectRoot, providerName string) string {
 // contents, so cleanup is exact even if the package set shrinks between
 // runs.
 func Apply(projectRoot string, adapter provider.Provider, pkgs []packages.Package) error {
+	return apply(projectRoot, adapter, pkgs, nil)
+}
+
+// WorkflowSequence describes an active workflow's ordered steps, so the
+// generated context file can say "follow these skills in this order"
+// instead of just listing an unordered package/skill set.
+type WorkflowSequence struct {
+	Name  string
+	Steps []string
+}
+
+// ApplyWorkflow stages only pkg's workflow steps (not its full skill set)
+// into adapter.SkillsDir, in the same idempotent/reversible way Apply does,
+// and writes the generated context file with the workflow's ordered
+// sequence made explicit. Scoping to just the workflow's steps is what
+// makes `lineage workflow run` meaningfully different from enabling the
+// whole package and running normally: only the skills the workflow
+// actually references get materialized.
+func ApplyWorkflow(projectRoot string, adapter provider.Provider, pkg packages.Package, wf packages.Workflow) error {
+	scoped := pkg
+	scoped.Skills = append([]string(nil), wf.Steps...)
+	return apply(projectRoot, adapter, []packages.Package{scoped}, &WorkflowSequence{Name: wf.Name, Steps: wf.Steps})
+}
+
+func apply(projectRoot string, adapter provider.Provider, pkgs []packages.Package, wf *WorkflowSequence) error {
 	prev, err := loadState(projectRoot, adapter.Name)
 	if err != nil {
 		return err
@@ -76,7 +101,7 @@ func Apply(projectRoot string, adapter provider.Provider, pkgs []packages.Packag
 	}
 	sort.Strings(written)
 
-	if err := writeSummary(filepath.Join(projectRoot, adapter.ContextFile), pkgs); err != nil {
+	if err := writeSummary(filepath.Join(projectRoot, adapter.ContextFile), pkgs, wf); err != nil {
 		return fmt.Errorf("update %s: %w", adapter.ContextFile, err)
 	}
 
@@ -106,6 +131,14 @@ func NeedsApproval(projectRoot string, adapter provider.Provider, pkgs []package
 	sort.Strings(prevDirs)
 
 	return !equalStrings(desiredDirs, prevDirs), nil
+}
+
+// NeedsApprovalForWorkflow is NeedsApproval scoped to a single workflow's
+// steps, matching what ApplyWorkflow would actually stage.
+func NeedsApprovalForWorkflow(projectRoot string, adapter provider.Provider, pkg packages.Package, wf packages.Workflow) (bool, error) {
+	scoped := pkg
+	scoped.Skills = append([]string(nil), wf.Steps...)
+	return NeedsApproval(projectRoot, adapter, []packages.Package{scoped})
 }
 
 func desiredSkillDirs(adapter provider.Provider, pkgs []packages.Package) map[string]string {
@@ -158,8 +191,8 @@ func saveState(projectRoot, providerName string, s state) error {
 	return os.WriteFile(path, data, 0o644)
 }
 
-func writeSummary(path string, pkgs []packages.Package) error {
-	block := renderSummaryBlock(pkgs)
+func writeSummary(path string, pkgs []packages.Package, wf *WorkflowSequence) error {
+	block := renderSummaryBlock(pkgs, wf)
 
 	existing, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
@@ -177,10 +210,20 @@ func writeSummary(path string, pkgs []packages.Package) error {
 	return os.WriteFile(path, []byte(next), 0o644)
 }
 
-func renderSummaryBlock(pkgs []packages.Package) string {
+func renderSummaryBlock(pkgs []packages.Package, wf *WorkflowSequence) string {
 	var b strings.Builder
 	b.WriteString(beginMarker + "\n")
 	b.WriteString("Lineage-managed section. Do not edit by hand; it is regenerated on every `lineage run`.\n\n")
+
+	if wf != nil {
+		fmt.Fprintf(&b, "Active workflow: %s\n", wf.Name)
+		b.WriteString("Follow these skills in order:\n\n")
+		for i, step := range wf.Steps {
+			fmt.Fprintf(&b, "  %d. %s\n", i+1, step)
+		}
+		b.WriteString("\n")
+	}
+
 	b.WriteString("Active Lineage packages:\n\n")
 	if len(pkgs) == 0 {
 		b.WriteString("none\n")

--- a/internal/materialize/workflow_test.go
+++ b/internal/materialize/workflow_test.go
@@ -1,0 +1,129 @@
+package materialize
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lineage-dev/lineage/internal/packages"
+	"github.com/lineage-dev/lineage/internal/provider"
+)
+
+func buildWorkflowPackage(t *testing.T, name string, skills ...string) packages.Package {
+	t.Helper()
+	pkgDir := filepath.Join(t.TempDir(), name)
+	if err := packages.InitPackage(pkgDir, name); err != nil {
+		t.Fatal(err)
+	}
+	for _, skill := range skills {
+		mustWriteMaterialize(t, filepath.Join(pkgDir, "skills", skill, "SKILL.md"), "# "+skill)
+	}
+
+	pkg, err := packages.Discover(pkgDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pkg
+}
+
+func TestApplyWorkflowStagesOnlyItsSteps(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildWorkflowPackage(t, "multi-pack", "gather", "review", "unused-skill")
+	wf := packages.Workflow{Name: "review-flow", Steps: []string{"gather", "review"}}
+	claude, err := provider.Get("claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ApplyWorkflow(root, claude, pkg, wf); err != nil {
+		t.Fatalf("ApplyWorkflow() error = %v", err)
+	}
+
+	for _, skill := range []string{"gather", "review"} {
+		if _, err := os.Stat(filepath.Join(root, ".claude", "skills", "multi-pack-"+skill)); err != nil {
+			t.Fatalf("expected %s staged: %v", skill, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(root, ".claude", "skills", "multi-pack-unused-skill")); !os.IsNotExist(err) {
+		t.Fatalf("unused-skill should not be staged, stat err = %v", err)
+	}
+}
+
+func TestApplyWorkflowWritesOrderedSequence(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildWorkflowPackage(t, "seq-pack", "gather", "review", "summarize")
+	wf := packages.Workflow{Name: "review-flow", Steps: []string{"gather", "review", "summarize"}}
+	claude, err := provider.Get("claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ApplyWorkflow(root, claude, pkg, wf); err != nil {
+		t.Fatalf("ApplyWorkflow() error = %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	if !containsAll(string(content), "Active workflow: review-flow", "1. gather", "2. review", "3. summarize") {
+		t.Fatalf("CLAUDE.md missing expected ordered sequence:\n%s", content)
+	}
+}
+
+func TestNeedsApprovalForWorkflowScopedToSteps(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildWorkflowPackage(t, "scoped-pack", "gather", "review")
+	wf := packages.Workflow{Name: "review-flow", Steps: []string{"gather"}}
+	claude, err := provider.Get("claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	needs, err := NeedsApprovalForWorkflow(root, claude, pkg, wf)
+	if err != nil {
+		t.Fatalf("NeedsApprovalForWorkflow() error = %v", err)
+	}
+	if !needs {
+		t.Fatal("NeedsApprovalForWorkflow() = false on first run, want true")
+	}
+
+	if err := ApplyWorkflow(root, claude, pkg, wf); err != nil {
+		t.Fatal(err)
+	}
+
+	needs, err = NeedsApprovalForWorkflow(root, claude, pkg, wf)
+	if err != nil {
+		t.Fatalf("NeedsApprovalForWorkflow() error = %v", err)
+	}
+	if needs {
+		t.Fatal("NeedsApprovalForWorkflow() = true after matching Apply, want false")
+	}
+}
+
+func TestApplyWorkflowThenFullApplyRestoresWholePackage(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildWorkflowPackage(t, "restore-pack", "gather", "review")
+	wf := packages.Workflow{Name: "review-flow", Steps: []string{"gather"}}
+	claude, err := provider.Get("claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ApplyWorkflow(root, claude, pkg, wf); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".claude", "skills", "restore-pack-review")); !os.IsNotExist(err) {
+		t.Fatalf("review should not be staged by the workflow-scoped Apply, stat err = %v", err)
+	}
+
+	// A normal, full Apply for the same provider afterward should restore
+	// the whole package's skill set, since both share the same state file
+	// and Apply always reconciles to exactly the set it's given.
+	if err := Apply(root, claude, []packages.Package{pkg}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".claude", "skills", "restore-pack-review")); err != nil {
+		t.Fatalf("expected review restored by full Apply: %v", err)
+	}
+}

--- a/internal/packages/discovery.go
+++ b/internal/packages/discovery.go
@@ -42,7 +42,7 @@ func Discover(dir string) (Package, error) {
 		return Package{}, fmt.Errorf("%s: %w", dir, err)
 	}
 
-	workflows, err := applyExportAuthority("workflow", manifest.Exports.Workflows, discoverNamesWithFile(filepath.Join(dir, "workflows"), "WORKFLOW.md"))
+	workflows, err := applyExportAuthority("workflow", manifest.Exports.Workflows, discoverNamesWithFile(filepath.Join(dir, "workflows"), WorkflowFileName))
 	if err != nil {
 		return Package{}, fmt.Errorf("%s: %w", dir, err)
 	}

--- a/internal/packages/validate.go
+++ b/internal/packages/validate.go
@@ -44,7 +44,7 @@ func Validate(dir string) (ValidateReport, error) {
 	for _, missing := range missingDeclared(manifest.Exports.Agents, discoverEntryNames(filepath.Join(dir, "agents"))) {
 		report.Errors = append(report.Errors, fmt.Sprintf("manifest declares agent %q but it was not found", missing))
 	}
-	for _, missing := range missingDeclared(manifest.Exports.Workflows, discoverNamesWithFile(filepath.Join(dir, "workflows"), "WORKFLOW.md")) {
+	for _, missing := range missingDeclared(manifest.Exports.Workflows, discoverNamesWithFile(filepath.Join(dir, "workflows"), WorkflowFileName)) {
 		report.Errors = append(report.Errors, fmt.Sprintf("manifest declares workflow %q but it was not found", missing))
 	}
 
@@ -63,6 +63,17 @@ func Validate(dir string) (ValidateReport, error) {
 	for _, required := range manifest.Requires.Skills {
 		if !skillSet[required] {
 			report.Notes = append(report.Notes, fmt.Sprintf("requires skill %q, not provided by this package alone — must come from another enabled package", required))
+		}
+	}
+
+	for _, wfName := range discoverNamesWithFile(filepath.Join(dir, "workflows"), WorkflowFileName) {
+		wf, err := LoadWorkflow(dir, wfName)
+		if err != nil {
+			report.Errors = append(report.Errors, fmt.Sprintf("workflow %q: %v", wfName, err))
+			continue
+		}
+		for _, missing := range missingDeclared(wf.Steps, discoveredSkills) {
+			report.Errors = append(report.Errors, fmt.Sprintf("workflow %q references skill %q, which was not found in this package", wfName, missing))
 		}
 	}
 

--- a/internal/packages/validate_test.go
+++ b/internal/packages/validate_test.go
@@ -109,3 +109,36 @@ func TestValidateFailsForUnloadableManifest(t *testing.T) {
 		t.Fatal("Validate() error = nil, want error for an unsupported schema")
 	}
 }
+
+func TestValidateRejectsWorkflowWithBrokenStep(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "broken-workflow-pack")
+	if err := InitPackage(root, "broken-workflow-pack"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, "workflows", "review", WorkflowFileName), "---\nsteps:\n  - does-not-exist\n---\n")
+
+	report, err := Validate(root)
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if report.Passed() {
+		t.Fatal("report.Passed() = true, want false for a workflow step referencing a nonexistent skill")
+	}
+}
+
+func TestValidatePassesWorkflowWithResolvedSteps(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "good-workflow-pack")
+	if err := InitPackage(root, "good-workflow-pack"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, "skills", "gather", "SKILL.md"), "# Gather")
+	mustWrite(t, filepath.Join(root, "workflows", "review", WorkflowFileName), "---\nsteps:\n  - gather\n---\n")
+
+	report, err := Validate(root)
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if !report.Passed() {
+		t.Fatalf("report.Passed() = false, errors = %#v", report.Errors)
+	}
+}

--- a/internal/packages/workflow.go
+++ b/internal/packages/workflow.go
@@ -1,0 +1,110 @@
+package packages
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const WorkflowFileName = "WORKFLOW.md"
+
+// Workflow is an ordered sequence of skill names, declared in a
+// WORKFLOW.md's YAML frontmatter (the same `---`-delimited convention
+// SKILL.md already uses). A workflow with no frontmatter, or frontmatter
+// with no `steps`, has an empty Steps list — WORKFLOW.md remains valid
+// plain documentation on its own, same as before this existed.
+type Workflow struct {
+	Name  string
+	Steps []string
+}
+
+// LoadWorkflow reads and parses the WORKFLOW.md frontmatter for the named
+// workflow inside pkgDir.
+func LoadWorkflow(pkgDir, name string) (Workflow, error) {
+	path := filepath.Join(pkgDir, "workflows", name, WorkflowFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Workflow{}, err
+	}
+
+	front, err := workflowFrontmatter(data)
+	if err != nil {
+		return Workflow{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	var parsed struct {
+		Steps []string `yaml:"steps"`
+	}
+	if len(front) > 0 {
+		if err := yaml.Unmarshal(front, &parsed); err != nil {
+			return Workflow{}, fmt.Errorf("parse %s frontmatter: %w", path, err)
+		}
+	}
+	return Workflow{Name: name, Steps: parsed.Steps}, nil
+}
+
+// workflowFrontmatter extracts the YAML block between a leading "---" line
+// and the next "---" line. Content with no frontmatter (no leading "---")
+// returns nil, nil rather than an error, since a plain-prose WORKFLOW.md is
+// valid and simply declares no steps.
+func workflowFrontmatter(data []byte) ([]byte, error) {
+	const delim = "---"
+	text := string(data)
+	if !strings.HasPrefix(text, delim+"\n") {
+		return nil, nil
+	}
+	rest := text[len(delim)+1:]
+	end := strings.Index(rest, "\n"+delim)
+	if end == -1 {
+		return nil, fmt.Errorf("unterminated frontmatter (missing closing %q)", delim)
+	}
+	return []byte(rest[:end]), nil
+}
+
+// ValidateWorkflowSteps checks that every step in wf references a skill
+// pkg actually has. Returns an error naming the first missing step.
+func ValidateWorkflowSteps(pkg Package, wf Workflow) error {
+	if missing := missingDeclared(wf.Steps, pkg.Skills); len(missing) > 0 {
+		return fmt.Errorf("workflow %q references skill %q, which package %q does not have", wf.Name, missing[0], pkg.Manifest.Name)
+	}
+	return nil
+}
+
+// FindWorkflow looks for a workflow named name across pkgs (typically the
+// set of currently-enabled packages) and returns the package that declares
+// it along with the parsed workflow. It's an error if no enabled package
+// declares the workflow, or if more than one does — workflow names aren't
+// namespaced across packages, so an ambiguous match needs a human decision
+// rather than a silent pick.
+func FindWorkflow(pkgs []Package, name string) (Package, Workflow, error) {
+	var ownerPkg Package
+	var found bool
+
+	for _, pkg := range pkgs {
+		for _, wfName := range pkg.Workflows {
+			if wfName != name {
+				continue
+			}
+			if found {
+				return Package{}, Workflow{}, fmt.Errorf("workflow %q is declared by more than one enabled package (%q and %q); this isn't supported yet", name, ownerPkg.Manifest.Name, pkg.Manifest.Name)
+			}
+			ownerPkg = pkg
+			found = true
+		}
+	}
+	if !found {
+		return Package{}, Workflow{}, fmt.Errorf("workflow %q not found in any enabled package", name)
+	}
+
+	wf, err := LoadWorkflow(ownerPkg.Path, name)
+	if err != nil {
+		return Package{}, Workflow{}, fmt.Errorf("load workflow %q: %w", name, err)
+	}
+	if err := ValidateWorkflowSteps(ownerPkg, wf); err != nil {
+		return Package{}, Workflow{}, err
+	}
+	return ownerPkg, wf, nil
+}

--- a/internal/packages/workflow_test.go
+++ b/internal/packages/workflow_test.go
@@ -1,0 +1,150 @@
+package packages
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadWorkflowParsesFrontmatterSteps(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "wf-pack")
+	if err := InitPackage(root, "wf-pack"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, "workflows", "review", WorkflowFileName), "---\nsteps:\n  - gather\n  - review\n  - summarize\n---\n\n# Review Workflow\n")
+
+	wf, err := LoadWorkflow(root, "review")
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+	assertEqualSlices(t, wf.Steps, []string{"gather", "review", "summarize"})
+	if wf.Name != "review" {
+		t.Fatalf("wf.Name = %q, want %q", wf.Name, "review")
+	}
+}
+
+func TestLoadWorkflowWithoutFrontmatterHasNoSteps(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "plain-pack")
+	if err := InitPackage(root, "plain-pack"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, "workflows", "review", WorkflowFileName), "# Review Workflow\n\n1. Do the thing.\n")
+
+	wf, err := LoadWorkflow(root, "review")
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+	if len(wf.Steps) != 0 {
+		t.Fatalf("wf.Steps = %#v, want none for plain-prose WORKFLOW.md", wf.Steps)
+	}
+}
+
+func TestLoadWorkflowRejectsUnterminatedFrontmatter(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "broken-fm-pack")
+	if err := InitPackage(root, "broken-fm-pack"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, "workflows", "review", WorkflowFileName), "---\nsteps:\n  - gather\n\n# No closing delimiter\n")
+
+	if _, err := LoadWorkflow(root, "review"); err == nil {
+		t.Fatal("LoadWorkflow() error = nil, want error for unterminated frontmatter")
+	}
+}
+
+func TestValidateWorkflowStepsRejectsMissingSkill(t *testing.T) {
+	pkg := Package{
+		Manifest: Manifest{Name: "wf-pack"},
+		Skills:   []string{"gather"},
+	}
+	wf := Workflow{Name: "review", Steps: []string{"gather", "does-not-exist"}}
+
+	if err := ValidateWorkflowSteps(pkg, wf); err == nil {
+		t.Fatal("ValidateWorkflowSteps() error = nil, want error naming the missing step")
+	}
+}
+
+func TestValidateWorkflowStepsPassesWhenAllStepsResolve(t *testing.T) {
+	pkg := Package{
+		Manifest: Manifest{Name: "wf-pack"},
+		Skills:   []string{"gather", "review", "summarize"},
+	}
+	wf := Workflow{Name: "review", Steps: []string{"gather", "review"}}
+
+	if err := ValidateWorkflowSteps(pkg, wf); err != nil {
+		t.Fatalf("ValidateWorkflowSteps() error = %v, want nil", err)
+	}
+}
+
+func TestFindWorkflowLocatesOwningPackage(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "owner-pack")
+	if err := InitPackage(root, "owner-pack"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, "skills", "gather", "SKILL.md"), "# Gather")
+	mustWrite(t, filepath.Join(root, "workflows", "review", WorkflowFileName), "---\nsteps:\n  - gather\n---\n")
+
+	pkg, err := Discover(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	owner, wf, err := FindWorkflow([]Package{pkg}, "review")
+	if err != nil {
+		t.Fatalf("FindWorkflow() error = %v", err)
+	}
+	if owner.Manifest.Name != "owner-pack" {
+		t.Fatalf("owner.Manifest.Name = %q, want %q", owner.Manifest.Name, "owner-pack")
+	}
+	assertEqualSlices(t, wf.Steps, []string{"gather"})
+}
+
+func TestFindWorkflowNotFound(t *testing.T) {
+	if _, _, err := FindWorkflow(nil, "missing"); err == nil {
+		t.Fatal("FindWorkflow() error = nil, want error for no matching workflow")
+	}
+}
+
+func TestFindWorkflowAmbiguousAcrossPackages(t *testing.T) {
+	rootA := filepath.Join(t.TempDir(), "pack-a")
+	if err := InitPackage(rootA, "pack-a"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(rootA, "skills", "gather", "SKILL.md"), "# Gather")
+	mustWrite(t, filepath.Join(rootA, "workflows", "shared-name", WorkflowFileName), "---\nsteps:\n  - gather\n---\n")
+
+	rootB := filepath.Join(t.TempDir(), "pack-b")
+	if err := InitPackage(rootB, "pack-b"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(rootB, "skills", "gather", "SKILL.md"), "# Gather")
+	mustWrite(t, filepath.Join(rootB, "workflows", "shared-name", WorkflowFileName), "---\nsteps:\n  - gather\n---\n")
+
+	pkgA, err := Discover(rootA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkgB, err := Discover(rootB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := FindWorkflow([]Package{pkgA, pkgB}, "shared-name"); err == nil {
+		t.Fatal("FindWorkflow() error = nil, want error for a workflow name declared by two enabled packages")
+	}
+}
+
+func TestFindWorkflowRejectsBrokenStepReference(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "broken-step-pack")
+	if err := InitPackage(root, "broken-step-pack"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, "workflows", "review", WorkflowFileName), "---\nsteps:\n  - does-not-exist\n---\n")
+
+	pkg, err := Discover(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := FindWorkflow([]Package{pkg}, "review"); err == nil {
+		t.Fatal("FindWorkflow() error = nil, want error for a step referencing a nonexistent skill")
+	}
+}


### PR DESCRIPTION
## Summary

Phase 4 of the v1 distribution plan. A workflow was previously indistinguishable from a skill at runtime — both were just a name discovered by the presence of a marker file (`SKILL.md` vs `WORKFLOW.md`). This makes a workflow actually mean something: an ordered sequence of skills that gets materialized together, scoped to exactly that sequence.

- `WORKFLOW.md` gains optional YAML frontmatter (the same `---`-delimited convention `SKILL.md` already uses) with a `steps` list referencing skill names within the same package. No frontmatter means no steps — a plain-prose `WORKFLOW.md` stays valid and unchanged.
- `packages.FindWorkflow(pkgs, name)` locates which enabled package declares a workflow and validates every step resolves to a skill that package actually has, failing clearly on the first missing one. A workflow name declared by two enabled packages is rejected as ambiguous rather than silently picking one.
- `lineage package validate` now also checks every declared workflow's steps, catching a broken reference before distribution rather than at run time.
- `materialize.ApplyWorkflow` stages *only* a workflow's steps — not the owning package's full skill set — reusing `Apply`'s existing idempotent/reversible state tracking. A plain `lineage run` afterward correctly restores the full enabled package set, since both share the same per-provider state file and `Apply` always reconciles to exactly the set it's given (verified by a dedicated test). The generated context file (`CLAUDE.md`/`AGENTS.md`) explicitly lists the active workflow and its ordered steps.
- `lineage workflow run <workflow-name> <provider> [--dry-run] [--yes] [-- provider args...]`, matching `lineage run`'s existing dry-run/permission-gate behavior exactly.
- `examples/resume-workflow` now has two skills (`gather-notes`, `resume-review`) and declares them as an ordered workflow, so the sample package actually demonstrates the feature instead of a single-step workflow indistinguishable from just enabling one skill.

Also fixes a pre-existing rendering bug where `printUsage`'s raw string had inconsistent tab/space indentation, showing up as literal tab characters in real `lineage help` output — caught while adding the new workflow usage line. Same class of glitch fixed in `CHANGELOG.md`.

## Linked Issue

Closes #49

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`.

## Package Impact

- [x] Package discovery or enablement
- [x] Provider launch/shim behavior
- [x] Package format or manifest behavior
- [ ] Setup or permission flow
- [ ] Documentation only
- [ ] Tests only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- `TestLoadWorkflowParsesFrontmatterSteps`, `TestLoadWorkflowWithoutFrontmatterHasNoSteps`, `TestLoadWorkflowRejectsUnterminatedFrontmatter`, `TestValidateWorkflowStepsRejectsMissingSkill`, `TestValidateWorkflowStepsPassesWhenAllStepsResolve`, `TestFindWorkflowLocatesOwningPackage`, `TestFindWorkflowNotFound`, `TestFindWorkflowAmbiguousAcrossPackages`, `TestFindWorkflowRejectsBrokenStepReference` (new, `internal/packages/workflow_test.go`)
- `TestValidateRejectsWorkflowWithBrokenStep`, `TestValidatePassesWorkflowWithResolvedSteps` (new, `internal/packages/validate_test.go`)
- `TestApplyWorkflowStagesOnlyItsSteps`, `TestApplyWorkflowWritesOrderedSequence`, `TestNeedsApprovalForWorkflowScopedToSteps`, `TestApplyWorkflowThenFullApplyRestoresWholePackage` (new, `internal/materialize/workflow_test.go`)
- `TestWorkflowRunDryRunShowsOrderedSteps`, `TestWorkflowRunMaterializesOnlyItsSteps`, `TestWorkflowRunUnknownWorkflowFails` (new, `internal/cli/cli_test.go`)

```text
go build ./...
go test ./...
```
All pass, including the full pre-existing suite unchanged. Also manually smoke-tested end-to-end against the real, updated `examples/resume-workflow` package and a fake `claude` binary: `--dry-run` shows the two-step plan without writing anything, approving stages exactly `gather-notes` and `resume-review` (nothing else), and `CLAUDE.md` gets the explicit "Active workflow: resume-review, steps 1/2" section.

## Notes For Reviewers

This closes out Phase 4. Remaining phases from the plan doc: Phase 5 (CLI completeness — `list`/`disable`/`inspect`/`doctor`, Windows shims) and Phase 6 (test/CI hardening), both continuous/lower-priority per the plan's own sequencing.