### PR TITLE
Add package setup playbook

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -58,7 +58,7 @@ func Execute(ctx context.Context, args []string, stdin io.Reader, stdout, stderr
 	case "add":
 		return runAdd(args[1:], home, stdin, stdout, stderr)
 	case "enable":
-		return runEnable(args[1:], home, stdout, stderr)
+		return runEnable(args[1:], home, stdin, stdout, stderr)
 	case "list":
 		return runList(home, stdout, stderr)
 	case "disable":
@@ -439,20 +439,47 @@ func emptyValue(value string) string {
 	return value
 }
 
-func runEnable(args []string, home string, stdout, stderr io.Writer) error {
-	if len(args) != 1 {
-		err := fmt.Errorf("usage: lineage enable <package-path-or-id>")
+// describeSuffix formats a setup item's optional description for the
+// setup plan printout: " - <description>" if present, otherwise nothing.
+func describeSuffix(description string) string {
+	if description == "" {
+		return ""
+	}
+	return " - " + description
+}
+
+func runEnable(args []string, home string, stdin io.Reader, stdout, stderr io.Writer) error {
+	if len(args) > 0 && isHelpFlag(args[0]) {
+		fmt.Fprintln(stdout, "usage: lineage enable <package-path-or-id> [--yes]\n\nEnable a package in the current project. If the package declares setup - tracker files or directories its workflow expects - shows the plan and asks permission before creating anything; --yes skips that prompt.")
+		return nil
+	}
+	ref := ""
+	autoApprove := false
+	for _, a := range args {
+		if a == "--yes" || a == "-y" {
+			autoApprove = true
+			continue
+		}
+		if ref != "" {
+			err := fmt.Errorf("usage: lineage enable <package-path-or-id> [--yes]")
+			fmt.Fprintln(stderr, err)
+			return err
+		}
+		ref = a
+	}
+	if ref == "" {
+		err := fmt.Errorf("usage: lineage enable <package-path-or-id> [--yes]")
 		fmt.Fprintln(stderr, err)
 		return err
 	}
-	return enableRef(args[0], home, stdout, stderr)
+	return enableRef(ref, home, autoApprove, stdin, stdout, stderr)
 }
 
 // enableRef is runEnable's actual work, factored out so `lineage add`
 // (which pulls a package and then enables it in one command) shares the
-// exact same project-root resolution and dependency validation instead of
-// a second, drifting implementation.
-func enableRef(ref, home string, stdout, stderr io.Writer) error {
+// exact same project-root resolution, dependency validation, and setup
+// handling instead of a second, drifting implementation.
+func enableRef(ref, home string, autoApprove bool, stdin io.Reader, stdout, stderr io.Writer) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		fmt.Fprintln(stderr, err)
@@ -526,6 +553,49 @@ func enableRef(ref, home string, stdout, stderr io.Writer) error {
 	if err := packages.ValidateDependencies(resolvedForValidation); err != nil {
 		fmt.Fprintln(stderr, err)
 		return err
+	}
+
+	// A package can declare local setup (#72) - tracker files or
+	// directories its workflow expects to exist. Show exactly what would
+	// be created and get permission before writing anything; declining
+	// leaves the workspace completely unchanged, same as declining to
+	// enable at all, rather than enabling into a half-set-up state.
+	manifest, err := packages.LoadManifest(resolvedPath)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	setupPlan, err := packages.PlanSetup(projectRoot, manifest.Setup)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	if setupPlan.NeedsAction() {
+		fmt.Fprintf(stdout, "%s wants to set up:\n", manifest.Name)
+		for _, f := range setupPlan.Files {
+			if f.Exists {
+				continue
+			}
+			fmt.Fprintf(stdout, "  create file %s%s\n", f.Path, describeSuffix(f.Description))
+		}
+		for _, d := range setupPlan.Directories {
+			if d.Exists {
+				continue
+			}
+			fmt.Fprintf(stdout, "  create directory %s%s\n", d.Path, describeSuffix(d.Description))
+		}
+		if !autoApprove {
+			fmt.Fprint(stdout, "Create these? [y/N] ")
+			if !confirm(stdin) {
+				fmt.Fprintln(stdout, "not enabled - setup was declined. Nothing was created or changed.")
+				return nil
+			}
+		}
+		if err := packages.ApplySetup(projectRoot, setupPlan); err != nil {
+			fmt.Fprintln(stderr, err)
+			return err
+		}
+		fmt.Fprintln(stdout, "setup complete.")
 	}
 
 	cfg.EnabledPackages = newEnabled
@@ -606,7 +676,7 @@ func runAdd(args []string, home string, stdin io.Reader, stdout, stderr io.Write
 	}
 
 	fmt.Fprintln(stdout)
-	if err := enableRef(name, home, stdout, stderr); err != nil {
+	if err := enableRef(name, home, autoApprove, stdin, stdout, stderr); err != nil {
 		return err
 	}
 
@@ -1080,7 +1150,7 @@ Registry:
   package pull <ref> [--as name]          fetch a published package
 
 Using a package:
-  enable <path-or-id>                     add a package to this project
+  enable <path-or-id> [--yes]              add a package to this project
   disable <path-or-id>                    remove a package from this project
   list                                    show enabled packages
   inspect <path-or-id>                    show a package's contents

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -1,0 +1,259 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agentic-lineage/lineage/internal/config"
+	"github.com/agentic-lineage/lineage/internal/packages"
+)
+
+// initPackageWithSetup scaffolds a package under project that declares one
+// tracker file and one directory as setup requirements (#72).
+func initPackageWithSetup(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := packages.InitPackage(dir, name); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := packages.LoadManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest.Setup = packages.Setup{
+		Files:       []packages.SetupFile{{Path: "tasks.csv", Description: "tracks work items", Template: "title,owner,status\n"}},
+		Directories: []packages.SetupDirectory{{Path: "notes", Description: "workflow output"}},
+	}
+	if err := packages.SaveManifest(dir, manifest); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnableSetupPromptsAndCreatesOnApproval(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	pkgDir := filepath.Join(project, "tracker-pack")
+	initPackageWithSetup(t, pkgDir, "tracker-pack")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(config.HomeEnv, home)
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	var stdout, stderr bytes.Buffer
+	stdin := strings.NewReader("y\n")
+	if err := Execute(nil, []string{"enable", "./tracker-pack"}, stdin, &stdout, &stderr); err != nil {
+		t.Fatalf("enable error = %v stderr=%s", err, stderr.String())
+	}
+
+	out := stdout.String()
+	for _, want := range []string{"tracker-pack wants to set up", "create file tasks.csv - tracks work items", "create directory notes - workflow output", "setup complete", "enabled package"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout = %q, want it to contain %q", out, want)
+		}
+	}
+
+	if got, err := os.ReadFile(filepath.Join(project, "tasks.csv")); err != nil || string(got) != "title,owner,status\n" {
+		t.Errorf("tasks.csv = %q, err=%v, want the declared template content", got, err)
+	}
+	if info, err := os.Stat(filepath.Join(project, "notes")); err != nil || !info.IsDir() {
+		t.Error("expected notes/ to be created as a directory")
+	}
+	found, err := config.FindProjectConfig(project)
+	if err != nil {
+		t.Fatalf("expected a project config: %v", err)
+	}
+	if !contains(found.Config.EnabledPackages, "./tracker-pack") {
+		t.Errorf("enabled packages = %v, want ./tracker-pack", found.Config.EnabledPackages)
+	}
+}
+
+func TestEnableSetupDeclinedLeavesWorkspaceUnchanged(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	pkgDir := filepath.Join(project, "tracker-pack")
+	initPackageWithSetup(t, pkgDir, "tracker-pack")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(config.HomeEnv, home)
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	var stdout, stderr bytes.Buffer
+	stdin := strings.NewReader("n\n")
+	if err := Execute(nil, []string{"enable", "./tracker-pack"}, stdin, &stdout, &stderr); err != nil {
+		t.Fatalf("enable error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "not enabled - setup was declined") {
+		t.Errorf("stdout = %q, want a message confirming setup was declined", stdout.String())
+	}
+
+	if _, err := os.Stat(filepath.Join(project, "tasks.csv")); !os.IsNotExist(err) {
+		t.Errorf("tasks.csv stat err = %v, want it to not exist after declining", err)
+	}
+	if _, err := os.Stat(filepath.Join(project, "notes")); !os.IsNotExist(err) {
+		t.Errorf("notes/ stat err = %v, want it to not exist after declining", err)
+	}
+	if _, err := config.FindProjectConfig(project); err == nil {
+		t.Error("expected no project config after declining setup - the package must not be enabled either")
+	}
+}
+
+func TestEnableSetupYesFlagSkipsPrompt(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	pkgDir := filepath.Join(project, "tracker-pack")
+	initPackageWithSetup(t, pkgDir, "tracker-pack")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(config.HomeEnv, home)
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	var stdout, stderr bytes.Buffer
+	// No stdin reader at all - if enable tried to read a confirmation
+	// despite --yes, this would fail/hang instead of silently passing.
+	if err := Execute(nil, []string{"enable", "./tracker-pack", "--yes"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("enable --yes error = %v stderr=%s", err, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(project, "tasks.csv")); err != nil {
+		t.Errorf("expected tasks.csv to be created under --yes without a prompt: %v", err)
+	}
+}
+
+func TestEnableSetupAlreadyPresentSkipsPromptEntirely(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	pkgDir := filepath.Join(project, "tracker-pack")
+	initPackageWithSetup(t, pkgDir, "tracker-pack")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The receiver already has their own tasks.csv and notes/ - setup has
+	// nothing to do, so it must not prompt at all (#72: repeated
+	// processing / a project that already has everything is a no-op).
+	if err := os.WriteFile(filepath.Join(project, "tasks.csv"), []byte("their own content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(project, "notes"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(config.HomeEnv, home)
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	var stdout, stderr bytes.Buffer
+	// No stdin reader - a prompt here (with nothing to answer it) would
+	// cause a read error, which Execute would surface as a non-nil error.
+	if err := Execute(nil, []string{"enable", "./tracker-pack"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("enable error = %v stderr=%s, want no prompt when everything already exists", err, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "wants to set up") {
+		t.Errorf("stdout = %q, want no setup plan printed when nothing needs creating", stdout.String())
+	}
+	got, err := os.ReadFile(filepath.Join(project, "tasks.csv"))
+	if err != nil || string(got) != "their own content\n" {
+		t.Errorf("tasks.csv = %q, err=%v, want the receiver's own content left untouched", got, err)
+	}
+}
+
+// TestEnableSetupReRunIsIdempotent covers #72's "repeated processing" and
+// "resumable" requirements directly: enabling the same package a second
+// time must not re-prompt (nothing new to create) and must not disturb
+// what the first run already created.
+func TestEnableSetupReRunIsIdempotent(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	pkgDir := filepath.Join(project, "tracker-pack")
+	initPackageWithSetup(t, pkgDir, "tracker-pack")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(config.HomeEnv, home)
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	var first bytes.Buffer
+	if err := Execute(nil, []string{"enable", "./tracker-pack", "--yes"}, nil, &first, &first); err != nil {
+		t.Fatalf("first enable error = %v output=%s", err, first.String())
+	}
+	if err := os.WriteFile(filepath.Join(project, "tasks.csv"), []byte("edited by the receiver\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var second bytes.Buffer
+	// No stdin - a second, unwanted setup prompt here would fail the test
+	// instead of silently passing, since NeedsAction() should be false.
+	if err := Execute(nil, []string{"enable", "./tracker-pack"}, nil, &second, &second); err != nil {
+		t.Fatalf("second enable error = %v output=%s", err, second.String())
+	}
+	if strings.Contains(second.String(), "wants to set up") {
+		t.Errorf("second enable output = %q, want no setup plan - everything already exists", second.String())
+	}
+
+	got, err := os.ReadFile(filepath.Join(project, "tasks.csv"))
+	if err != nil || string(got) != "edited by the receiver\n" {
+		t.Errorf("tasks.csv = %q, err=%v, want the receiver's edit preserved across the re-run", got, err)
+	}
+}
+
+func TestAddWithSetupYesAppliesWithoutPrompt(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	srcDir := filepath.Join(tmp, "tracker-pack")
+	initPackageWithSetup(t, srcDir, "tracker-pack")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ref := "tracker-pack@0.1.0"
+	srv := addTestServer(t, ref, srcDir)
+	defer srv.Close()
+
+	t.Setenv(config.HomeEnv, home)
+	t.Setenv("LINEAGE_REGISTRY_URL", srv.URL)
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"add", ref, "--yes"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("add --yes error = %v stderr=%s", err, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(project, "tasks.csv")); err != nil {
+		t.Errorf("expected tasks.csv to be created via add --yes without a prompt: %v", err)
+	}
+}

--- a/internal/packages/manifest.go
+++ b/internal/packages/manifest.go
@@ -24,6 +24,32 @@ type Manifest struct {
 	Requires     Requires     `yaml:"requires"`
 	Entrypoints  Entrypoints  `yaml:"entrypoints"`
 	Capabilities Capabilities `yaml:"capabilities"`
+	Setup        Setup        `yaml:"setup"`
+}
+
+// Setup declares local resources a package's workflow expects to exist -
+// tracker files and directories - so a receiver sees and approves exactly
+// what will be created before anything is, instead of a workflow silently
+// assuming files exist or creating them itself without asking (#72).
+type Setup struct {
+	Files       []SetupFile      `yaml:"files"`
+	Directories []SetupDirectory `yaml:"directories"`
+}
+
+// SetupFile is a single local file a package wants to exist, relative to
+// the project root. Template is its initial content if the file doesn't
+// already exist; a file already present at Path is never overwritten.
+type SetupFile struct {
+	Path        string `yaml:"path"`
+	Description string `yaml:"description"`
+	Template    string `yaml:"template"`
+}
+
+// SetupDirectory is a single local directory a package wants to exist,
+// relative to the project root (e.g. an output or notes directory).
+type SetupDirectory struct {
+	Path        string `yaml:"path"`
+	Description string `yaml:"description"`
 }
 
 type Exports struct {
@@ -69,6 +95,10 @@ func DefaultManifest(name string) Manifest {
 		Capabilities: Capabilities{
 			Filesystem: FilesystemCapabilities{Read: []string{}},
 			Network:    []string{},
+		},
+		Setup: Setup{
+			Files:       []SetupFile{},
+			Directories: []SetupDirectory{},
 		},
 	}
 }

--- a/internal/packages/setup.go
+++ b/internal/packages/setup.go
@@ -1,0 +1,126 @@
+package packages
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// SetupPlan is what applying a package's Setup declarations against a
+// project root would do: every declared file/directory, and whether it
+// already exists (a no-op) or would be created. Computing this separately
+// from ApplySetup is what lets a caller show "here's what will happen"
+// and get permission before anything is written (#72).
+type SetupPlan struct {
+	Files       []SetupFileAction
+	Directories []SetupDirectoryAction
+}
+
+// NeedsAction reports whether applying plan would actually create
+// anything. A plan where every declared file and directory already exists
+// doesn't need a permission prompt - there's nothing new to approve.
+func (p SetupPlan) NeedsAction() bool {
+	for _, f := range p.Files {
+		if !f.Exists {
+			return true
+		}
+	}
+	for _, d := range p.Directories {
+		if !d.Exists {
+			return true
+		}
+	}
+	return false
+}
+
+type SetupFileAction struct {
+	Path        string // relative to the project root
+	Description string
+	Template    string
+	Exists      bool
+}
+
+type SetupDirectoryAction struct {
+	Path        string // relative to the project root
+	Description string
+	Exists      bool
+}
+
+// PlanSetup resolves every path setup declares against projectRoot and
+// checks what's already there, without creating anything. A setup path is
+// publisher-declared, untrusted input like every other package-controlled
+// path in this project, so it goes through SafeJoin the same way archive
+// entries and manifest-declared entrypoints do.
+func PlanSetup(projectRoot string, setup Setup) (SetupPlan, error) {
+	var plan SetupPlan
+	for _, f := range setup.Files {
+		abs, err := SafeJoin(projectRoot, f.Path)
+		if err != nil {
+			return SetupPlan{}, fmt.Errorf("setup file %q: %w", f.Path, err)
+		}
+		_, statErr := os.Stat(abs)
+		if statErr != nil && !os.IsNotExist(statErr) {
+			return SetupPlan{}, fmt.Errorf("check setup file %q: %w", f.Path, statErr)
+		}
+		plan.Files = append(plan.Files, SetupFileAction{
+			Path:        f.Path,
+			Description: f.Description,
+			Template:    f.Template,
+			Exists:      statErr == nil,
+		})
+	}
+	for _, d := range setup.Directories {
+		abs, err := SafeJoin(projectRoot, d.Path)
+		if err != nil {
+			return SetupPlan{}, fmt.Errorf("setup directory %q: %w", d.Path, err)
+		}
+		_, statErr := os.Stat(abs)
+		if statErr != nil && !os.IsNotExist(statErr) {
+			return SetupPlan{}, fmt.Errorf("check setup directory %q: %w", d.Path, statErr)
+		}
+		plan.Directories = append(plan.Directories, SetupDirectoryAction{
+			Path:        d.Path,
+			Description: d.Description,
+			Exists:      statErr == nil,
+		})
+	}
+	return plan, nil
+}
+
+// ApplySetup creates whatever plan says doesn't already exist: missing
+// files get their declared template content, missing directories get
+// created empty. Anything already present is left completely untouched -
+// this is what makes ApplySetup safe to call more than once (#72's
+// idempotent/resumable requirement): a second call after a first partial
+// success only creates what's still missing, and a call against a project
+// that already has everything does nothing at all.
+func ApplySetup(projectRoot string, plan SetupPlan) error {
+	for _, f := range plan.Files {
+		if f.Exists {
+			continue
+		}
+		abs, err := SafeJoin(projectRoot, f.Path)
+		if err != nil {
+			return fmt.Errorf("setup file %q: %w", f.Path, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			return fmt.Errorf("create directory for %q: %w", f.Path, err)
+		}
+		if err := os.WriteFile(abs, []byte(f.Template), 0o644); err != nil {
+			return fmt.Errorf("create %q: %w", f.Path, err)
+		}
+	}
+	for _, d := range plan.Directories {
+		if d.Exists {
+			continue
+		}
+		abs, err := SafeJoin(projectRoot, d.Path)
+		if err != nil {
+			return fmt.Errorf("setup directory %q: %w", d.Path, err)
+		}
+		if err := os.MkdirAll(abs, 0o755); err != nil {
+			return fmt.Errorf("create directory %q: %w", d.Path, err)
+		}
+	}
+	return nil
+}

--- a/internal/packages/setup_test.go
+++ b/internal/packages/setup_test.go
@@ -1,0 +1,137 @@
+package packages
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPlanSetupReportsExistingVsMissing(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "tasks.csv"), "title,owner,status\n")
+
+	setup := Setup{
+		Files: []SetupFile{
+			{Path: "tasks.csv", Template: "title,owner,status\n"},
+			{Path: "notes/log.md", Template: "# Log\n"},
+		},
+		Directories: []SetupDirectory{
+			{Path: "output"},
+		},
+	}
+
+	plan, err := PlanSetup(root, setup)
+	if err != nil {
+		t.Fatalf("PlanSetup() error = %v", err)
+	}
+	if len(plan.Files) != 2 || !plan.Files[0].Exists || plan.Files[1].Exists {
+		t.Fatalf("plan.Files = %+v, want [tasks.csv Exists=true, notes/log.md Exists=false]", plan.Files)
+	}
+	if len(plan.Directories) != 1 || plan.Directories[0].Exists {
+		t.Fatalf("plan.Directories = %+v, want [output Exists=false]", plan.Directories)
+	}
+	if !plan.NeedsAction() {
+		t.Error("NeedsAction() = false, want true - notes/log.md and output/ are both missing")
+	}
+}
+
+func TestPlanSetupNeedsActionFalseWhenEverythingExists(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "tasks.csv"), "title\n")
+	if err := os.MkdirAll(filepath.Join(root, "output"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	setup := Setup{
+		Files:       []SetupFile{{Path: "tasks.csv", Template: "title\n"}},
+		Directories: []SetupDirectory{{Path: "output"}},
+	}
+	plan, err := PlanSetup(root, setup)
+	if err != nil {
+		t.Fatalf("PlanSetup() error = %v", err)
+	}
+	if plan.NeedsAction() {
+		t.Error("NeedsAction() = true, want false - both already exist")
+	}
+}
+
+func TestPlanSetupRejectsUnsafePaths(t *testing.T) {
+	root := t.TempDir()
+	for _, setup := range []Setup{
+		{Files: []SetupFile{{Path: "../escape.csv"}}},
+		{Files: []SetupFile{{Path: "/etc/passwd"}}},
+		{Directories: []SetupDirectory{{Path: "../escape-dir"}}},
+	} {
+		if _, err := PlanSetup(root, setup); err == nil {
+			t.Errorf("PlanSetup(%+v) error = nil, want an error for an unsafe path", setup)
+		}
+	}
+}
+
+func TestApplySetupCreatesOnlyWhatsMissing(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "tasks.csv"), "custom content the receiver already had\n")
+
+	setup := Setup{
+		Files: []SetupFile{
+			{Path: "tasks.csv", Template: "title,owner,status\n"},
+			{Path: "notes/log.md", Template: "# Log\n"},
+		},
+		Directories: []SetupDirectory{{Path: "output"}},
+	}
+	plan, err := PlanSetup(root, setup)
+	if err != nil {
+		t.Fatalf("PlanSetup() error = %v", err)
+	}
+	if err := ApplySetup(root, plan); err != nil {
+		t.Fatalf("ApplySetup() error = %v", err)
+	}
+
+	// The file that already existed must be left completely untouched -
+	// ApplySetup never overwrites existing content.
+	got, err := os.ReadFile(filepath.Join(root, "tasks.csv"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "custom content the receiver already had\n" {
+		t.Errorf("tasks.csv content = %q, want the pre-existing content preserved", got)
+	}
+
+	// The missing file and directory must now exist with the declared content.
+	got, err = os.ReadFile(filepath.Join(root, "notes", "log.md"))
+	if err != nil {
+		t.Fatalf("expected notes/log.md to be created: %v", err)
+	}
+	if string(got) != "# Log\n" {
+		t.Errorf("notes/log.md content = %q, want %q", got, "# Log\n")
+	}
+	if info, err := os.Stat(filepath.Join(root, "output")); err != nil || !info.IsDir() {
+		t.Errorf("expected output/ to be created as a directory")
+	}
+}
+
+func TestApplySetupIsIdempotent(t *testing.T) {
+	root := t.TempDir()
+	setup := Setup{
+		Files:       []SetupFile{{Path: "tasks.csv", Template: "title,owner,status\n"}},
+		Directories: []SetupDirectory{{Path: "output"}},
+	}
+
+	for i := 0; i < 2; i++ {
+		plan, err := PlanSetup(root, setup)
+		if err != nil {
+			t.Fatalf("PlanSetup() call %d error = %v", i, err)
+		}
+		if err := ApplySetup(root, plan); err != nil {
+			t.Fatalf("ApplySetup() call %d error = %v", i, err)
+		}
+	}
+
+	got, err := os.ReadFile(filepath.Join(root, "tasks.csv"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "title,owner,status\n" {
+		t.Errorf("tasks.csv content = %q after two applies, want unchanged template content", got)
+	}
+}

--- a/internal/packages/validate.go
+++ b/internal/packages/validate.go
@@ -55,6 +55,23 @@ func Validate(dir string) (ValidateReport, error) {
 		report.Errors = append(report.Errors, err.Error())
 	}
 
+	// Setup paths are receiver-project-relative at apply time, but their
+	// safety (not absolute, can't escape via "..") doesn't depend on which
+	// root they're eventually resolved against - catch a bad declaration
+	// here, at publish time, rather than only when some future receiver
+	// tries to enable the package. dir stands in for "some root" purely to
+	// exercise the same check validateEntrypoint already relies on.
+	for _, f := range manifest.Setup.Files {
+		if _, err := SafeJoin(dir, f.Path); err != nil {
+			report.Errors = append(report.Errors, fmt.Sprintf("setup.files: %v", err))
+		}
+	}
+	for _, d := range manifest.Setup.Directories {
+		if _, err := SafeJoin(dir, d.Path); err != nil {
+			report.Errors = append(report.Errors, fmt.Sprintf("setup.directories: %v", err))
+		}
+	}
+
 	discoveredSkills := discoverSkillNames(filepath.Join(dir, "skills"))
 	skillSet := make(map[string]bool, len(discoveredSkills))
 	for _, s := range discoveredSkills {

--- a/internal/packages/validate_test.go
+++ b/internal/packages/validate_test.go
@@ -75,6 +75,29 @@ func TestValidateRejectsTraversingEntrypoint(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsTraversingSetupPath(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "setup-traversal-pack")
+	if err := InitPackage(root, "setup-traversal-pack"); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := LoadManifest(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest.Setup.Files = []SetupFile{{Path: "../../etc/passwd"}}
+	if err := SaveManifest(root, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := Validate(root)
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if report.Passed() {
+		t.Fatal("report.Passed() = true, want false for a traversing setup file path")
+	}
+}
+
 func TestValidateNotesUnsatisfiedRequiredSkillWithoutFailing(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "dependent-pack")
 	if err := InitPackage(root, "dependent-pack"); err != nil {


### PR DESCRIPTION
## Summary

A package can now declare local setup its workflow expects, via a new manifest section:

```yaml
setup:
  files:
    - path: tasks.csv
      description: tracks work items
      template: "title,owner,status\n"
  directories:
    - path: notes
      description: workflow output
```

`lineage enable` resolves these against the project root, shows exactly what would be created, and asks permission before writing anything - declining leaves the workspace completely unchanged (nothing created, package not enabled), the same contract as declining to enable at all. `lineage add`'s existing `--yes` flag now also covers this new prompt, so the non-interactive receiver flow (bootstrap prompt, CI) stays fully unattended. A package with no setup declarations behaves exactly as before - no new prompt, no behavior change.

Idempotency doesn't need a separate state file: an existing file or directory is always left untouched and never re-prompted for, so re-running `enable` after a partial success (or just enabling again later) only creates what's still missing, and does nothing at all once everything's already there.

Setup paths are publisher-declared, untrusted input like every other package-controlled path in this project - checked with `SafeJoin` both at apply time and earlier, at `lineage package validate`/publish time, so an unsafe declaration is caught before a receiver ever sees it.

## Linked Issue

Closes #72

- [x] The linked issue is assigned to me.
- [ ] This PR targets `develop`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [x] Package format or manifest behavior
- [x] Package discovery or enablement
- [x] Setup or permission flow

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- `internal/packages/setup_test.go` - plan computation (existing vs. missing, unsafe paths rejected), apply only creates what's missing, apply is idempotent across repeated calls
- `TestValidateRejectsTraversingSetupPath` - a `../`-style setup path fails validation
- `internal/cli/setup_test.go` - prompts and creates on approval, declining leaves the workspace unchanged (no files, no enable), `--yes` skips the prompt, a project that already has everything is never prompted, a second `enable` call is idempotent and doesn't disturb the receiver's own edits, and `lineage add --yes` covers the same prompt end to end

```text
go build ./...
go test ./...
go vet ./...
gofmt -l internal/ cmd/
```

All pass/clean. Also manually verified against a real build: scaffolded a package with a tracker-file + directory setup declaration, ran `enable` interactively (plan printed correctly, approved, files created with the right content), then re-ran `enable` with no stdin available at all - no prompt, exit 0, confirming the no-op path never tries to read confirmation when there's nothing to create.

## Notes For Reviewers

I put the setup prompt inside `enableRef` (the function `runEnable` and `runAdd` both already funnel through) rather than a separate command, so both existing entry points share the same behavior instead of one of them silently skipping it. This does mean a package with setup declarations now has two sequential prompts when added interactively via `lineage add` (enable confirmation, then setup confirmation) - I considered collapsing them into one, but decided showing the file-creation plan as its own explicit, itemized decision was worth the extra prompt rather than folding "yes, enable" and "yes, also write these new files to disk" into a single generic yes/no.