### PR TITLE
Document the real install path in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ prepare once -> package safely -> share -> enable locally -> run with the user's
 
 Lineage does not try to replace the agent provider. It sits around local agent commands and makes the surrounding environment easier to package, review, and reproduce.
 
+## Install
+
+```bash
+curl -fsSL https://agenticlineage.vercel.app/install.sh | sh
+```
+
+Downloads the right prebuilt binary for your OS/architecture (macOS/Linux, amd64/arm64), verifies it against the release's published checksum, and installs it to `~/.lineage/bin`. No Go toolchain required. Windows: download `lineage-windows-amd64.exe` directly from the [latest release](https://github.com/agentic-lineage/lineage/releases/latest).
+
+Go developers can also build from source:
+
+```bash
+go install github.com/agentic-lineage/lineage/cmd/lineage@latest
+```
+
 ## What Is In A Package?
 
 A Lineage package is a normal folder with a `lineage.yaml` manifest:


### PR DESCRIPTION
## Summary

Documents the curl installer (`public/install.sh` in `priyam-jain-2002/lineagelanding`, backed by the v0.2.0 GitHub release's prebuilt binaries) as the primary install path, with `go install` as the alternative for Go developers. Previously the only documented way to get `lineage` was cloning the repo and building it yourself.

## Linked Issue

Closes #64

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [x] Documentation only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

(Unaffected - documentation only.)

## Verification

If this PR does not need automated tests, explain why:

- Documentation-only change; no code to test. The installer itself was verified separately by actually running it against the live release (see the lineagelanding repo's PR adding install.sh).

```text
go test ./...
```

## Notes For Reviewers

`go install github.com/agentic-lineage/lineage/cmd/lineage@latest` (mentioned here) only works once #92 (module path fix) merges - currently the module path 404s. Worth merging #92 first, or at least before this becomes misleading.
