### PR TITLE
Keep the internal v2 plan doc out of the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage.out
 .env.*
 !.env.example
 docs/v1-distribution-plan.md
+docs/v2-plan.md


### PR DESCRIPTION
## Summary
- Adds `docs/v2-plan.md` to `.gitignore`, same as `docs/v1-distribution-plan.md`. The v2 phase plan is an internal session-scoping doc, not project documentation, so it stays local.

Refs #65

## Test plan
- [x] `git check-ignore -v docs/v2-plan.md` confirms it's ignored.
- [x] No code changes.