### PR TITLE
Add test coverage reporting to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,18 @@ jobs:
           go-version-file: go.mod
           cache: true
       - name: Test
-        run: go test ./...
+        run: go test -coverprofile=coverage.out ./...
+      - name: Coverage summary
+        run: |
+          go tool cover -func=coverage.out | tee coverage-summary.txt
+          {
+            echo "## Test Coverage"
+            echo '```'
+            cat coverage-summary.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload coverage profile
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.out


### PR DESCRIPTION
## Summary

Closes the last unaddressed piece of #12 - the rest of its scope was already satisfied by this cycle's test-driven development (see the closing comment on #12 for the full breakdown: 6 files now use `httptest.NewServer` for real integration-style tests, `go test ./...` remains the required check on both `develop` and `master`).

`go test` now runs with `-coverprofile`, prints a per-package/per-function summary directly to the job's step summary (visible on the PR's checks tab, no click-through into logs needed), and uploads the raw coverage profile as a build artifact for `go tool cover -html` locally. No external service (Codecov etc.), no hard coverage threshold gate - #12 only asked to "consider coverage reporting," and adding a merge-blocking threshold would be a bigger policy decision nobody's made.

Current baseline for reference: ~73% overall (`internal/cli` 66.5%, `internal/packages` 79.5%, `internal/auth` 72.2%, `internal/config` 60%, `internal/materialize` 84.1%, `internal/provider` 72.1%, `internal/runtime` 88.2%, `internal/shim` 83.3%).

## Linked Issue

Closes #12

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`, or it is a release-tracked promotion into `master`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [x] Tests only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- N/A - CI workflow change only, no Go code changed.

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- This only changes how the existing test suite's output is reported in CI, not what it tests. Verified by running `go test -coverprofile=coverage.out ./...` and `go tool cover -func=coverage.out` locally and confirming both commands succeed and produce the expected per-package breakdown (pasted above).

## Notes For Reviewers

`coverage.out`/`coverage.html` were already in `.gitignore` before this PR - nothing new needed there.