### PR TITLE
Fix module path: github.com/lineage-dev -> github.com/agentic-lineage

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security report
-    url: https://github.com/lineage-dev/lineage/security/advisories/new
+    url: https://github.com/agentic-lineage/lineage/security/advisories/new
     about: Please report private security issues through GitHub Security Advisories.

--- a/cmd/lineage/main.go
+++ b/cmd/lineage/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/lineage-dev/lineage/internal/cli"
+	"github.com/agentic-lineage/lineage/internal/cli"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/lineage-dev/lineage
+module github.com/agentic-lineage/lineage
 
 go 1.22
 

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/lineage-dev/lineage/internal/auth"
+	"github.com/agentic-lineage/lineage/internal/auth"
 )
 
 // runLogin walks a publisher through GitHub's OAuth device flow and stores

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/lineage-dev/lineage/internal/auth"
-	"github.com/lineage-dev/lineage/internal/config"
+	"github.com/agentic-lineage/lineage/internal/auth"
+	"github.com/agentic-lineage/lineage/internal/config"
 )
 
 // withGitHubAuthServer points the auth package's device-flow and identity

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -10,13 +10,13 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/lineage-dev/lineage/internal/auth"
-	"github.com/lineage-dev/lineage/internal/config"
-	"github.com/lineage-dev/lineage/internal/materialize"
-	"github.com/lineage-dev/lineage/internal/packages"
-	"github.com/lineage-dev/lineage/internal/provider"
-	"github.com/lineage-dev/lineage/internal/runtime"
-	"github.com/lineage-dev/lineage/internal/shim"
+	"github.com/agentic-lineage/lineage/internal/auth"
+	"github.com/agentic-lineage/lineage/internal/config"
+	"github.com/agentic-lineage/lineage/internal/materialize"
+	"github.com/agentic-lineage/lineage/internal/packages"
+	"github.com/agentic-lineage/lineage/internal/provider"
+	"github.com/agentic-lineage/lineage/internal/runtime"
+	"github.com/agentic-lineage/lineage/internal/shim"
 )
 
 // resolveGitHubToken finds the GitHub token that identifies a publisher:

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/lineage-dev/lineage/internal/config"
-	"github.com/lineage-dev/lineage/internal/packages"
+	"github.com/agentic-lineage/lineage/internal/config"
+	"github.com/agentic-lineage/lineage/internal/packages"
 )
 
 func TestEnableAndDryRun(t *testing.T) {

--- a/internal/cli/publish_pull_test.go
+++ b/internal/cli/publish_pull_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/lineage-dev/lineage/internal/config"
-	"github.com/lineage-dev/lineage/internal/packages"
+	"github.com/agentic-lineage/lineage/internal/config"
+	"github.com/agentic-lineage/lineage/internal/packages"
 )
 
 func TestPackagePublishUsage(t *testing.T) {

--- a/internal/cli/regression_test.go
+++ b/internal/cli/regression_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/lineage-dev/lineage/internal/config"
-	"github.com/lineage-dev/lineage/internal/packages"
+	"github.com/agentic-lineage/lineage/internal/config"
+	"github.com/agentic-lineage/lineage/internal/packages"
 )
 
 // TestEnableFromSubdirectoryUsesProjectRoot guards against a regression

--- a/internal/materialize/materialize.go
+++ b/internal/materialize/materialize.go
@@ -15,8 +15,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/lineage-dev/lineage/internal/packages"
-	"github.com/lineage-dev/lineage/internal/provider"
+	"github.com/agentic-lineage/lineage/internal/packages"
+	"github.com/agentic-lineage/lineage/internal/provider"
 )
 
 const (

--- a/internal/materialize/materialize_test.go
+++ b/internal/materialize/materialize_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/lineage-dev/lineage/internal/packages"
-	"github.com/lineage-dev/lineage/internal/provider"
+	"github.com/agentic-lineage/lineage/internal/packages"
+	"github.com/agentic-lineage/lineage/internal/provider"
 )
 
 func TestNeedsApprovalOnFirstRun(t *testing.T) {

--- a/internal/materialize/workflow_test.go
+++ b/internal/materialize/workflow_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/lineage-dev/lineage/internal/packages"
-	"github.com/lineage-dev/lineage/internal/provider"
+	"github.com/agentic-lineage/lineage/internal/packages"
+	"github.com/agentic-lineage/lineage/internal/provider"
 )
 
 func buildWorkflowPackage(t *testing.T, name string, skills ...string) packages.Package {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/lineage-dev/lineage/internal/config"
+	"github.com/agentic-lineage/lineage/internal/config"
 )
 
 type Plan struct {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/lineage-dev/lineage/internal/config"
+	"github.com/agentic-lineage/lineage/internal/config"
 )
 
 func TestIsShimPath(t *testing.T) {

--- a/internal/runtime/plan.go
+++ b/internal/runtime/plan.go
@@ -5,9 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/lineage-dev/lineage/internal/config"
-	"github.com/lineage-dev/lineage/internal/packages"
-	"github.com/lineage-dev/lineage/internal/provider"
+	"github.com/agentic-lineage/lineage/internal/config"
+	"github.com/agentic-lineage/lineage/internal/packages"
+	"github.com/agentic-lineage/lineage/internal/provider"
 )
 
 type Plan struct {

--- a/internal/runtime/plan_test.go
+++ b/internal/runtime/plan_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/lineage-dev/lineage/internal/config"
-	"github.com/lineage-dev/lineage/internal/packages"
+	"github.com/agentic-lineage/lineage/internal/config"
+	"github.com/agentic-lineage/lineage/internal/packages"
 )
 
 func TestBuildPlanDryRun(t *testing.T) {

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/lineage-dev/lineage/internal/provider"
+	"github.com/agentic-lineage/lineage/internal/provider"
 )
 
 // Install writes a shim for every registered provider (internal/provider's


### PR DESCRIPTION
## Summary

`go.mod`'s module path was `github.com/lineage-dev/lineage` - that GitHub org doesn't exist (404). The real org is `agentic-lineage`. This meant `go install`/`go get` has never worked for anyone outside a local checkout of this exact repo, this whole time:

```text
$ go install github.com/lineage-dev/lineage/cmd/lineage@latest
go: github.com/lineage-dev/lineage/cmd/lineage: module github.com/lineage-dev/lineage:
git ls-remote ... https://github.com/lineage-dev/lineage: exit status 128:
	remote: Repository not found.
```

Renames the module to `github.com/agentic-lineage/lineage` and updates every internal import across the codebase (`go mod edit -module` plus a mechanical string replace - Go doesn't rewrite import statements for you). Also fixes one stray reference in `.github/ISSUE_TEMPLATE/config.yml` (security advisory link pointed at the same wrong org).

## Linked Issue

Closes #64

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [ ] Package format or manifest behavior
- [ ] Package discovery or enablement
- [ ] Provider launch/shim behavior
- [ ] Setup or permission flow
- [ ] Documentation only
- [ ] Tests only

(A module-path rename touching every file's imports - none of the categories above quite fit.)

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

(Unaffected by this change - listed for completeness.)

## Verification

If this PR does not need automated tests, explain why:

- Mechanical rename with no behavior change; the existing suite (unaffected in substance) is the verification.

```text
go test ./...
```

## Notes For Reviewers

This is a real prerequisite for #64 (CLI install path): a `curl | sh` installer or `go install` instructions are meaningless while the module path 404s. Verified live after this rename lands: `go install github.com/agentic-lineage/lineage/cmd/lineage@latest` should resolve correctly against the real org.
