### PR TITLE
Add lineage package publish/pull against the Lineage registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,3 +140,33 @@ All notable changes to Lineage will be documented here.
 - Fixed a rendering bug where `lineage help`/usage output for several
   commands contained literal tab characters instead of consistent
   indentation.
+- Added `lineage package publish <path>` and `lineage package pull
+  <package-ref> [--as name]` against the Lineage registry (the
+  `landing/` website's `api/`, backed by a private GitHub repo used
+  purely as artifact storage — see `docs/decisions/
+  0012-v1-distribution-contract-and-receiver-activation.md`). Publish
+  reuses the same Validate-then-Export path as `package export` and
+  refuses to publish anything that fails validation; publishing the
+  same `name@version` twice with identical content is a no-op,
+  publishing it with different content is rejected — published
+  versions are immutable. Pull resolves a ref (`name` for latest, or
+  an exact `name@version`), imports it exactly like `package import`,
+  and then independently recomputes the content digest from what was
+  actually imported, failing closed and discarding the import if it
+  doesn't match what the registry reported. Registry location and the
+  publish token are read from `LINEAGE_REGISTRY_URL`/
+  `LINEAGE_PUBLISH_TOKEN`, not `.lineage/config.yaml` — a publish
+  credential is a per-invocation secret, not committed project state.
+- The registry now records who published each package (a publish token
+  maps to a publisher id) and enforces that only the same publisher can
+  push a new version of a name they already own — publishing an update
+  is a normal `lineage package publish` with a bumped `version` and the
+  same token; a different publisher's token is rejected.
+- Publish is now safe to interrupt and retry: since publish is commonly
+  run by an agent on someone's behalf and that agent's own session can
+  end mid-command, the registry creates the GitHub Release as a draft,
+  uploads the archive, and only then finalizes it — a publish cut off
+  in between is invisible to receivers and resumed, not duplicated or
+  errored on, by simply retrying the same publish call. CLI-side error
+  messages from a failed publish/pull now surface the registry's own
+  error text instead of a raw JSON body.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ lineage package init <name>
 lineage package validate <path>
 lineage package export <path> [-o file.tgz]
 lineage package import <file.tgz> [--as name]
+lineage package publish <path>
+lineage package pull <package-ref> [--as name]
 lineage enable <package-path-or-id>
 lineage run claude --dry-run
 lineage run codex --dry-run
@@ -86,7 +88,7 @@ Install local shims when you want commands such as `claude` or `codex` to enter 
 lineage install-shims
 ```
 
-Share a package with someone else:
+Share a package as a file:
 
 ```bash
 lineage package validate ./resume-workflow
@@ -99,6 +101,24 @@ On the receiving end:
 lineage package import resume-workflow.tgz
 lineage enable resume-workflow
 ```
+
+Or publish it to the Lineage registry instead of passing a file around:
+
+```bash
+export LINEAGE_PUBLISH_TOKEN=...  # ask a maintainer for one, tied to your publisher id
+lineage package publish ./resume-workflow
+```
+
+On the receiving end, pull it straight from the registry:
+
+```bash
+lineage package pull resume-workflow
+lineage enable resume-workflow
+```
+
+`lineage package pull` fetches `resume-workflow` (or `resume-workflow@0.2.0` for an exact version), verifies its content digest, and imports it exactly like `package import` would - see [docs/decisions/0012-v1-distribution-contract-and-receiver-activation.md](docs/decisions/0012-v1-distribution-contract-and-receiver-activation.md) for how the registry is structured.
+
+The first publish of a package name claims it for your publisher id. To ship an update, bump `version` in `lineage.yaml` and run `lineage package publish` again with the same token - the registry accepts it because you're still the recorded owner of that name; a different publisher's token would be rejected.
 
 ## Safety Principles
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ lineage package export <path> [-o file.tgz]
 lineage package import <file.tgz> [--as name]
 lineage package publish <path>
 lineage package pull <package-ref> [--as name]
+lineage login
+lineage logout
+lineage whoami
 lineage enable <package-path-or-id>
 lineage run claude --dry-run
 lineage run codex --dry-run
@@ -102,14 +105,14 @@ lineage package import resume-workflow.tgz
 lineage enable resume-workflow
 ```
 
-Or publish it to the Lineage registry instead of passing a file around:
+Or publish it to the Lineage registry instead of passing a file around. No token to request first - `lineage login` authenticates you with your own GitHub account (the same device-flow approval `gh auth login` uses):
 
 ```bash
-export LINEAGE_PUBLISH_TOKEN=...  # ask a maintainer for one, tied to your publisher id
+lineage login   # opens a code + a github.com link to approve once
 lineage package publish ./resume-workflow
 ```
 
