### PR TITLE
Fix DefaultRegistryURL placeholder to the real deployed domain

### DIFF
--- a/internal/packages/registry.go
+++ b/internal/packages/registry.go
@@ -18,7 +18,11 @@ import (
 // 0012-v1-distribution-contract-and-receiver-activation.md), which is
 // itself a thin proxy in front of a private GitHub repo used as artifact
 // storage - the registry API is the only interface this file talks to.
-const DefaultRegistryURL = "https://lineage.dev"
+//
+// This is the actual deployed domain (priyam-jain-2002/lineagelanding on
+// Vercel), not a placeholder - update it if a custom domain is ever
+// attached in front of that deployment.
+const DefaultRegistryURL = "https://agenticlineage.vercel.app"
 
 // RegistryConfig is read from the environment by CLI commands, not stored
 // in .lineage/config.yaml: a publish token is a per-invocation secret, not


### PR DESCRIPTION
## Summary

`DefaultRegistryURL` in `internal/packages/registry.go` was `https://lineage.dev` - a placeholder guess from before the website existed, not a real domain. Publish/pull failed by default (no such host resolves) unless `LINEAGE_REGISTRY_URL` was set manually every time. Now points at the actual deployment: `https://agenticlineage.vercel.app`.

## Linked Issue

Closes #67

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [ ] Package format or manifest behavior
- [ ] Package discovery or enablement
- [ ] Provider launch/shim behavior
- [ ] Setup or permission flow
- [ ] Documentation only
- [ ] Tests only

(A one-constant config fix - none of the categories above quite fit.)

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

(Unaffected by this change - listed for completeness.)

## Verification

If this PR does not need automated tests, explain why:

- One-constant change with no new behavior to unit test; existing `internal/packages` and `internal/cli` suites (which exercise `RegistryConfig`/`Publish`/`Pull` against local test servers, unaffected by the default) still pass.

```text
go test ./...
```

## Notes For Reviewers

Verified live: `curl https://agenticlineage.vercel.app/api/packages` now returns `{"packages":[]}` (registry env vars provisioned, GitHub token permissions fixed) rather than a connection error, so this default now actually resolves to a working endpoint.
