### PR TITLE
Add lineage add command

### DIFF
--- a/internal/cli/add_test.go
+++ b/internal/cli/add_test.go
@@ -1,0 +1,165 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agentic-lineage/lineage/internal/config"
+	"github.com/agentic-lineage/lineage/internal/packages"
+)
+
+func TestAddUsage(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"add"}, nil, &stdout, &stderr); err == nil {
+		t.Fatal("add with no ref: error = nil, want error")
+	} else if !strings.Contains(stderr.String(), "usage: lineage add <package-ref>") {
+		t.Fatalf("stderr = %q, want usage message", stderr.String())
+	}
+}
+
+func TestAddHelp(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"add", "-h"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("add -h error = %v", err)
+	}
+	if !strings.HasPrefix(stdout.String(), "usage: lineage add <package-ref>") {
+		t.Fatalf("stdout = %q, want the add usage line", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+// addTestServer serves the same contract as the real registry API, backed
+// by an in-memory package built from srcDir.
+func addTestServer(t *testing.T, ref, srcDir string) *httptest.Server {
+	t.Helper()
+	report, err := packages.Validate(srcDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var archive bytes.Buffer
+	if err := packages.Export(srcDir, &archive); err != nil {
+		t.Fatal(err)
+	}
+	archiveBytes := archive.Bytes()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/packages/"+ref, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name": report.Manifest.Name, "version": report.Manifest.Version, "digest": report.Digest,
+			"downloadPath": "/api/packages/" + ref + "/download",
+		})
+	})
+	mux.HandleFunc("/api/packages/"+ref+"/download", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(archiveBytes)
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestAddFetchesInspectsAndEnablesWithYes(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	srcDir := filepath.Join(tmp, "commit-helper")
+	if err := packages.InitPackage(srcDir, "commit-helper"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(srcDir, "skills", "commit-messages"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "skills", "commit-messages", "SKILL.md"), []byte("# Commit messages"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ref := "commit-helper@0.1.0"
+	srv := addTestServer(t, ref, srcDir)
+	defer srv.Close()
+
+	oldHome := os.Getenv(config.HomeEnv)
+	t.Setenv(config.HomeEnv, home)
+	defer t.Setenv(config.HomeEnv, oldHome)
+	t.Setenv("LINEAGE_REGISTRY_URL", srv.URL)
+
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"add", ref, "--yes"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("add error = %v stderr=%s", err, stderr.String())
+	}
+
+	out := stdout.String()
+	for _, want := range []string{"fetched commit-helper@0.1.0", "skills: commit-messages", "enabled package commit-helper", "Ready. Run `lineage run"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout = %q, want it to contain %q", out, want)
+		}
+	}
+
+	found, err := config.FindProjectConfig(project)
+	if err != nil {
+		t.Fatalf("expected a project config after add --yes: %v", err)
+	}
+	if !contains(found.Config.EnabledPackages, "commit-helper") {
+		t.Errorf("enabled packages = %v, want commit-helper", found.Config.EnabledPackages)
+	}
+}
+
+func TestAddDeclinedDoesNotEnable(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	srcDir := filepath.Join(tmp, "resume-like")
+	if err := packages.InitPackage(srcDir, "resume-like"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ref := "resume-like@0.1.0"
+	srv := addTestServer(t, ref, srcDir)
+	defer srv.Close()
+
+	oldHome := os.Getenv(config.HomeEnv)
+	t.Setenv(config.HomeEnv, home)
+	defer t.Setenv(config.HomeEnv, oldHome)
+	t.Setenv("LINEAGE_REGISTRY_URL", srv.URL)
+
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	var stdout, stderr bytes.Buffer
+	stdin := strings.NewReader("n\n")
+	if err := Execute(nil, []string{"add", ref}, stdin, &stdout, &stderr); err != nil {
+		t.Fatalf("add error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "not enabled") {
+		t.Fatalf("stdout = %q, want a message confirming it was not enabled", stdout.String())
+	}
+
+	if _, err := config.FindProjectConfig(project); err == nil {
+		t.Fatal("expected no project config to exist after declining - add must not enable without permission")
+	}
+
+	// The package is still fetched locally even though it wasn't enabled -
+	// declining should stop at enable, not undo the fetch.
+	if _, err := os.Stat(filepath.Join(config.UserPackagesDir(home), "resume-like", packages.ManifestFileName)); err != nil {
+		t.Errorf("expected the package to still be pulled locally after declining: %v", err)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -55,6 +55,8 @@ func Execute(ctx context.Context, args []string, stdin io.Reader, stdout, stderr
 		return runInit(args[1:], home, stdout, stderr)
 	case "package":
 		return runPackage(args[1:], home, stdout, stderr)
+	case "add":
+		return runAdd(args[1:], home, stdin, stdout, stderr)
 	case "enable":
 		return runEnable(args[1:], home, stdout, stderr)
 	case "list":
@@ -443,7 +445,14 @@ func runEnable(args []string, home string, stdout, stderr io.Writer) error {
 		fmt.Fprintln(stderr, err)
 		return err
 	}
+	return enableRef(args[0], home, stdout, stderr)
+}
 
+// enableRef is runEnable's actual work, factored out so `lineage add`
+// (which pulls a package and then enables it in one command) shares the
+// exact same project-root resolution and dependency validation instead of
+// a second, drifting implementation.
+func enableRef(ref, home string, stdout, stderr io.Writer) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		fmt.Fprintln(stderr, err)
@@ -467,8 +476,6 @@ func runEnable(args []string, home string, stdout, stderr io.Writer) error {
 		fmt.Fprintln(stderr, err)
 		return err
 	}
-
-	ref := args[0]
 
 	// A "./" or "../" style ref is relative to where the user typed it
 	// (cwd), matching the documented `lineage enable ./resume-workflow`
@@ -527,6 +534,83 @@ func runEnable(args []string, home string, stdout, stderr io.Writer) error {
 		return err
 	}
 	fmt.Fprintf(stdout, "enabled package %s in %s\n", storedRef, configPath)
+	return nil
+}
+
+// runAdd is the one-command receiver path (#77): pull a published package,
+// show what it contains, ask permission, then enable it - fetch, inspect,
+// and enable in one step instead of three separate commands. This is what
+// the bootstrap prompt (#98) and `lineage add`'s own direct users both
+// build on.
+func runAdd(args []string, home string, stdin io.Reader, stdout, stderr io.Writer) error {
+	if len(args) > 0 && isHelpFlag(args[0]) {
+		fmt.Fprintln(stdout, "usage: lineage add <package-ref> [--yes]\n\nFetch a published package, show what it contains, ask permission, then enable it in the current project - the one-command receiver path.")
+		return nil
+	}
+	if len(args) < 1 {
+		err := fmt.Errorf("usage: lineage add <package-ref> [--yes]")
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	ref := args[0]
+	autoApprove := false
+	for _, a := range args[1:] {
+		if a == "--yes" || a == "-y" {
+			autoApprove = true
+			continue
+		}
+		err := fmt.Errorf("usage: lineage add <package-ref> [--yes]")
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	destParent := config.UserPackagesDir(home)
+	if err := os.MkdirAll(destParent, 0o755); err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	cfg := packages.RegistryConfig{URL: os.Getenv("LINEAGE_REGISTRY_URL")}
+	name, err := packages.Pull(ref, cfg, destParent, "")
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	pkg, err := packages.Discover(filepath.Join(destParent, name))
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	fmt.Fprintf(stdout, "fetched %s@%s\n", pkg.Manifest.Name, pkg.Manifest.Version)
+	fmt.Fprintf(stdout, "digest: %s\n", emptyValue(pkg.Digest))
+	if pkg.Manifest.Description != "" {
+		fmt.Fprintf(stdout, "description: %s\n", pkg.Manifest.Description)
+	}
+	fmt.Fprintf(stdout, "skills: %s\n", listValue(pkg.Skills))
+	fmt.Fprintf(stdout, "workflows: %s\n", listValue(pkg.Workflows))
+	fmt.Fprintf(stdout, "agents: %s\n", listValue(pkg.Agents))
+	fmt.Fprintf(stdout, "policies: %s\n", listValue(pkg.Policies))
+	fmt.Fprintf(stdout, "capabilities:\n")
+	fmt.Fprintf(stdout, "  filesystem.read: %s\n", listValue(pkg.Manifest.Capabilities.Filesystem.Read))
+	fmt.Fprintf(stdout, "  network: %s\n", listValue(pkg.Manifest.Capabilities.Network))
+
+	if !autoApprove {
+		fmt.Fprint(stdout, "\nEnable this package in the current project? [y/N] ")
+		if !confirm(stdin) {
+			fmt.Fprintf(stdout, "not enabled. It's still available locally - run `lineage enable %s` when you're ready.\n", name)
+			return nil
+		}
+	}
+
+	fmt.Fprintln(stdout)
+	if err := enableRef(name, home, stdout, stderr); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(stdout, "\nReady. Run `lineage run <%s>` to use it.\n", providerNameList())
 	return nil
 }
 
@@ -988,6 +1072,7 @@ Package authoring:
   package import <file.tgz> [--as name]   install an archive locally
 
 Registry:
+  add <ref> [--yes]                       fetch, inspect, and enable a package in one step
   login                                   authorize with GitHub (device flow)
   logout                                  clear the stored credential
   whoami                                  show who publish/pull will act as


### PR DESCRIPTION
## Summary

Adds `lineage add <ref> [--yes]`: the one-command receiver path that fetches a published package, prints what it contains (skills, workflows, agents, policies, capabilities), asks permission, then enables it in the current project. Previously this took three separate commands (`package pull`, `package inspect`, `enable`). Refactors `runEnable`'s body into a shared `enableRef()` helper so `add` and `enable` share the exact same project-root resolution and dependency validation instead of a second, drifting implementation.

This is the necessary foundation for #98 (the copy-paste bootstrap prompt for non-coders), which builds directly on `add`.

## Linked Issue

Closes #77

- [x] The linked issue is assigned to me.
- [ ] This PR targets `develop`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

This PR is stacked on the not-yet-merged `feat/cli-help-polish` (#95), since `add` depends on `isHelpFlag` and the grouped `printUsage()` from that branch. It should target `develop` once #95 merges — GitHub will retarget it automatically.

## Package Impact

- [x] Package discovery or enablement
- [x] Setup or permission flow
- [x] Tests only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- `TestAddUsage` / `TestAddHelp` - usage and `-h` output
- `TestAddFetchesInspectsAndEnablesWithYes` - full fetch/inspect/enable flow against a stub registry, `--yes` skips the prompt, output includes the inspect summary and the enabled package shows up in the project config
- `TestAddDeclinedDoesNotEnable` - declining the prompt leaves the package pulled locally (importable, still on disk) but does not create a project config or enable it

```text
go build ./...
go test ./...
go vet ./...
gofmt -l internal/ cmd/
```

All four pass/are clean. Also manually verified against the live production registry (agenticlineage.vercel.app): `add commit-message-helper --yes` in a clean receiver project correctly fetched, printed the inspect summary, enabled the package, and `lineage run claude --dry-run` showed the resulting launch plan; and the interactive decline path (`echo "n" | lineage add resume-workflow`) correctly declined without creating any project config.

## Notes For Reviewers

Stacked on #95 - the diff here is scoped to `runAdd`/`enableRef` plus the new `add_test.go`; the help-polish changes are #95's own diff and shouldn't be re-reviewed here.