-On the receiving end, pull it straight from the registry:
+On the receiving end, pull it straight from the registry (no login needed - pulling is an open read):
 
 ```bash
 lineage package pull resume-workflow
@@ -118,7 +121,7 @@ lineage enable resume-workflow
 
 `lineage package pull` fetches `resume-workflow` (or `resume-workflow@0.2.0` for an exact version), verifies its content digest, and imports it exactly like `package import` would - see [docs/decisions/0012-v1-distribution-contract-and-receiver-activation.md](docs/decisions/0012-v1-distribution-contract-and-receiver-activation.md) for how the registry is structured.
 
-The first publish of a package name claims it for your publisher id. To ship an update, bump `version` in `lineage.yaml` and run `lineage package publish` again with the same token - the registry accepts it because you're still the recorded owner of that name; a different publisher's token would be rejected.
+The first publish of a package name claims it for your verified GitHub login. To ship an update, bump `version` in `lineage.yaml` and run `lineage package publish` again - the registry accepts it because you're still the recorded owner of that name; a different GitHub account would be rejected. Run `lineage whoami` any time to check which identity is currently active, or `lineage logout` to clear it. For non-interactive use (CI), set `LINEAGE_PUBLISH_TOKEN` to any GitHub-issued token with `read:user` access instead of running `lineage login`.
 
 ## Safety Principles
 

--- a/internal/auth/device.go
+++ b/internal/auth/device.go
@@ -1,0 +1,167 @@
+// Package auth implements Lineage's publisher identity: GitHub's OAuth
+// Device Flow, the same mechanism `gh auth login` uses. Publisher identity
+// is a GitHub-verified login rather than a token the site operator has to
+// mint and distribute by hand - see docs/decisions/
+// 0012-v1-distribution-contract-and-receiver-activation.md, decision 6b.
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// ClientID is Lineage's public GitHub OAuth App client id. It is not a
+// secret: GitHub's device flow for a public/native client never requires a
+// client secret to exchange a device code for an access token.
+const ClientID = "REPLACE_WITH_LINEAGE_OAUTH_CLIENT_ID"
+
+// scope requests just enough to identify who's publishing. Lineage never
+// needs write access to a publisher's own account or repos - the registry
+// repo is written to by the website's own token, not the publisher's.
+const scope = "read:user"
+
+// Overridable for tests; point at github.com in production.
+var (
+	DeviceCodeURL  = "https://github.com/login/device/code"
+	AccessTokenURL = "https://github.com/login/oauth/access_token"
+)
+
+// DeviceCode is what a receiver sees and approves in a browser.
+type DeviceCode struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURI string `json:"verification_uri"`
+	ExpiresIn       int    `json:"expires_in"`
+	Interval        int    `json:"interval"`
+}
+
+// RequestDeviceCode starts GitHub's device flow.
+func RequestDeviceCode() (DeviceCode, error) {
+	body, err := postForm(DeviceCodeURL, url.Values{"client_id": {ClientID}, "scope": {scope}})
+	if err != nil {
+		return DeviceCode{}, fmt.Errorf("request device code: %w", err)
+	}
+	var dc DeviceCode
+	if err := json.Unmarshal(body, &dc); err != nil {
+		return DeviceCode{}, fmt.Errorf("parse device code response: %w", err)
+	}
+	if dc.DeviceCode == "" || dc.UserCode == "" {
+		return DeviceCode{}, fmt.Errorf("device code response missing device_code/user_code: %s", string(body))
+	}
+	return dc, nil
+}
+
+var (
+	errAuthorizationPending = errors.New("authorization pending")
+	errSlowDown             = errors.New("slow down")
+	// ErrExpired is returned by PollForToken when the device code expires
+	// before the user approves it - the caller should start over with a
+	// fresh RequestDeviceCode.
+	ErrExpired = errors.New("device code expired before it was approved; run `lineage login` again")
+	// ErrDenied is returned by PollForToken when the user explicitly
+	// declines the authorization request.
+	ErrDenied = errors.New("authorization was denied")
+)
+
+// PollForToken polls GitHub's token endpoint, following dc's own interval
+// (backing off further whenever GitHub asks to slow_down), until the user
+// approves, the device code expires, or ctx is cancelled.
+func PollForToken(ctx context.Context, dc DeviceCode) (string, error) {
+	interval := time.Duration(dc.Interval) * time.Second
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	deadline := time.Now().Add(time.Duration(dc.ExpiresIn) * time.Second)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(interval):
+		}
+		if time.Now().After(deadline) {
+			return "", ErrExpired
+		}
+
+		token, err := pollOnce(dc.DeviceCode)
+		switch {
+		case err == nil:
+			return token, nil
+		case errors.Is(err, errAuthorizationPending):
+			continue
+		case errors.Is(err, errSlowDown):
+			interval += 5 * time.Second
+			continue
+		default:
+			return "", err
+		}
+	}
+}
+
+func pollOnce(deviceCode string) (string, error) {
+	body, err := postForm(AccessTokenURL, url.Values{
+		"client_id":   {ClientID},
+		"device_code": {deviceCode},
+		"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
+	})
+	if err != nil {
+		return "", fmt.Errorf("poll for token: %w", err)
+	}
+
+	var parsed struct {
+		AccessToken string `json:"access_token"`
+		Error       string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", fmt.Errorf("parse token response: %w", err)
+	}
+
+	switch parsed.Error {
+	case "":
+		if parsed.AccessToken == "" {
+			return "", fmt.Errorf("token response had neither an access token nor an error: %s", string(body))
+		}
+		return parsed.AccessToken, nil
+	case "authorization_pending":
+		return "", errAuthorizationPending
+	case "slow_down":
+		return "", errSlowDown
+	case "expired_token":
+		return "", ErrExpired
+	case "access_denied":
+		return "", ErrDenied
+	default:
+		return "", fmt.Errorf("device flow error: %s", parsed.Error)
+	}
+}
+
+func postForm(rawURL string, form url.Values) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodPost, rawURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}

--- a/internal/auth/device.go
+++ b/internal/auth/device.go
@@ -17,10 +17,11 @@ import (
 	"time"
 )
 
-// ClientID is Lineage's public GitHub OAuth App client id. It is not a
-// secret: GitHub's device flow for a public/native client never requires a
-// client secret to exchange a device code for an access token.
-const ClientID = "REPLACE_WITH_LINEAGE_OAUTH_CLIENT_ID"
+// ClientID is Lineage's public GitHub OAuth App client id (org:
+// agentic-lineage, Device Flow enabled). It is not a secret: GitHub's
+// device flow for a public/native client never requires a client secret to
+// exchange a device code for an access token.
+const ClientID = "Ov23liHPdq5xNJy2DU8W"
 
 // scope requests just enough to identify who's publishing. Lineage never
 // needs write access to a publisher's own account or repos - the registry

--- a/internal/auth/device_test.go
+++ b/internal/auth/device_test.go
@@ -1,0 +1,127 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func withDeviceCodeServer(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	oldDC, oldAT := DeviceCodeURL, AccessTokenURL
+	DeviceCodeURL = srv.URL + "/device/code"
+	AccessTokenURL = srv.URL + "/oauth/access_token"
+	t.Cleanup(func() { DeviceCodeURL, AccessTokenURL = oldDC, oldAT })
+}
+
+func TestRequestDeviceCode(t *testing.T) {
+	withDeviceCodeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/device/code" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		if r.Form.Get("scope") != "read:user" {
+			t.Fatalf("scope = %q, want read:user", r.Form.Get("scope"))
+		}
+		_ = json.NewEncoder(w).Encode(DeviceCode{
+			DeviceCode: "dc-1", UserCode: "ABCD-1234",
+			VerificationURI: "https://github.com/login/device", ExpiresIn: 900, Interval: 1,
+		})
+	})
+
+	dc, err := RequestDeviceCode()
+	if err != nil {
+		t.Fatalf("RequestDeviceCode() error = %v", err)
+	}
+	if dc.UserCode != "ABCD-1234" || dc.DeviceCode != "dc-1" {
+		t.Errorf("RequestDeviceCode() = %+v, want user_code=ABCD-1234 device_code=dc-1", dc)
+	}
+}
+
+func TestPollForTokenSucceedsAfterPending(t *testing.T) {
+	var calls int32
+	withDeviceCodeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "authorization_pending"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"access_token": "gho_test123"})
+	})
+
+	// Interval is in whole seconds (matches GitHub's real response shape),
+	// so this test takes a few real seconds rather than mocking time.
+	dc := DeviceCode{DeviceCode: "dc-1", ExpiresIn: 30, Interval: 1}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	token, err := PollForToken(ctx, dc)
+	if err != nil {
+		t.Fatalf("PollForToken() error = %v", err)
+	}
+	if token != "gho_test123" {
+		t.Errorf("PollForToken() = %q, want gho_test123", token)
+	}
+	if calls < 3 {
+		t.Errorf("expected at least 3 poll calls, got %d", calls)
+	}
+}
+
+func TestPollForTokenReturnsErrDenied(t *testing.T) {
+	withDeviceCodeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "access_denied"})
+	})
+
+	dc := DeviceCode{DeviceCode: "dc-1", ExpiresIn: 30, Interval: 1}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := PollForToken(ctx, dc)
+	if err != ErrDenied {
+		t.Fatalf("PollForToken() error = %v, want ErrDenied", err)
+	}
+}
+
+func TestPollForTokenExpiresWithoutApproval(t *testing.T) {
+	withDeviceCodeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "authorization_pending"})
+	})
+
+	// ExpiresIn shorter than a single poll interval means the deadline check
+	// after the first wait should already report expired.
+	dc := DeviceCode{DeviceCode: "dc-1", ExpiresIn: 1, Interval: 1}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := PollForToken(ctx, dc)
+	if err != ErrExpired {
+		t.Fatalf("PollForToken() error = %v, want ErrExpired", err)
+	}
+}
+
+func TestPollForTokenRespectsContextCancellation(t *testing.T) {
+	withDeviceCodeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "authorization_pending"})
+	})
+
+	dc := DeviceCode{DeviceCode: "dc-1", ExpiresIn: 30, Interval: 1}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := PollForToken(ctx, dc)
+	if err != context.Canceled {
+		t.Fatalf("PollForToken() error = %v, want context.Canceled", err)
+	}
+}

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -1,0 +1,51 @@
+package auth
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// TokenPath is where `lineage login` stores the GitHub device-flow token.
+func TokenPath(home string) string {
+	return filepath.Join(home, "github_token")
+}
+
+// SaveToken writes token to TokenPath(home), creating home if needed, with
+// permissions that only the owner can read - this is a bearer credential
+// good enough to publish as this person, handled like any other local
+// secret Lineage must never leak.
+func SaveToken(home, token string) error {
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		return fmt.Errorf("create lineage home: %w", err)
+	}
+	if err := os.WriteFile(TokenPath(home), []byte(strings.TrimSpace(token)+"\n"), 0o600); err != nil {
+		return fmt.Errorf("save GitHub token: %w", err)
+	}
+	return nil
+}
+
+// LoadToken reads the token saved by SaveToken, or "" with no error if
+// `lineage login` was never run - callers that also accept
+// LINEAGE_PUBLISH_TOKEN treat a missing stored token as "check the env var
+// instead," not as a failure.
+func LoadToken(home string) (string, error) {
+	data, err := os.ReadFile(TokenPath(home))
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read stored GitHub token: %w", err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// DeleteToken removes the token saved by SaveToken, if any. Removing a
+// token that was never saved is not an error.
+func DeleteToken(home string) error {
+	if err := os.Remove(TokenPath(home)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove stored GitHub token: %w", err)
+	}
+	return nil
+}

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -1,0 +1,65 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestSaveLoadDeleteTokenRoundTrip(t *testing.T) {
+	home := t.TempDir()
+
+	got, err := LoadToken(home)
+	if err != nil {
+		t.Fatalf("LoadToken() before any save: error = %v", err)
+	}
+	if got != "" {
+		t.Fatalf("LoadToken() before any save = %q, want empty", got)
+	}
+
+	if err := SaveToken(home, "gho_abc123"); err != nil {
+		t.Fatalf("SaveToken() error = %v", err)
+	}
+
+	got, err = LoadToken(home)
+	if err != nil {
+		t.Fatalf("LoadToken() error = %v", err)
+	}
+	if got != "gho_abc123" {
+		t.Errorf("LoadToken() = %q, want gho_abc123", got)
+	}
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(TokenPath(home))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if mode := info.Mode().Perm(); mode&0o077 != 0 {
+			t.Errorf("token file mode = %o, want no group/other permission bits", mode)
+		}
+	}
+
+	if err := DeleteToken(home); err != nil {
+		t.Fatalf("DeleteToken() error = %v", err)
+	}
+	got, err = LoadToken(home)
+	if err != nil {
+		t.Fatalf("LoadToken() after delete: error = %v", err)
+	}
+	if got != "" {
+		t.Errorf("LoadToken() after delete = %q, want empty", got)
+	}
+
+	// Deleting an already-absent token is not an error.
+	if err := DeleteToken(home); err != nil {
+		t.Fatalf("DeleteToken() on an already-deleted token: error = %v", err)
+	}
+}
+
+func TestTokenPathIsUnderHome(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "lineage-home")
+	if got, want := TokenPath(home), filepath.Join(home, "github_token"); got != want {
+		t.Errorf("TokenPath(%q) = %q, want %q", home, got, want)
+	}
+}

--- a/internal/auth/whoami.go
+++ b/internal/auth/whoami.go
@@ -1,0 +1,49 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Overridable for tests; points at api.github.com in production.
+var UserURL = "https://api.github.com/user"
+
+// WhoAmI resolves the GitHub login a token identifies, the same way the
+// website verifies a publish request (landing/api/_lib/auth.js) - a token
+// is never trusted to say who it belongs to, only GitHub is.
+func WhoAmI(token string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, UserURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("verify GitHub identity: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("verify GitHub identity failed (%s): %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	var parsed struct {
+		Login string `json:"login"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", fmt.Errorf("parse GitHub identity response: %w", err)
+	}
+	if parsed.Login == "" {
+		return "", fmt.Errorf("GitHub identity response had no login: %s", string(body))
+	}
+	return parsed.Login, nil
+}

