### PR TITLE
Sync top-level docs with shipped Phase 2/3 work

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,16 @@ These folders are intentionally plain. A receiver should be able to open the pac
 lineage init user
 lineage init workspace <name>
 lineage package init <name>
+lineage package validate <path>
+lineage package export <path> [-o file.tgz]
+lineage package import <file.tgz> [--as name]
 lineage enable <package-path-or-id>
 lineage run claude --dry-run
 lineage run codex --dry-run
 lineage install-shims
 ```
+
+The first time `lineage run` would actually stage files for a provider, it shows what it's about to create or change and asks for confirmation; pass `--yes`/`-y` to skip the prompt in scripts. `--dry-run` never writes anything.
 
 Project configuration lives at `.lineage/config.yaml`.
 
@@ -79,6 +84,20 @@ Install local shims when you want commands such as `claude` or `codex` to enter 
 
 ```bash
 lineage install-shims
+```
+
+Share a package with someone else:
+
+```bash
+lineage package validate ./resume-workflow
+lineage package export ./resume-workflow -o resume-workflow.tgz
+```
+
+On the receiving end:
+
+```bash
+lineage package import resume-workflow.tgz
+lineage enable resume-workflow
 ```
 
 ## Safety Principles

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,19 +2,29 @@
 
 This roadmap is intentionally limited to the public local package runtime.
 
-## Current
+## Done
 
-- Make package creation, enablement, and launch planning reliable.
-- Keep package contents inspectable and secret-safe.
-- Strengthen tests for config, package discovery, and provider boundaries.
+- Package creation, enablement, and launch planning.
+- Manifest schema versioning, export authority, and content digests.
+- Secret scanning and path-traversal protection for package-controlled input.
+- `lineage package validate`, `lineage package export`, `lineage package import`.
+- Permission-gated materialization: enabling a package actually stages skills
+  into a provider's own directory and generates its context file, with an
+  explicit confirmation before anything is written.
 
 ## Next
 
-- Add package export/import archives.
-- Add setup prompts for receiver-side configuration.
-- Add package validation before enablement.
-- Add exact reconstruction tests for included package files.
+- Land workflow execution (`lineage workflow run`), naming an ordered
+  sequence of skills a package declares.
+- Round out day-to-day CLI coverage: `list`, `disable`, `inspect`, `doctor`.
+- Verify the CLI on Windows, including shim generation and binary
+  resolution.
+- Add an end-to-end integration fixture covering the full author-to-receiver
+  flow through the real CLI.
 
 ## Later
 
-- Broaden provider adapter coverage while keeping the core package format provider-neutral.
+- Design the `.lineage` artifact (project- and user-level state) as a
+  deliberate whole, rather than one field at a time.
+- Broaden provider adapter coverage while keeping the core package format
+  provider-neutral.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,8 +4,10 @@ Lineage is a local runtime for distributing agent environment packages.
 
 ## Core Ideas
 
-- A package is a folder with a `lineage.yaml` manifest and optional native assets such as skills, workflows, agents, policies, references, and provider adapters.
+- A package is a folder with a `lineage.yaml` manifest and optional native assets such as skills, workflows, agents, policies, references, and provider adapters. The manifest carries a `schema` version and a content digest, and can declare exports and capabilities explicitly.
 - A project enables packages through `.lineage/config.yaml`.
+- Enabling a package doesn't just plan a launch — running a provider materializes it: skills are staged into that provider's own discovery directory (e.g. `.claude/skills/`), and a generated section is written into its context file (e.g. `CLAUDE.md`), tracked per-provider so re-running stays idempotent. This is gated behind an explicit confirmation the first time it would actually change anything.
+- A package can be exported to a deterministic `.tgz` archive and imported on another machine; import re-validates the extracted content exactly as `lineage package validate` would, rather than trusting the archive because it parsed.
 - The runtime resolves enabled packages, builds a launch plan, and starts the selected provider through an explicit adapter boundary.
 - Provider shims let a normal command such as `claude` or `codex` enter the Lineage runtime first, then hand off to the real provider binary.
 
@@ -29,14 +31,15 @@ The receiver should be able to inspect these contents before enabling a package.
 - `cmd/lineage`: CLI entrypoint.
 - `internal/cli`: command routing and user-facing command behavior.
 - `internal/config`: project and user configuration.
-- `internal/packages`: package manifest, discovery, and reference resolution.
+- `internal/packages`: package manifest, discovery, reference resolution, validation, and export/import.
+- `internal/materialize`: stages an enabled package's skills and generated context into a provider's own directories, and tracks that state per provider so re-running stays idempotent.
 - `internal/runtime`: provider-neutral launch planning.
-- `internal/provider`: provider command resolution and execution.
+- `internal/provider`: the provider registry, command resolution, and execution.
 - `internal/shim`: local command shims.
 
 ## Safety Model
 
-Packages are local files, but they are still untrusted input. Lineage should validate manifests, normalize paths, avoid secret capture, and require explicit permission before any setup flow creates or changes files.
+Packages are local files, but they are still untrusted input. Manifests are validated, package-controlled paths (entrypoints, archive entries) are normalized through a traversal guard, package content is scanned against a documented secret allow/denylist, and materialization requires explicit permission before it creates or changes files. An imported archive gets no special trust for having been exported by Lineage — import re-runs the full validation pass against the extracted content before anything is kept.
 
 ## Decision Records
 

--- a/docs/hypothesis-test-plan.md
+++ b/docs/hypothesis-test-plan.md
@@ -6,21 +6,38 @@
 - A receiver can inspect package contents before enabling them.
 - Package enablement can be idempotent and safe for repeated runs.
 - Provider-specific launch behavior can stay behind explicit adapter boundaries.
+- A package can move to another machine (export, then import) and reconstruct exactly, without the receiver having to trust the archive's origin.
 
 ## Current Tests
 
-- Project config load, save, and discovery.
-- Package initialization, manifest loading, and discovery.
-- Provider launch planning.
-- Runtime plan rendering.
-- Shim creation.
+- Project config load, save, and discovery (`internal/config`).
+- Package initialization, manifest loading, and discovery, including
+  export-authoritative resolution and schema versioning
+  (`internal/packages`).
+- Path traversal rejection for package-controlled input
+  (`internal/packages/safepath_test.go`).
+- Secret-shaped filename and content detection
+  (`internal/packages/secrets_test.go`).
+- `lineage package validate` end to end, including a failing case
+  (`internal/cli/cli_test.go`).
+- Export/import archive round trip and exact content reconstruction,
+  including a byte-identical digest check and rejection of a package that
+  fails validation (`internal/packages/export_test.go`,
+  `internal/packages/import_test.go`).
+- Materialization staging and its idempotent, per-provider state tracking,
+  for both the Claude Code and Codex adapters (`internal/materialize`).
+- The permission-gated confirmation flow before materialization writes
+  anything, and that `--dry-run` never triggers it (`internal/cli`).
+- Provider launch planning and command resolution (`internal/provider`).
+- Runtime plan rendering (`internal/runtime`).
+- Shim creation (`internal/shim`).
 
 ## Needed Tests
 
-- Export/import archive round trip.
-- Exact file reconstruction for package contents.
-- Secret and ignored-file detection.
-- Permission-gated setup flow.
-- Path traversal rejection.
-- Repeated enablement and repeated setup idempotency.
-- Cross-platform path behavior.
+- A single end-to-end integration fixture exercising the full
+  author-to-receiver flow (package, export, import, enable, run,
+  materialize, disable) through the real CLI entrypoint, once workflow
+  execution and the remaining CLI commands land.
+- Real Windows CI verification for shim generation and binary resolution
+  (currently covered by GOOS-parameterized unit tests only, run on
+  non-Windows CI).

--- a/docs/lean-development.md
+++ b/docs/lean-development.md
@@ -15,12 +15,16 @@ Lineage uses a lean, goal-based development process.
 
 Milestones are goals, not dates.
 
-Current milestone style:
+Current milestones (see the GitHub Milestones page for the authoritative, up-to-date list):
 
+- `Goal: Durable runtime foundations`
 - `Goal: Safe package round trip`
 - `Goal: Receiver setup experience`
-- `Goal: Durable runtime foundations`
 - `Goal: Provider and CI confidence`
+- `Goal: Package materialization`
+- `Goal: Add providers`
+- `Goal: Workflow execution`
+- `Goal: CLI completeness`
 
 A milestone is done when its issues prove the goal works well enough to trust, not when a calendar date arrives.
 


### PR DESCRIPTION
## Summary
- README: adds `package validate`/`export`/`import` to Current Commands (already shipped, just never documented) and notes the materialization confirmation gate.
- ROADMAP: moves shipped work (export/import, permission-gated setup, validation) out of "Next" into a new "Done" section; "Next" now names the actually-open work (workflow execution, remaining CLI commands, Windows verification, the integration fixture).
- docs/architecture.md: adds `internal/materialize` to the module boundaries (it does real, central work and was missing entirely), and updates the Safety Model to describe what's actually implemented rather than what "should" happen.
- docs/lean-development.md: lists all 8 current milestones instead of 4, and points at the GitHub Milestones page as the source of truth.
- docs/hypothesis-test-plan.md: moves export/import round trip, secret detection, permission-gated setup, and path traversal rejection from "Needed Tests" to "Current Tests" (all implemented and covered); narrows "Needed Tests" to the two genuinely open items — the end-to-end integration fixture and real Windows CI.

Closes #62

## Test plan
- [x] Documentation only, no code changes.
- [x] `go build ./...` and `go test ./...` unaffected (verified before starting).