### PR TITLE
Unify local and pulled artifact processing in lineage add

### DIFF
--- a/internal/cli/add_test.go
+++ b/internal/cli/add_test.go
@@ -163,3 +163,206 @@ func TestAddDeclinedDoesNotEnable(t *testing.T) {
 		t.Errorf("expected the package to still be pulled locally after declining: %v", err)
 	}
 }
+
+// buildArchive exports srcDir to a .tgz file under tmp and returns its path,
+// for tests exercising add's local-archive source (#71: a local .tgz and a
+// pulled ref converge on the same inspect -> confirm -> enable pipeline).
+func buildArchive(t *testing.T, tmp, srcDir string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := packages.Export(srcDir, &buf); err != nil {
+		t.Fatal(err)
+	}
+	archivePath := filepath.Join(tmp, filepath.Base(srcDir)+".tgz")
+	if err := os.WriteFile(archivePath, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return archivePath
+}
+
+func TestAddLocalArchiveInspectsAndEnablesWithYes(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	srcDir := filepath.Join(tmp, "changelog-writer")
+	if err := packages.InitPackage(srcDir, "changelog-writer"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	archivePath := buildArchive(t, tmp, srcDir)
+
+	t.Setenv(config.HomeEnv, home)
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"add", archivePath, "--yes"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("add error = %v stderr=%s", err, stderr.String())
+	}
+
+	out := stdout.String()
+	for _, want := range []string{"imported changelog-writer@0.1.0", "enabled package changelog-writer"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout = %q, want it to contain %q", out, want)
+		}
+	}
+
+	found, err := config.FindProjectConfig(project)
+	if err != nil {
+		t.Fatalf("expected a project config after add --yes: %v", err)
+	}
+	if !contains(found.Config.EnabledPackages, "changelog-writer") {
+		t.Errorf("enabled packages = %v, want changelog-writer", found.Config.EnabledPackages)
+	}
+}
+
+func TestAddDeclinedLocalArchiveDoesNotEnable(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	srcDir := filepath.Join(tmp, "notes-cleaner")
+	if err := packages.InitPackage(srcDir, "notes-cleaner"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	archivePath := buildArchive(t, tmp, srcDir)
+
+	t.Setenv(config.HomeEnv, home)
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	var stdout, stderr bytes.Buffer
+	stdin := strings.NewReader("n\n")
+	if err := Execute(nil, []string{"add", archivePath}, stdin, &stdout, &stderr); err != nil {
+		t.Fatalf("add error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "not enabled") {
+		t.Fatalf("stdout = %q, want a message confirming it was not enabled", stdout.String())
+	}
+	if _, err := config.FindProjectConfig(project); err == nil {
+		t.Fatal("expected no project config to exist after declining")
+	}
+}
+
+// TestAddRepeatedProcessingIsIdempotent covers #71's "make repeated
+// processing safe and idempotent": re-running add for a package already
+// present locally (from either source) must succeed as a no-op instead of
+// failing with "already exists", as long as the content matches.
+func TestAddRepeatedProcessingIsIdempotent(t *testing.T) {
+	for _, src := range []string{"pulled", "local archive"} {
+		t.Run(src, func(t *testing.T) {
+			tmp := t.TempDir()
+			home := filepath.Join(tmp, "home")
+			project := filepath.Join(tmp, "project")
+			srcDir := filepath.Join(tmp, "pkg")
+			if err := packages.InitPackage(srcDir, "idempotent-pkg"); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(project, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv(config.HomeEnv, home)
+			oldWd, _ := os.Getwd()
+			if err := os.Chdir(project); err != nil {
+				t.Fatal(err)
+			}
+			defer os.Chdir(oldWd)
+
+			var ref string
+			if src == "pulled" {
+				srv := addTestServer(t, "idempotent-pkg@0.1.0", srcDir)
+				defer srv.Close()
+				t.Setenv("LINEAGE_REGISTRY_URL", srv.URL)
+				ref = "idempotent-pkg@0.1.0"
+			} else {
+				ref = buildArchive(t, tmp, srcDir)
+			}
+
+			var first bytes.Buffer
+			if err := Execute(nil, []string{"add", ref, "--yes"}, nil, &first, &first); err != nil {
+				t.Fatalf("first add error = %v output=%s", err, first.String())
+			}
+
+			var second bytes.Buffer
+			if err := Execute(nil, []string{"add", ref, "--yes"}, nil, &second, &second); err != nil {
+				t.Fatalf("second add error = %v, want a no-op success, output=%s", err, second.String())
+			}
+			if !strings.Contains(second.String(), "already have idempotent-pkg@0.1.0") {
+				t.Errorf("second add output = %q, want it to report the package was already present", second.String())
+			}
+
+			found, err := config.FindProjectConfig(project)
+			if err != nil {
+				t.Fatalf("expected a project config: %v", err)
+			}
+			count := 0
+			for _, p := range found.Config.EnabledPackages {
+				if p == "idempotent-pkg" {
+					count++
+				}
+			}
+			if count != 1 {
+				t.Errorf("enabled_packages = %v, want exactly one idempotent-pkg entry, not %d", found.Config.EnabledPackages, count)
+			}
+		})
+	}
+}
+
+// TestAddDigestMismatchFailsClosed covers the other half of idempotent
+// reuse: if a package already exists locally under the same name but with
+// *different* content than what's being added, that's a real conflict, not
+// a no-op - add must fail rather than silently keep serving the stale copy.
+func TestAddDigestMismatchFailsClosed(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(config.HomeEnv, home)
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	// Something already lives locally under this name - deliberately
+	// different content than the archive add is about to bring in.
+	existingDir := filepath.Join(config.UserPackagesDir(home), "conflict-pkg")
+	if err := os.MkdirAll(existingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existingManifest := "schema: 1\nname: conflict-pkg\nversion: 0.1.0\ndescription: the version already on disk\nexports:\n    agents: []\n    workflows: []\nrequires:\n    skills: []\nentrypoints:\n    claude: \"\"\n    codex: \"\"\ncapabilities:\n    filesystem:\n        read: []\n    network: []\n"
+	if err := os.WriteFile(filepath.Join(existingDir, packages.ManifestFileName), []byte(existingManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srcDir := filepath.Join(tmp, "conflict-pkg-new")
+	if err := packages.InitPackage(srcDir, "conflict-pkg"); err != nil {
+		t.Fatal(err)
+	}
+	archivePath := buildArchive(t, tmp, srcDir)
+
+	var stdout, stderr bytes.Buffer
+	err := Execute(nil, []string{"add", archivePath, "--yes"}, nil, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("add error = nil, want a digest-mismatch error instead of silently keeping the stale local copy")
+	}
+	if !strings.Contains(stderr.String(), "different content") {
+		t.Errorf("stderr = %q, want it to explain the content differs", stderr.String())
+	}
+
+	if _, cfgErr := config.FindProjectConfig(project); cfgErr == nil {
+		t.Error("expected no project config to exist after a failed, conflicting add")
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -542,9 +542,52 @@ func enableRef(ref, home string, stdout, stderr io.Writer) error {
 // and enable in one step instead of three separate commands. This is what
 // the bootstrap prompt (#98) and `lineage add`'s own direct users both
 // build on.
+// importAddSource brings ref into destParent as an extracted, digest-
+// verified package directory, converging local .tgz archives and registry
+// refs on the exact same shape before the shared inspect -> confirm ->
+// enable pipeline in runAdd ever runs (#71) - nothing past this point
+// cares which kind of source a package came from. action names what
+// actually happened ("fetched", "imported", or "already have") so runAdd
+// can report it accurately instead of always claiming to have fetched.
+//
+// Re-running add for a package already present locally is a deliberate
+// no-op, not a failure: Import/Pull both refuse to overwrite an existing
+// package directory, so a second run would otherwise error even though
+// nothing is wrong. This treats that specific error as success as long as
+// the content matches (digests equal) - a genuine conflict, the same
+// name/version now resolving to different content, still fails loudly
+// instead of silently keeping the stale local copy.
+func importAddSource(ref, destParent string) (name, action string, err error) {
+	if info, statErr := os.Stat(ref); statErr == nil && !info.IsDir() {
+		f, openErr := os.Open(ref)
+		if openErr != nil {
+			return "", "", openErr
+		}
+		defer f.Close()
+		name, err = packages.Import(f, destParent, "")
+		action = "imported"
+	} else {
+		cfg := packages.RegistryConfig{URL: os.Getenv("LINEAGE_REGISTRY_URL")}
+		name, err = packages.Pull(ref, cfg, destParent, "")
+		action = "fetched"
+	}
+
+	var already *packages.ErrAlreadyImported
+	if errors.As(err, &already) {
+		existingDigest, digestErr := packages.ComputeDigest(already.Dest)
+		if digestErr == nil && existingDigest == already.Digest {
+			return already.Name, "already have", nil
+		}
+		if digestErr == nil {
+			return "", "", fmt.Errorf("package %q already exists locally with different content (local digest %s, requested digest %s); remove %s first if you want to replace it", already.Name, existingDigest, already.Digest, already.Dest)
+		}
+	}
+	return name, action, err
+}
+
 func runAdd(args []string, home string, stdin io.Reader, stdout, stderr io.Writer) error {
 	if len(args) > 0 && isHelpFlag(args[0]) {
-		fmt.Fprintln(stdout, "usage: lineage add <package-ref> [--yes]\n\nFetch a published package, show what it contains, ask permission, then enable it in the current project - the one-command receiver path.")
+		fmt.Fprintln(stdout, "usage: lineage add <package-ref> [--yes]\n\nFetch a published package, show what it contains, ask permission, then enable it in the current project - the one-command receiver path. <package-ref> is a registry ref (name or name@version), or the path to a local .tgz archive from `lineage package export`.")
 		return nil
 	}
 	if len(args) < 1 {
@@ -571,8 +614,7 @@ func runAdd(args []string, home string, stdin io.Reader, stdout, stderr io.Write
 		return err
 	}
 
-	cfg := packages.RegistryConfig{URL: os.Getenv("LINEAGE_REGISTRY_URL")}
-	name, err := packages.Pull(ref, cfg, destParent, "")
+	name, action, err := importAddSource(ref, destParent)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return err
@@ -584,7 +626,7 @@ func runAdd(args []string, home string, stdin io.Reader, stdout, stderr io.Write
 		return err
 	}
 
-	fmt.Fprintf(stdout, "fetched %s@%s\n", pkg.Manifest.Name, pkg.Manifest.Version)
+	fmt.Fprintf(stdout, "%s %s@%s\n", action, pkg.Manifest.Name, pkg.Manifest.Version)
 	fmt.Fprintf(stdout, "digest: %s\n", emptyValue(pkg.Digest))
 	if pkg.Manifest.Description != "" {
 		fmt.Fprintf(stdout, "description: %s\n", pkg.Manifest.Description)

--- a/internal/packages/import.go
+++ b/internal/packages/import.go
@@ -21,6 +21,23 @@ import (
 // overwrites an existing package directory; it fails rather than silently
 // clobbering one.
 //
+// ErrAlreadyImported is returned by Import when destParent already has a
+// package directory under the name Import resolved (asName, or the
+// manifest's own name). Digest is the digest of the content Import was
+// just asked to import, computed before it discovered the conflict - a
+// caller that wants idempotent-reuse semantics (re-running the same
+// import is a no-op, not a failure) can compare Digest against the
+// existing directory's own digest instead of re-deriving either value.
+type ErrAlreadyImported struct {
+	Name   string
+	Dest   string
+	Digest string
+}
+
+func (e *ErrAlreadyImported) Error() string {
+	return fmt.Sprintf("package %q already exists at %s; remove it first or import with --as to use a different name", e.Name, e.Dest)
+}
+
 // Import returns the name the package was imported under.
 func Import(r io.Reader, destParent, asName string) (string, error) {
 	tmp, err := os.MkdirTemp("", "lineage-import-*")
@@ -48,7 +65,7 @@ func Import(r io.Reader, destParent, asName string) (string, error) {
 
 	dest := filepath.Join(destParent, name)
 	if _, err := os.Stat(dest); err == nil {
-		return "", fmt.Errorf("package %q already exists at %s; remove it first or import with --as to use a different name", name, dest)
+		return "", &ErrAlreadyImported{Name: name, Dest: dest, Digest: report.Digest}
 	} else if !os.IsNotExist(err) {
 		return "", fmt.Errorf("check destination %s: %w", dest, err)
 	}


### PR DESCRIPTION
## Summary

`lineage add <package-ref>` now accepts either a registry ref (`name` or `name@version`) or the path to a local `.tgz` archive produced by `lineage package export`. Both converge on the exact same import -> discover -> confirm -> enable pipeline - previously `add` only handled the pulled case, and a local archive needed three separate commands (`package import`, then `enable`) with no inspect-and-confirm step in between.

While unifying the two, I found a real gap: re-running `add` for a package already present locally used to hard-fail with "already exists", because `Import`/`Pull` both refuse to overwrite an existing package directory. That's not what "safe, idempotent repeated processing" should look like. Fixed by adding `packages.ErrAlreadyImported` (Name/Dest/Digest) so `add` can recognize that specific case, verify the existing local copy's digest still matches what's being added, and treat a match as a no-op success. A genuine conflict (same name, different content) still fails closed with a clear error - it does not silently keep serving the stale copy.

## Linked Issue

Closes #71

- [x] The linked issue is assigned to me.
- [ ] This PR targets `develop`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [x] Package discovery or enablement
- [x] Setup or permission flow

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- `TestAddLocalArchiveInspectsAndEnablesWithYes` / `TestAddDeclinedLocalArchiveDoesNotEnable` - local `.tgz` source goes through the same inspect/confirm/enable behavior as a pulled ref, including declining cleanly
- `TestAddRepeatedProcessingIsIdempotent` (table test, both sources) - re-running add for an already-present package succeeds as a no-op, doesn't duplicate the `enabled_packages` entry
- `TestAddDigestMismatchFailsClosed` - a genuine name/content conflict fails with a clear error instead of silently keeping the stale local copy

```text
go build ./...
go test ./...
go vet ./...
gofmt -l internal/ cmd/
```

All pass/clean. Also manually verified against a real build: exported a package to `.tgz`, ran `add <path> --yes` (imported, enabled, correct summary), then ran it again (`already have ...`, exit 0, `enabled_packages` still has exactly one entry).

## Notes For Reviewers

I checked whether changing `Import`'s "already exists" error to a typed error breaks anything relying on the old message text - nothing does; the `Error()` string is preserved byte-for-byte, so `lineage package import`'s own behavior/output is unchanged for the case that isn't going through `add`'s new idempotent-reuse check.