### PR TITLE
Add lineage list, disable, and inspect commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,9 +81,9 @@ All notable changes to Lineage will be documented here.
 - Added `lineage package export <path> [-o file.tgz]`: produces a
   deterministic tar.gz archive (manifest + content directories, sorted
   order, normalized permissions and timestamps) after running the same
-	  checks as `lineage package validate` and refusing to export if any
-	  fail. Two exports of byte-identical package content always produce
-	  byte-identical archive bytes.
+  checks as `lineage package validate` and refusing to export if any
+  fail. Two exports of byte-identical package content always produce
+  byte-identical archive bytes.
 - Added `lineage package import <file.tgz> [--as name]`: extracts an
   exported archive into the user packages directory. The archive is
   treated as untrusted input — every entry path is checked against
@@ -93,3 +93,13 @@ All notable changes to Lineage will be documented here.
   than installed. Never overwrites an existing package; use `--as` to
   import under a different name. Export followed by import reproduces
   the original package exactly, verified by matching content digests.
+- Added `lineage list` (enabled packages in the current project, with
+  digest), `lineage disable <ref>` (removes a package and
+  re-materializes for every provider that has ever run in this
+  project, so disabling actually cleans up staged skills instead of
+  just editing config and leaving stale files behind), and `lineage
+  inspect <ref>` (manifest, discovered contents, digest, and
+  capabilities for any resolvable package — project path, user id, or
+  workspace id — without enabling it).
+- Fixed a pre-existing rendering bug where `lineage help`/usage output
+  contained literal tab characters instead of consistent indentation.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -37,6 +37,12 @@ func Execute(ctx context.Context, args []string, stdin io.Reader, stdout, stderr
 		return runPackage(args[1:], home, stdout, stderr)
 	case "enable":
 		return runEnable(args[1:], home, stdout, stderr)
+	case "list":
+		return runList(home, stdout, stderr)
+	case "disable":
+		return runDisable(args[1:], home, stdout, stderr)
+	case "inspect":
+		return runInspect(args[1:], home, stdout, stderr)
 	case "run":
 		return runProvider(ctx, args[1:], home, stdin, stdout, stderr)
 	case "install-shims":
@@ -363,6 +369,164 @@ func runEnable(args []string, home string, stdout, stderr io.Writer) error {
 	return nil
 }
 
+func runList(home string, stdout, stderr io.Writer) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	found, err := config.FindProjectConfig(cwd)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	if len(found.Config.EnabledPackages) == 0 {
+		fmt.Fprintln(stdout, "no packages enabled")
+		return nil
+	}
+
+	resolved, err := packages.ResolveEnabled(home, found.Config.Workspace, found.Root, found.Config.EnabledPackages)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	for _, pkg := range resolved {
+		fmt.Fprintf(stdout, "%s@%s  %s\n", pkg.Manifest.Name, pkg.Manifest.Version, pkg.Digest)
+	}
+	return nil
+}
+
+func runDisable(args []string, home string, stdout, stderr io.Writer) error {
+	if len(args) != 1 {
+		err := fmt.Errorf("usage: lineage disable <package-path-or-id>")
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	ref := args[0]
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	found, err := config.FindProjectConfig(cwd)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	if !contains(found.Config.EnabledPackages, ref) {
+		err := fmt.Errorf("package %q is not enabled in %s", ref, found.Path)
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	newEnabled := make([]string, 0, len(found.Config.EnabledPackages)-1)
+	for _, r := range found.Config.EnabledPackages {
+		if r != ref {
+			newEnabled = append(newEnabled, r)
+		}
+	}
+
+	resolved, err := packages.ResolveEnabled(home, found.Config.Workspace, found.Root, newEnabled)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	// Re-materialize for every provider that has ever been materialized in
+	// this project, so disabling actually removes what was staged - Apply
+	// already reconciles to exactly the package set it's given, removing
+	// anything no longer desired. A provider that was never materialized
+	// here doesn't get a state file created just because something else
+	// was disabled.
+	for _, p := range provider.Known() {
+		hasState, err := materialize.HasState(found.Root, p.Name)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return err
+		}
+		if !hasState {
+			continue
+		}
+		if err := materialize.Apply(found.Root, p, resolved); err != nil {
+			fmt.Fprintln(stderr, err)
+			return err
+		}
+	}
+
+	found.Config.EnabledPackages = newEnabled
+	if err := config.SaveProjectConfig(found.Path, found.Config); err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	fmt.Fprintf(stdout, "disabled package %s in %s\n", ref, found.Path)
+	return nil
+}
+
+func runInspect(args []string, home string, stdout, stderr io.Writer) error {
+	if len(args) != 1 {
+		err := fmt.Errorf("usage: lineage inspect <package-path-or-id>")
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	ref := args[0]
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	// Same resolution rule as enable: a "."/absolute ref is relative to
+	// where the user typed it, a bare id is looked up against the
+	// project/user/workspace search path anchored at the project root (if
+	// any - inspect works even outside a project, e.g. against a bare
+	// local path).
+	projectRoot := cwd
+	workspace := ""
+	if found, err := config.FindProjectConfig(cwd); err == nil {
+		projectRoot = found.Root
+		workspace = found.Config.Workspace
+	} else if !errors.Is(err, config.ErrProjectConfigNotFound) {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	resolveRoot := projectRoot
+	if filepath.IsAbs(ref) || strings.HasPrefix(ref, ".") {
+		resolveRoot = cwd
+	}
+	path, err := packages.ResolveReference(home, workspace, resolveRoot, ref)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	pkg, err := packages.Discover(path)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	fmt.Fprintf(stdout, "package: %s@%s (schema %d)\n", pkg.Manifest.Name, pkg.Manifest.Version, pkg.Manifest.Schema)
+	fmt.Fprintf(stdout, "path: %s\n", pkg.Path)
+	fmt.Fprintf(stdout, "digest: %s\n", emptyValue(pkg.Digest))
+	if pkg.Manifest.Description != "" {
+		fmt.Fprintf(stdout, "description: %s\n", pkg.Manifest.Description)
+	}
+	fmt.Fprintf(stdout, "skills: %s\n", listValue(pkg.Skills))
+	fmt.Fprintf(stdout, "workflows: %s\n", listValue(pkg.Workflows))
+	fmt.Fprintf(stdout, "agents: %s\n", listValue(pkg.Agents))
+	fmt.Fprintf(stdout, "policies: %s\n", listValue(pkg.Policies))
+	fmt.Fprintf(stdout, "requires.skills: %s\n", listValue(pkg.Manifest.Requires.Skills))
+	fmt.Fprintf(stdout, "capabilities:\n")
+	fmt.Fprintf(stdout, "  filesystem.read: %s\n", listValue(pkg.Manifest.Capabilities.Filesystem.Read))
+	fmt.Fprintf(stdout, "  network: %s\n", listValue(pkg.Manifest.Capabilities.Network))
+	return nil
+}
+
 func runProvider(ctx context.Context, args []string, home string, stdin io.Reader, stdout, stderr io.Writer) error {
 	_ = ctx
 	if len(args) == 0 {
@@ -468,13 +632,16 @@ Lineage shareable agent runtime
 Usage:
   lineage init user
   lineage init workspace <name>
-	  lineage package init <name>
-	  lineage package validate <path>
-	  lineage package export <path> [-o file.tgz]
-	  lineage package import <file.tgz> [--as name]
-	  lineage enable <package-path-or-id>
-	  lineage run <%s> [--dry-run] [--yes] [-- provider args...]
-	  lineage install-shims
+  lineage package init <name>
+  lineage package validate <path>
+  lineage package export <path> [-o file.tgz]
+  lineage package import <file.tgz> [--as name]
+  lineage enable <package-path-or-id>
+  lineage disable <package-path-or-id>
+  lineage list
+  lineage inspect <package-path-or-id>
+  lineage run <%s> [--dry-run] [--yes] [-- provider args...]
+  lineage install-shims
 `, providerNameList())))
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -405,3 +405,116 @@ func TestPackageExportThenImportRoundTrip(t *testing.T) {
 		t.Fatalf("imported digest = %q, want %q", imported.Digest, original.Digest)
 	}
 }
+
+func TestListShowsEnabledPackages(t *testing.T) {
+	setUpEnabledProject(t)
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"list"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("list error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "agent-pack@0.1.0") {
+		t.Fatalf("list output = %q, want it to include the enabled package", stdout.String())
+	}
+}
+
+func TestListWithNoEnabledPackagesSaysSo(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveProjectConfig(config.ProjectConfigPath(project), config.DefaultProjectConfig()); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(config.HomeEnv, home)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"list"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("list error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "no packages enabled") {
+		t.Fatalf("list output = %q, want a clear empty message", stdout.String())
+	}
+}
+
+func TestDisableCleansUpMaterializedContent(t *testing.T) {
+	project, _ := setUpEnabledProject(t)
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"run", "claude", "--yes"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("run error = %v stderr=%s", err, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(project, ".claude", "skills", "agent-pack-hello")); err != nil {
+		t.Fatalf("expected materialized skill before disable: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if err := Execute(nil, []string{"disable", "./agent-pack"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("disable error = %v stderr=%s", err, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(project, ".claude", "skills", "agent-pack-hello")); !os.IsNotExist(err) {
+		t.Fatalf("expected staged skill removed after disable, stat err = %v", err)
+	}
+
+	cfg, err := config.LoadProjectConfig(config.ProjectConfigPath(project))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contains(cfg.EnabledPackages, "./agent-pack") {
+		t.Fatalf("EnabledPackages = %#v, want ./agent-pack removed", cfg.EnabledPackages)
+	}
+}
+
+func TestDisableUnknownRefFails(t *testing.T) {
+	setUpEnabledProject(t)
+
+	var stdout, stderr bytes.Buffer
+	err := Execute(nil, []string{"disable", "./not-enabled"}, nil, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("disable error = nil, want error for a ref that isn't enabled")
+	}
+}
+
+func TestInspectShowsPackageWithoutEnabling(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	pkgDir := filepath.Join(tmp, "standalone-pack")
+	if err := packages.InitPackage(pkgDir, "standalone-pack"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(pkgDir, "skills", "review"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "skills", "review", "SKILL.md"), []byte("# Review"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(config.HomeEnv, home)
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"inspect", pkgDir}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("inspect error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "standalone-pack@0.1.0") {
+		t.Fatalf("inspect output = %q, want package identity", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "skills: review") {
+		t.Fatalf("inspect output = %q, want discovered skills", stdout.String())
+	}
+
+	cfgPath := config.ProjectConfigPath(filepath.Dir(pkgDir))
+	if _, err := os.Stat(cfgPath); !os.IsNotExist(err) {
+		t.Fatal("inspect must not create a project config or enable anything")
+	}
+}

--- a/internal/materialize/materialize.go
+++ b/internal/materialize/materialize.go
@@ -36,6 +36,21 @@ func statePath(projectRoot, providerName string) string {
 	return filepath.Join(projectRoot, stateDirName, "materialized-"+providerName+".json")
 }
 
+// HasState reports whether a provider has ever been materialized for this
+// project — i.e. whether Apply has run for it before. Used to decide which
+// providers need re-materializing after a package is disabled, without
+// creating a state file for a provider that was never used.
+func HasState(projectRoot, providerName string) (bool, error) {
+	_, err := os.Stat(statePath(projectRoot, providerName))
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
 // Apply stages every skill from pkgs into adapter.SkillsDir and refreshes
 // the generated section of adapter.ContextFile describing active packages,
 // agents, policies, and workflows.

--- a/internal/materialize/materialize_test.go
+++ b/internal/materialize/materialize_test.go
@@ -284,3 +284,42 @@ func containsAll(haystack string, needles ...string) bool {
 	}
 	return true
 }
+
+func TestHasStateFalseBeforeApply(t *testing.T) {
+	root := t.TempDir()
+	has, err := HasState(root, "claude")
+	if err != nil {
+		t.Fatalf("HasState() error = %v", err)
+	}
+	if has {
+		t.Fatal("HasState() = true before any Apply call, want false")
+	}
+}
+
+func TestHasStateTrueAfterApply(t *testing.T) {
+	root := t.TempDir()
+	pkg := buildTestPackage(t, "review-pack", "review")
+	claude, err := provider.Get("claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(root, claude, []packages.Package{pkg}); err != nil {
+		t.Fatal(err)
+	}
+
+	has, err := HasState(root, "claude")
+	if err != nil {
+		t.Fatalf("HasState() error = %v", err)
+	}
+	if !has {
+		t.Fatal("HasState() = false after Apply, want true")
+	}
+
+	has, err = HasState(root, "codex")
+	if err != nil {
+		t.Fatalf("HasState() error = %v", err)
+	}
+	if has {
+		t.Fatal("HasState(codex) = true, want false - only claude was ever applied")
+	}
+}


### PR DESCRIPTION
## Summary

Phase 5 of the v1 distribution plan. Rounds out day-to-day package management: before this, the only way to see what's enabled was reading `.lineage/config.yaml` by hand, there was no way to disable a package short of editing that file, and no way to inspect a package's manifest/digest/capabilities without either enabling it or running `package validate` against a raw path (which doesn't resolve project/user/workspace refs the way `enable` does).

- `lineage list`: enabled packages for the current project (name, version, digest), resolved the same way `lineage run` does.
- `lineage disable <ref>`: removes a ref from `enabled_packages` and re-materializes for every provider that has ever run in this project (`materialize.HasState` checks which providers have a state file, so a provider that was never used doesn't get one created just because something else was disabled). `Apply` already reconciles to exactly the package set it's given, so reusing it here means `disable` actually removes staged skills and refreshes the generated context file instead of just editing config and leaving stale files behind.
- `lineage inspect <ref>`: resolves a ref the same way `enable` does (project-relative path, user package id, or workspace package id) and prints manifest, discovered contents, digest, and capabilities — without writing anything, without requiring the package to already be enabled.

Also fixes the same tab-indentation rendering bug in `printUsage`/`CHANGELOG.md` caught on the workflow-execution branch (#50) — this branch was cut before that fix merged, so it needed the same fix independently; it'll be a no-op once both merge.

## Linked Issue

Closes #51

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`.

## Package Impact

- [x] Package discovery or enablement
- [x] Provider launch/shim behavior
- [ ] Package format or manifest behavior
- [ ] Setup or permission flow
- [ ] Documentation only
- [ ] Tests only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- `TestHasStateFalseBeforeApply`, `TestHasStateTrueAfterApply` (new, `internal/materialize/materialize_test.go`)
- `TestListShowsEnabledPackages`, `TestListWithNoEnabledPackagesSaysSo`, `TestDisableCleansUpMaterializedContent`, `TestDisableUnknownRefFails`, `TestInspectShowsPackageWithoutEnabling` (new, `internal/cli/cli_test.go`)

```text
go build ./...
go test ./...
```
All pass. Also manually smoke-tested end-to-end against the real `examples/resume-workflow` package and a fake `claude` binary: `inspect` before enabling (no side effects), `run` to materialize, `list` shows the enabled package with digest, `disable` removes both the staged `.claude/skills/` content and the config entry, and a follow-up `list` correctly reports nothing enabled.

## Notes For Reviewers

Remaining Phase 5 work: `lineage doctor` (#52) and Windows shim generation (#53), both separate PRs to follow.