--- a/internal/auth/whoami_test.go
+++ b/internal/auth/whoami_test.go
@@ -1,0 +1,47 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func withUserServer(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	old := UserURL
+	UserURL = srv.URL
+	t.Cleanup(func() { UserURL = old })
+}
+
+func TestWhoAmIReturnsVerifiedLogin(t *testing.T) {
+	var gotAuth string
+	withUserServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewEncoder(w).Encode(map[string]string{"login": "priyam"})
+	})
+
+	login, err := WhoAmI("gho_abc123")
+	if err != nil {
+		t.Fatalf("WhoAmI() error = %v", err)
+	}
+	if login != "priyam" {
+		t.Errorf("WhoAmI() = %q, want priyam", login)
+	}
+	if gotAuth != "Bearer gho_abc123" {
+		t.Errorf("Authorization header = %q, want Bearer gho_abc123", gotAuth)
+	}
+}
+
+func TestWhoAmIFailsOnInvalidToken(t *testing.T) {
+	withUserServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+	})
+
+	if _, err := WhoAmI("bad-token"); err == nil {
+		t.Fatal("WhoAmI() error = nil, want error for an invalid token")
+	}
+}

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/lineage-dev/lineage/internal/auth"
+)
+
+// runLogin walks a publisher through GitHub's OAuth device flow and stores
+// the resulting token locally, so `lineage package publish` can identify
+// them without a token anyone had to hand-mint - see docs/decisions/
+// 0012-v1-distribution-contract-and-receiver-activation.md, decision 6b.
+func runLogin(home string, stdout, stderr io.Writer) error {
+	dc, err := auth.RequestDeviceCode()
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	fmt.Fprintf(stdout, "To authorize Lineage to publish as you, go to:\n\n  %s\n\nand enter this code: %s\n\nWaiting for approval...\n", dc.VerificationURI, dc.UserCode)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(dc.ExpiresIn)*time.Second)
+	defer cancel()
+
+	token, err := auth.PollForToken(ctx, dc)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	login, err := auth.WhoAmI(token)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	if err := auth.SaveToken(home, token); err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	fmt.Fprintf(stdout, "logged in as %s\n", login)
+	return nil
+}
+
+func runLogout(home string, stdout, stderr io.Writer) error {
+	if err := auth.DeleteToken(home); err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	fmt.Fprintln(stdout, "logged out")
+	return nil
+}
+
+// runWhoAmI prints the GitHub login that would be used to publish right
+// now - useful to confirm `lineage login` worked, or to check which
+// identity LINEAGE_PUBLISH_TOKEN resolves to before publishing.
+func runWhoAmI(home string, stdout, stderr io.Writer) error {
+	token, err := resolveGitHubToken(home)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	if token == "" {
+		err := fmt.Errorf("not logged in; run `lineage login`, or set LINEAGE_PUBLISH_TOKEN for non-interactive use")
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	login, err := auth.WhoAmI(token)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	fmt.Fprintf(stdout, "%s\n", login)
+	return nil
+}

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -1,0 +1,125 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lineage-dev/lineage/internal/auth"
+	"github.com/lineage-dev/lineage/internal/config"
+)
+
+// withGitHubAuthServer points the auth package's device-flow and identity
+// endpoints at a local stub for the duration of the test, restoring the
+// real GitHub URLs afterward.
+func withGitHubAuthServer(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	oldDC, oldAT, oldUser := auth.DeviceCodeURL, auth.AccessTokenURL, auth.UserURL
+	auth.DeviceCodeURL = srv.URL + "/login/device/code"
+	auth.AccessTokenURL = srv.URL + "/login/oauth/access_token"
+	auth.UserURL = srv.URL + "/user"
+	t.Cleanup(func() {
+		auth.DeviceCodeURL, auth.AccessTokenURL, auth.UserURL = oldDC, oldAT, oldUser
+	})
+}
+
+func TestLoginStoresTokenAndPrintsLogin(t *testing.T) {
+	withGitHubAuthServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/device/code"):
+			_ = json.NewEncoder(w).Encode(auth.DeviceCode{
+				DeviceCode: "dc-1", UserCode: "ABCD-1234",
+				VerificationURI: "https://github.com/login/device", ExpiresIn: 30, Interval: 1,
+			})
+		case strings.HasSuffix(r.URL.Path, "/oauth/access_token"):
+			_ = json.NewEncoder(w).Encode(map[string]string{"access_token": "gho_test123"})
+		case strings.HasSuffix(r.URL.Path, "/user"):
+			_ = json.NewEncoder(w).Encode(map[string]string{"login": "priyam"})
+		default:
+			t.Fatalf("unexpected request to %s", r.URL.Path)
+		}
+	})
+
+	home := filepath.Join(t.TempDir(), "home")
+	t.Setenv(config.HomeEnv, home)
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"login"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("login error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "logged in as priyam") {
+		t.Fatalf("stdout = %q, want confirmation naming the logged-in user", stdout.String())
+	}
+
+	got, err := auth.LoadToken(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "gho_test123" {
+		t.Fatalf("LoadToken() after login = %q, want gho_test123", got)
+	}
+}
+
+func TestWhoAmIReportsNotLoggedIn(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	t.Setenv(config.HomeEnv, home)
+	t.Setenv("LINEAGE_PUBLISH_TOKEN", "")
+
+	var stdout, stderr bytes.Buffer
+	err := Execute(nil, []string{"whoami"}, nil, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("whoami with nothing logged in: error = nil, want error")
+	}
+	if !strings.Contains(stderr.String(), "not logged in") {
+		t.Fatalf("stderr = %q, want a message pointing at `lineage login`", stderr.String())
+	}
+}
+
+func TestWhoAmIAfterLoginRoundTrip(t *testing.T) {
+	withGitHubAuthServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"login": "priyam"})
+	})
+
+	home := filepath.Join(t.TempDir(), "home")
+	if err := auth.SaveToken(home, "gho_test123"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(config.HomeEnv, home)
+	t.Setenv("LINEAGE_PUBLISH_TOKEN", "")
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"whoami"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("whoami error = %v stderr=%s", err, stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "priyam" {
+		t.Fatalf("stdout = %q, want priyam", stdout.String())
+	}
+}
+
+func TestLogoutRemovesStoredToken(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	if err := auth.SaveToken(home, "gho_test123"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(config.HomeEnv, home)
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"logout"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("logout error = %v stderr=%s", err, stderr.String())
+	}
+
+	got, err := auth.LoadToken(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Fatalf("LoadToken() after logout = %q, want empty", got)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/lineage-dev/lineage/internal/auth"
 	"github.com/lineage-dev/lineage/internal/config"
 	"github.com/lineage-dev/lineage/internal/materialize"
 	"github.com/lineage-dev/lineage/internal/packages"
@@ -17,6 +18,19 @@ import (
 	"github.com/lineage-dev/lineage/internal/runtime"
 	"github.com/lineage-dev/lineage/internal/shim"
 )
+
+// resolveGitHubToken finds the GitHub token that identifies a publisher:
+// LINEAGE_PUBLISH_TOKEN first (the escape hatch for non-interactive use,
+// e.g. CI - set it to any GitHub-issued token with read:user access), then
+// whatever `lineage login` stored locally. Returns "" with no error if
+// neither is set; callers decide how to report that (runWhoAmI and
+// runPackagePublish both need it, with different error messages).
+func resolveGitHubToken(home string) (string, error) {
+	if token := os.Getenv("LINEAGE_PUBLISH_TOKEN"); token != "" {
+		return token, nil
+	}
+	return auth.LoadToken(home)
+}
 
 func Execute(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	if len(args) == 0 {
@@ -51,6 +65,12 @@ func Execute(ctx context.Context, args []string, stdin io.Reader, stdout, stderr
 		return runInstallShims(home, stdout, stderr)
 	case "doctor":
 		return runDoctor(home, stdout, stderr)
+	case "login":
+		return runLogin(home, stdout, stderr)
+	case "logout":
+		return runLogout(home, stdout, stderr)
+	case "whoami":
+		return runWhoAmI(home, stdout, stderr)
 	case "help", "-h", "--help":
 		printUsage(stdout)
 		return nil
@@ -131,7 +151,7 @@ func runPackage(args []string, home string, stdout, stderr io.Writer) error {
 	case "import":
 		return runPackageImport(args[1:], home, stdout, stderr)
 	case "publish":
-		return runPackagePublish(args[1:], stdout, stderr)
+		return runPackagePublish(args[1:], home, stdout, stderr)
 	case "pull":
 		return runPackagePull(args[1:], home, stdout, stderr)
 	default:
@@ -141,25 +161,26 @@ func runPackage(args []string, home string, stdout, stderr io.Writer) error {
 	}
 }
 
-// registryConfigFromEnv reads registry location and publish credentials
-// from the environment rather than .lineage/config.yaml: a publish token is
-// a per-invocation secret, not project state that belongs in a committed
-// file. See docs/decisions/0012-v1-distribution-contract-and-receiver-activation.md.
-func registryConfigFromEnv() packages.RegistryConfig {
-	return packages.RegistryConfig{
-		URL:   os.Getenv("LINEAGE_REGISTRY_URL"),
-		Token: os.Getenv("LINEAGE_PUBLISH_TOKEN"),
-	}
-}
-
-func runPackagePublish(args []string, stdout, stderr io.Writer) error {
+func runPackagePublish(args []string, home string, stdout, stderr io.Writer) error {
 	if len(args) != 1 {
 		err := fmt.Errorf("usage: lineage package publish <path>")
 		fmt.Fprintln(stderr, err)
 		return err
 	}
 
-	result, err := packages.Publish(filepath.Clean(args[0]), registryConfigFromEnv())
+	token, err := resolveGitHubToken(home)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	if token == "" {
+		err := fmt.Errorf("not logged in; run `lineage login` first, or set LINEAGE_PUBLISH_TOKEN for non-interactive use")
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	cfg := packages.RegistryConfig{URL: os.Getenv("LINEAGE_REGISTRY_URL"), Token: token}
+	result, err := packages.Publish(filepath.Clean(args[0]), cfg)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return err
@@ -199,7 +220,10 @@ func runPackagePull(args []string, home string, stdout, stderr io.Writer) error 
 		return err
 	}
 
-	name, err := packages.Pull(ref, registryConfigFromEnv(), destParent, asName)
+	// Pull is an unauthenticated read - the registry doesn't gate who can
+	// fetch a published package, only who can publish one.
+	cfg := packages.RegistryConfig{URL: os.Getenv("LINEAGE_REGISTRY_URL")}
+	name, err := packages.Pull(ref, cfg, destParent, asName)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return err
@@ -901,6 +925,9 @@ Usage:
   lineage package import <file.tgz> [--as name]
   lineage package publish <path>
   lineage package pull <package-ref> [--as name]
+  lineage login
+  lineage logout
+  lineage whoami
   lineage enable <package-path-or-id>
   lineage disable <package-path-or-id>
   lineage list

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -99,7 +99,7 @@ func runInit(args []string, home string, stdout, stderr io.Writer) error {
 
 func runPackage(args []string, home string, stdout, stderr io.Writer) error {
 	if len(args) < 2 {
-		err := fmt.Errorf("usage: lineage package init <name> | lineage package validate <path> | lineage package export <path> [-o file.tgz] | lineage package import <file.tgz> [--as name]")
+		err := fmt.Errorf("usage: lineage package init <name> | lineage package validate <path> | lineage package export <path> [-o file.tgz] | lineage package import <file.tgz> [--as name] | lineage package publish <path> | lineage package pull <package-ref> [--as name]")
 		fmt.Fprintln(stderr, err)
 		return err
 	}
@@ -130,11 +130,83 @@ func runPackage(args []string, home string, stdout, stderr io.Writer) error {
 		return runPackageExport(args[1:], stdout, stderr)
 	case "import":
 		return runPackageImport(args[1:], home, stdout, stderr)
+	case "publish":
+		return runPackagePublish(args[1:], stdout, stderr)
+	case "pull":
+		return runPackagePull(args[1:], home, stdout, stderr)
 	default:
 		err := fmt.Errorf("unknown package command %q", args[0])
 		fmt.Fprintln(stderr, err)
 		return err
 	}
+}
+
+// registryConfigFromEnv reads registry location and publish credentials
+// from the environment rather than .lineage/config.yaml: a publish token is
+// a per-invocation secret, not project state that belongs in a committed
+// file. See docs/decisions/0012-v1-distribution-contract-and-receiver-activation.md.
+func registryConfigFromEnv() packages.RegistryConfig {
+	return packages.RegistryConfig{
+		URL:   os.Getenv("LINEAGE_REGISTRY_URL"),
+		Token: os.Getenv("LINEAGE_PUBLISH_TOKEN"),
+	}
+}
+
+func runPackagePublish(args []string, stdout, stderr io.Writer) error {
+	if len(args) != 1 {
+		err := fmt.Errorf("usage: lineage package publish <path>")
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	result, err := packages.Publish(filepath.Clean(args[0]), registryConfigFromEnv())
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	if result.AlreadyPublished {
+		fmt.Fprintf(stdout, "%s@%s is already published with this content (digest %s); nothing to do\n", result.Name, result.Version, result.Digest)
+		return nil
+	}
+	fmt.Fprintf(stdout, "published %s@%s (digest %s)\n", result.Name, result.Version, result.Digest)
+	return nil
+}
+
+func runPackagePull(args []string, home string, stdout, stderr io.Writer) error {
+	if len(args) < 1 {
+		err := fmt.Errorf("usage: lineage package pull <package-ref> [--as name]")
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	ref := args[0]
+	asName := ""
+	for i := 1; i < len(args); i++ {
+		if args[i] == "--as" && i+1 < len(args) {
+			asName = args[i+1]
+			i++
+			continue
+		}
+		err := fmt.Errorf("usage: lineage package pull <package-ref> [--as name]")
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	destParent := config.UserPackagesDir(home)
+	if err := os.MkdirAll(destParent, 0o755); err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	name, err := packages.Pull(ref, registryConfigFromEnv(), destParent, asName)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	fmt.Fprintf(stdout, "pulled package %s into %s\n", name, filepath.Join(destParent, name))
+	return nil
 }
 
 func runPackageImport(args []string, home string, stdout, stderr io.Writer) error {
@@ -827,6 +899,8 @@ Usage:
   lineage package validate <path>
   lineage package export <path> [-o file.tgz]
   lineage package import <file.tgz> [--as name]
+  lineage package publish <path>
+  lineage package pull <package-ref> [--as name]
   lineage enable <package-path-or-id>
   lineage disable <package-path-or-id>
   lineage list

--- a/internal/cli/publish_pull_test.go
+++ b/internal/cli/publish_pull_test.go
@@ -1,0 +1,140 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lineage-dev/lineage/internal/config"
+	"github.com/lineage-dev/lineage/internal/packages"
+)
+
+func TestPackagePublishUsage(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	// A single-arg "package publish" (no path) is caught by runPackage's own
+	// top-level arg-count gate before it ever reaches the publish-specific
+	// usage check - same as every other package subcommand. Passing too many
+	// args instead is what actually reaches runPackagePublish's own usage
+	// message.
+	err := Execute(nil, []string{"package", "publish", "a", "b"}, nil, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("publish with too many args: error = nil, want usage error")
+	}
+	if !strings.Contains(stderr.String(), "usage: lineage package publish <path>") {
+		t.Fatalf("stderr = %q, want publish usage message", stderr.String())
+	}
+}
+
+func TestPackagePublishRequiresToken(t *testing.T) {
+	root := t.TempDir()
+	pkgDir := filepath.Join(root, "needs-token")
+	if err := packages.InitPackage(pkgDir, "needs-token"); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("LINEAGE_PUBLISH_TOKEN", "")
+	t.Setenv("LINEAGE_REGISTRY_URL", "http://unused.invalid")
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"package", "publish", pkgDir}, nil, &stdout, &stderr); err == nil {
+		t.Fatal("publish without a token: error = nil, want error")
+	}
+}
+
+func TestPackagePublishSucceeds(t *testing.T) {
+	root := t.TempDir()
+	pkgDir := filepath.Join(root, "publish-me")
+	if err := packages.InitPackage(pkgDir, "publish-me"); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"alreadyPublished": false})
+	}))
+	defer srv.Close()
+
+	t.Setenv("LINEAGE_PUBLISH_TOKEN", "test-token")
+	t.Setenv("LINEAGE_REGISTRY_URL", srv.URL)
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"package", "publish", pkgDir}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("publish error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "published publish-me@0.1.0") {
+		t.Fatalf("stdout = %q, want confirmation naming the published package", stdout.String())
+	}
+}
+
+func TestPackagePullUsage(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	// Same top-level gate as TestPackagePublishUsage: a malformed --as flag
+	// (missing its value) is what actually reaches runPackagePull's own
+	// usage message.
+	err := Execute(nil, []string{"package", "pull", "some-ref", "--as"}, nil, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("pull with a dangling --as flag: error = nil, want usage error")
+	}
+	if !strings.Contains(stderr.String(), "usage: lineage package pull <package-ref>") {
+		t.Fatalf("stderr = %q, want pull usage message", stderr.String())
+	}
+}
+
+func TestPackagePullImportsIntoUserPackages(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	srcDir := filepath.Join(tmp, "pull-me")
+	if err := packages.InitPackage(srcDir, "pull-me"); err != nil {
+		t.Fatal(err)
+	}
+	report, err := packages.Validate(srcDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var archive bytes.Buffer
+	if err := packages.Export(srcDir, &archive); err != nil {
+		t.Fatal(err)
+	}
+	archiveBytes := archive.Bytes()
+
+	ref := "pull-me@0.1.0"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/packages/"+ref, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name": "pull-me", "version": "0.1.0", "digest": report.Digest,
+			"downloadPath": "/api/packages/" + ref + "/download",
+		})
+	})
+	mux.HandleFunc("/api/packages/"+ref+"/download", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(archiveBytes)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	oldHome := os.Getenv(config.HomeEnv)
+	t.Setenv(config.HomeEnv, home)
+	defer t.Setenv(config.HomeEnv, oldHome)
+	t.Setenv("LINEAGE_REGISTRY_URL", srv.URL)
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"package", "pull", ref}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("pull error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "pulled package pull-me") {
+		t.Fatalf("stdout = %q, want confirmation naming the pulled package", stdout.String())
+	}
+
+	importedDir := filepath.Join(config.UserPackagesDir(home), "pull-me")
+	if _, err := os.Stat(filepath.Join(importedDir, packages.ManifestFileName)); err != nil {
+		t.Fatalf("expected pulled manifest: %v", err)
+	}
+}

--- a/internal/cli/publish_pull_test.go
+++ b/internal/cli/publish_pull_test.go
@@ -37,12 +37,21 @@ func TestPackagePublishRequiresToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Isolate LINEAGE_HOME to an empty temp dir: resolveGitHubToken falls
+	// back to whatever `lineage login` stored on disk, and this test must
+	// not accidentally pick up a real token file from the machine it runs
+	// on.
+	t.Setenv(config.HomeEnv, filepath.Join(root, "home"))
 	t.Setenv("LINEAGE_PUBLISH_TOKEN", "")
 	t.Setenv("LINEAGE_REGISTRY_URL", "http://unused.invalid")
 
 	var stdout, stderr bytes.Buffer
-	if err := Execute(nil, []string{"package", "publish", pkgDir}, nil, &stdout, &stderr); err == nil {
+	err := Execute(nil, []string{"package", "publish", pkgDir}, nil, &stdout, &stderr)
+	if err == nil {
 		t.Fatal("publish without a token: error = nil, want error")
+	}
+	if !strings.Contains(stderr.String(), "not logged in") {
+		t.Fatalf("stderr = %q, want a message pointing at `lineage login`", stderr.String())
 	}
 }
 
@@ -63,6 +72,7 @@ func TestPackagePublishSucceeds(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	t.Setenv(config.HomeEnv, filepath.Join(root, "home"))
 	t.Setenv("LINEAGE_PUBLISH_TOKEN", "test-token")
 	t.Setenv("LINEAGE_REGISTRY_URL", srv.URL)
 

--- a/internal/packages/registry.go
+++ b/internal/packages/registry.go
@@ -1,0 +1,192 @@
+package packages
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// DefaultRegistryURL is used when LINEAGE_REGISTRY_URL isn't set. It points
+// at the Lineage website's package API (docs/decisions/
+// 0012-v1-distribution-contract-and-receiver-activation.md), which is
+// itself a thin proxy in front of a private GitHub repo used as artifact
+// storage - the registry API is the only interface this file talks to.
+const DefaultRegistryURL = "https://lineage.dev"
+
+// RegistryConfig is read from the environment by CLI commands, not stored
+// in .lineage/config.yaml: a publish token is a per-invocation secret, not
+// committed project state.
+type RegistryConfig struct {
+	URL   string
+	Token string
+}
+
+func (c RegistryConfig) baseURL() string {
+	if c.URL != "" {
+		return strings.TrimRight(c.URL, "/")
+	}
+	return DefaultRegistryURL
+}
+
+type PublishResult struct {
+	Name             string
+	Version          string
+	Digest           string
+	AlreadyPublished bool
+}
+
+// Publish validates dir the same way Export does, then uploads the
+// resulting archive to the registry. It refuses to run against a package
+// that fails Validate for the same reason Export does: publish is exactly
+// the moment package content starts moving to other machines.
+func Publish(dir string, cfg RegistryConfig) (PublishResult, error) {
+	report, err := Validate(dir)
+	if err != nil {
+		return PublishResult{}, err
+	}
+	if !report.Passed() {
+		return PublishResult{}, fmt.Errorf("package failed validation, refusing to publish (%d error(s)); run `lineage package validate` for details", len(report.Errors))
+	}
+	if cfg.Token == "" {
+		return PublishResult{}, fmt.Errorf("no publish token configured; set LINEAGE_PUBLISH_TOKEN")
+	}
+
+	var buf bytes.Buffer
+	if err := Export(dir, &buf); err != nil {
+		return PublishResult{}, err
+	}
+
+	q := url.Values{}
+	q.Set("name", report.Manifest.Name)
+	q.Set("version", report.Manifest.Version)
+	q.Set("digest", report.Digest)
+	if report.Manifest.Description != "" {
+		q.Set("description", report.Manifest.Description)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, cfg.baseURL()+"/api/publish?"+q.Encode(), &buf)
+	if err != nil {
+		return PublishResult{}, fmt.Errorf("build publish request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/gzip")
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return PublishResult{}, fmt.Errorf("publish %s@%s: %w", report.Manifest.Name, report.Manifest.Version, err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return PublishResult{}, fmt.Errorf("publish %s@%s failed (%s): %s", report.Manifest.Name, report.Manifest.Version, resp.Status, apiErrorMessage(body))
+	}
+
+	var parsed struct {
+		AlreadyPublished bool `json:"alreadyPublished"`
+	}
+	_ = json.Unmarshal(body, &parsed)
+
+	return PublishResult{
+		Name:             report.Manifest.Name,
+		Version:          report.Manifest.Version,
+		Digest:           report.Digest,
+		AlreadyPublished: parsed.AlreadyPublished,
+	}, nil
+}
+
+type packageMetadata struct {
+	Name         string `json:"name"`
+	Version      string `json:"version"`
+	Digest       string `json:"digest"`
+	Description  string `json:"description"`
+	DownloadPath string `json:"downloadPath"`
+}
+
+// Pull fetches a published package by ref ("<name>@<version>", or just
+// "<name>" for the latest published version) from the registry and imports
+// it into destParent, the same way Import does for a local archive.
+//
+// The digest the registry reports for ref is untrusted the same way the
+// archive bytes are: after import, Pull recomputes the digest from the
+// content Import actually kept and fails closed - removing what was
+// imported - if it doesn't match what the registry claimed.
+func Pull(ref string, cfg RegistryConfig, destParent, asName string) (string, error) {
+	meta, err := fetchPackageMetadata(ref, cfg)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := http.Get(cfg.baseURL() + meta.DownloadPath)
+	if err != nil {
+		return "", fmt.Errorf("download %s: %w", ref, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("download %s failed (%s): %s", ref, resp.Status, apiErrorMessage(body))
+	}
+
+	name, err := Import(resp.Body, destParent, asName)
+	if err != nil {
+		return "", err
+	}
+
+	importedDir := filepath.Join(destParent, name)
+	actualDigest, err := ComputeDigest(importedDir)
+	if err != nil {
+		os.RemoveAll(importedDir)
+		return "", fmt.Errorf("verify digest for %s: %w", ref, err)
+	}
+	if meta.Digest != "" && actualDigest != meta.Digest {
+		os.RemoveAll(importedDir)
+		return "", fmt.Errorf("digest mismatch for %s: registry reported %s, imported content hashes to %s; refusing to keep it", ref, meta.Digest, actualDigest)
+	}
+
+	return name, nil
+}
+
+func fetchPackageMetadata(ref string, cfg RegistryConfig) (packageMetadata, error) {
+	resp, err := http.Get(cfg.baseURL() + "/api/packages/" + url.PathEscape(ref))
+	if err != nil {
+		return packageMetadata{}, fmt.Errorf("resolve %s: %w", ref, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return packageMetadata{}, fmt.Errorf("read metadata for %s: %w", ref, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return packageMetadata{}, fmt.Errorf("resolve %s failed (%s): %s", ref, resp.Status, apiErrorMessage(body))
+	}
+
+	var meta packageMetadata
+	if err := json.Unmarshal(body, &meta); err != nil {
+		return packageMetadata{}, fmt.Errorf("parse metadata for %s: %w", ref, err)
+	}
+	return meta, nil
+}
+
+// apiErrorMessage extracts the registry's {"error": "..."} body into a
+// clean message, falling back to the raw body if it isn't that shape. The
+// registry's own error text already carries retry guidance where it
+// applies (e.g. "safe to retry the same publish" after an interrupted
+// upload) - this just keeps that readable instead of dumping raw JSON.
+func apiErrorMessage(body []byte) string {
+	var parsed struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &parsed); err == nil && parsed.Error != "" {
+		return parsed.Error
+	}
+	return strings.TrimSpace(string(body))
+}

--- a/internal/packages/registry_test.go
+++ b/internal/packages/registry_test.go
@@ -1,0 +1,196 @@
+package packages
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPublishUploadsExportedArchive(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "publish-pack")
+	if err := InitPackage(root, "publish-pack"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, "skills", "review", "SKILL.md"), "# Review")
+
+	report, err := Validate(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var gotArchive []byte
+	var gotAuth, gotName, gotVersion, gotDigest string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/publish" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		gotName = r.URL.Query().Get("name")
+		gotVersion = r.URL.Query().Get("version")
+		gotDigest = r.URL.Query().Get("digest")
+		gotArchive, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name": gotName, "version": gotVersion, "digest": gotDigest, "alreadyPublished": false,
+		})
+	}))
+	defer srv.Close()
+
+	result, err := Publish(root, RegistryConfig{URL: srv.URL, Token: "test-token"})
+	if err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	if gotAuth != "Bearer test-token" {
+		t.Errorf("Authorization header = %q, want Bearer test-token", gotAuth)
+	}
+	if gotName != "publish-pack" || gotVersion != report.Manifest.Version || gotDigest != report.Digest {
+		t.Errorf("query params = name=%q version=%q digest=%q, want name=publish-pack version=%q digest=%q", gotName, gotVersion, gotDigest, report.Manifest.Version, report.Digest)
+	}
+	if len(gotArchive) == 0 {
+		t.Error("Publish() sent an empty archive body")
+	}
+	if result.AlreadyPublished {
+		t.Error("Publish() result.AlreadyPublished = true, want false")
+	}
+	if result.Digest != report.Digest {
+		t.Errorf("Publish() result.Digest = %q, want %q", result.Digest, report.Digest)
+	}
+}
+
+func TestPublishRefusesWhenValidationFails(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "broken-pack")
+	if err := InitPackage(root, "broken-pack"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, ".env"), "API_KEY=whatever")
+
+	if _, err := Publish(root, RegistryConfig{URL: "http://unused.invalid", Token: "t"}); err == nil {
+		t.Fatal("Publish() error = nil, want error for a package that fails validation")
+	}
+}
+
+func TestPublishRequiresToken(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "token-pack")
+	if err := InitPackage(root, "token-pack"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Publish(root, RegistryConfig{URL: "http://unused.invalid"}); err == nil {
+		t.Fatal("Publish() error = nil, want error when no token is configured")
+	}
+}
+
+func TestPublishSurfacesConflictOnDigestMismatch(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "conflict-pack")
+	if err := InitPackage(root, "conflict-pack"); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":"already published with a different digest"}`))
+	}))
+	defer srv.Close()
+
+	_, err := Publish(root, RegistryConfig{URL: srv.URL, Token: "t"})
+	if err == nil {
+		t.Fatal("Publish() error = nil, want error on 409 from the registry")
+	}
+}
+
+// pullTestServer serves the same contract as landing/api: metadata at
+// /api/packages/:ref, archive bytes at /api/packages/:ref/download.
+func pullTestServer(t *testing.T, ref string, meta map[string]any, archive []byte) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/packages/"+ref, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(meta)
+	})
+	mux.HandleFunc("/api/packages/"+ref+"/download", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(archive)
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestPullImportsAndVerifiesDigest(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "pull-pack")
+	if err := InitPackage(src, "pull-pack"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(src, "skills", "review", "SKILL.md"), "# Review")
+
+	report, err := Validate(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var archive bytes.Buffer
+	if err := Export(src, &archive); err != nil {
+		t.Fatal(err)
+	}
+
+	ref := "pull-pack@0.1.0"
+	srv := pullTestServer(t, ref, map[string]any{
+		"name": "pull-pack", "version": "0.1.0", "digest": report.Digest,
+		"downloadPath": "/api/packages/" + ref + "/download",
+	}, archive.Bytes())
+	defer srv.Close()
+
+	destParent := t.TempDir()
+	name, err := Pull(ref, RegistryConfig{URL: srv.URL}, destParent, "")
+	if err != nil {
+		t.Fatalf("Pull() error = %v", err)
+	}
+	if name != "pull-pack" {
+		t.Errorf("Pull() name = %q, want pull-pack", name)
+	}
+	if _, err := os.Stat(filepath.Join(destParent, name, ManifestFileName)); err != nil {
+		t.Errorf("pulled package manifest missing: %v", err)
+	}
+}
+
+func TestPullFailsClosedOnDigestMismatch(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "mismatch-pack")
+	if err := InitPackage(src, "mismatch-pack"); err != nil {
+		t.Fatal(err)
+	}
+	var archive bytes.Buffer
+	if err := Export(src, &archive); err != nil {
+		t.Fatal(err)
+	}
+
+	ref := "mismatch-pack@0.1.0"
+	srv := pullTestServer(t, ref, map[string]any{
+		"name": "mismatch-pack", "version": "0.1.0",
+		"digest":       "sha256:0000000000000000000000000000000000000000000000000000000000000",
+		"downloadPath": "/api/packages/" + ref + "/download",
+	}, archive.Bytes())
+	defer srv.Close()
+
+	destParent := t.TempDir()
+	if _, err := Pull(ref, RegistryConfig{URL: srv.URL}, destParent, ""); err == nil {
+		t.Fatal("Pull() error = nil, want error on digest mismatch")
+	}
+	if _, err := os.Stat(filepath.Join(destParent, "mismatch-pack")); !os.IsNotExist(err) {
+		t.Errorf("Pull() left a package directory behind after a digest mismatch: err = %v", err)
+	}
+}
+
+func TestPullReportsMissingRef(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"error":"not found"}`)
+	}))
+	defer srv.Close()
+
+	if _, err := Pull("nope@1.0.0", RegistryConfig{URL: srv.URL}, t.TempDir(), ""); err == nil {
+		t.Fatal("Pull() error = nil, want error for an unknown ref")
+	}
+}


### PR DESCRIPTION
## Summary

Adds the CLI side of the registry: `lineage package publish <path>`, `lineage package pull <package-ref> [--as name]`, and publisher identity (`lineage login`/`logout`/`whoami`) against the registry API added in the paired `priyam-jain-2002/lineagelanding` PR (`feat/registry-publish-pull-api`, merged).

- Publish reuses the same Validate-then-Export path as `package export` and refuses to publish anything that fails validation.
- Pull resolves a ref (`name` for latest, or an exact `name@version`), imports it exactly like `package import`, then independently recomputes the digest from what was actually imported and fails closed (discarding the import) if it doesn't match what the registry reported.
- Publisher identity is a verified GitHub login, not a hand-minted token: `lineage login` runs GitHub's OAuth Device Flow (same mechanism `gh auth login` uses, no client secret needed for a public/native CLI) and stores the resulting token locally. `LINEAGE_PUBLISH_TOKEN` remains as an escape hatch for CI - any GitHub token with `read:user` access works, verified the same way.
- Lineage's GitHub OAuth App Client ID (`agentic-lineage`, Device Flow enabled) is compiled in and verified against the real endpoint end to end (device code request + a real `lineage login` run print the correct verification URL/code; the interactive browser-approval step itself hasn't been exercised by an actual human yet).
- Registry location comes from `LINEAGE_REGISTRY_URL`, not `.lineage/config.yaml` - not project state that belongs in a committed file.
- CLI-side errors surface the registry's actual `error` message instead of a raw JSON body.

**Stacked on #88** — this PR is based on `docs/v1-distribution-contract-record` so the diff shown here is just this change; retarget to `develop` once #88 merges.

## Linked Issue

Closes #68
Closes #70

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [ ] Package format or manifest behavior
- [ ] Package discovery or enablement
- [ ] Provider launch/shim behavior
- [ ] Setup or permission flow
- [ ] Documentation only
- [ ] Tests only

(New CLI commands plus a new `internal/auth` package - none of the above categories quite fit; see Summary.)

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

`lineage login`'s stored token is written with 0600 permissions and never printed. Pull independently re-verifies the digest of imported content rather than trusting what the registry reports.

## Verification

Relevant test cases:

- `internal/packages/registry_test.go`: publish success (asserts uploaded archive, auth header, query params), refuses on validation failure, requires a token, surfaces a 409 conflict; pull imports and verifies digest, fails closed and cleans up on digest mismatch, reports a missing ref.
- `internal/cli/publish_pull_test.go`: usage/error paths for both commands at the CLI layer, a full publish round trip against an `httptest` server, a full pull round trip landing the package under the user packages dir, and a "not logged in" error path with proper `LINEAGE_HOME` isolation.
- `internal/auth/device_test.go`: device code request, poll success after `authorization_pending`, `slow_down` backoff, `access_denied`, expiry, context cancellation - all against a stubbed device-flow server.
- `internal/auth/whoami_test.go`: identity resolution success and failure against a stubbed `/user` endpoint.
- `internal/auth/token_test.go`: save/load/delete round trip and file permissions.
- `internal/cli/auth_test.go`: `login`/`logout`/`whoami` wiring end to end against a stubbed GitHub auth server.

```text
go test ./...
```

## Notes For Reviewers

This PR grew across several commits as real gaps surfaced during implementation: the first cut used a flat admin-minted token list for publisher identity, which didn't scale (every new publisher needed an env var edit + redeploy) - replaced with GitHub OAuth identity per #87 before this ever merged. Worth a close look: `resolveGitHubToken`'s priority order (`LINEAGE_PUBLISH_TOKEN` env var first, then the locally stored login token) in `internal/cli/cli.go`.
