### PR TITLE
Publish provider entrypoints and capabilities to the registry

### DIFF
--- a/internal/packages/manifest.go
+++ b/internal/packages/manifest.go
@@ -35,21 +35,25 @@ type Requires struct {
 	Skills []string `yaml:"skills"`
 }
 
+// Entrypoints and Capabilities carry both yaml and json tags: yaml for the
+// manifest file itself, json because Publish (#90) sends both verbatim to
+// the registry so a receiver can see provider compatibility and safety
+// notes before ever pulling the package, not just after enabling it.
 type Entrypoints struct {
-	Claude string `yaml:"claude"`
-	Codex  string `yaml:"codex"`
+	Claude string `yaml:"claude" json:"claude"`
+	Codex  string `yaml:"codex" json:"codex"`
 }
 
 // Capabilities is a purely declarative statement of what a package wants
 // access to — printed by lineage package validate and the enable-time plan
 // so a receiver can see it before enabling, not enforced by this build.
 type Capabilities struct {
-	Filesystem FilesystemCapabilities `yaml:"filesystem"`
-	Network    []string               `yaml:"network"`
+	Filesystem FilesystemCapabilities `yaml:"filesystem" json:"filesystem"`
+	Network    []string               `yaml:"network" json:"network"`
 }
 
 type FilesystemCapabilities struct {
-	Read []string `yaml:"read"`
+	Read []string `yaml:"read" json:"read"`
 }
 
 func DefaultManifest(name string) Manifest {

--- a/internal/packages/registry.go
+++ b/internal/packages/registry.go
@@ -74,6 +74,17 @@ func Publish(dir string, cfg RegistryConfig) (PublishResult, error) {
 	if report.Manifest.Description != "" {
 		q.Set("description", report.Manifest.Description)
 	}
+	// Provider compatibility and capabilities are already public,
+	// declarative information (visible to anyone running `lineage package
+	// validate` against the archive itself) - sending them lets a receiver
+	// see what a package targets and asks for before ever pulling it,
+	// rounding out #69's original directory scope (#90).
+	if entrypoints, err := json.Marshal(report.Manifest.Entrypoints); err == nil {
+		q.Set("entrypoints", string(entrypoints))
+	}
+	if capabilities, err := json.Marshal(report.Manifest.Capabilities); err == nil {
+		q.Set("capabilities", string(capabilities))
+	}
 
 	req, err := http.NewRequest(http.MethodPost, cfg.baseURL()+"/api/publish?"+q.Encode(), &buf)
 	if err != nil {

--- a/internal/packages/registry_test.go
+++ b/internal/packages/registry_test.go
@@ -12,6 +12,62 @@ import (
 	"testing"
 )
 
+// TestPublishIncludesEntrypointsAndCapabilities covers #90: provider
+// compatibility and capabilities are already public, declarative
+// information once a package validates - Publish must send them to the
+// registry so a receiver can see them before ever pulling the package.
+func TestPublishIncludesEntrypointsAndCapabilities(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "capable-pack")
+	if err := InitPackage(root, "capable-pack"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, "skills", "review", "SKILL.md"), "# Review")
+	manifest, err := LoadManifest(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest.Entrypoints = Entrypoints{Claude: "skills/review/SKILL.md"}
+	manifest.Capabilities = Capabilities{
+		Filesystem: FilesystemCapabilities{Read: []string{"./data"}},
+		Network:    []string{"api.example.com"},
+	}
+	if err := SaveManifest(root, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotEntrypoints, gotCapabilities string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEntrypoints = r.URL.Query().Get("entrypoints")
+		gotCapabilities = r.URL.Query().Get("capabilities")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"alreadyPublished": false})
+	}))
+	defer srv.Close()
+
+	if _, err := Publish(root, RegistryConfig{URL: srv.URL, Token: "test-token"}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	var entrypoints Entrypoints
+	if err := json.Unmarshal([]byte(gotEntrypoints), &entrypoints); err != nil {
+		t.Fatalf("entrypoints query param = %q, not valid JSON: %v", gotEntrypoints, err)
+	}
+	if entrypoints.Claude != "skills/review/SKILL.md" {
+		t.Errorf("entrypoints.Claude = %q, want skills/review/SKILL.md", entrypoints.Claude)
+	}
+
+	var capabilities Capabilities
+	if err := json.Unmarshal([]byte(gotCapabilities), &capabilities); err != nil {
+		t.Fatalf("capabilities query param = %q, not valid JSON: %v", gotCapabilities, err)
+	}
+	if len(capabilities.Filesystem.Read) != 1 || capabilities.Filesystem.Read[0] != "./data" {
+		t.Errorf("capabilities.Filesystem.Read = %v, want [./data]", capabilities.Filesystem.Read)
+	}
+	if len(capabilities.Network) != 1 || capabilities.Network[0] != "api.example.com" {
+		t.Errorf("capabilities.Network = %v, want [api.example.com]", capabilities.Network)
+	}
+}
+
 func TestPublishUploadsExportedArchive(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "publish-pack")
 	if err := InitPackage(root, "publish-pack"); err != nil {


### PR DESCRIPTION
## Summary

Part of #90 (surfacing provider compatibility and safety notes on the package directory). This is the CLI side: `lineage package publish` now sends the manifest's `entrypoints` and `capabilities` as JSON-encoded query params alongside the existing `name`/`version`/`digest`/`description`, matching the request's existing shape. This data was already public and declarative - visible in `lineage package validate`'s output - it just never reached the registry, so the website had nothing to show even though the source data exists at publish time.

No new manifest schema fields. `Entrypoints`/`Capabilities`/`FilesystemCapabilities` gain `json` tags matching their existing `yaml` tags so they marshal with the same field names already used in the manifest itself.

The website-side changes (storing these fields on the release, returning them from `/api/packages` and `/api/packages/:ref`, and showing them on the `/packages` directory and detail pages) land separately in `lineagelanding`, since this CLI change needs to exist first for that side to have anything real to test against.

## Linked Issue

Part of #90 (not closing - the acceptance criteria need the website side too)

- [x] The linked issue is assigned to me.
- [ ] This PR targets `develop`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [x] Package format or manifest behavior

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- `TestPublishIncludesEntrypointsAndCapabilities` - publishes a package with a real `claude` entrypoint and filesystem/network capabilities, confirms both round-trip through the request as valid JSON with the right values

```text
go build ./...
go test ./...
go vet ./...
gofmt -l internal/ cmd/
```

All pass/clean.

## Notes For Reviewers

This only changes what the CLI *sends*; the website's publish endpoint doesn't read these new query params yet; until that lands, they're harmlessly ignored by the current production registry. Safe to merge independently of the website change.