### PR TITLE
Closes #112: Add portability report to package compile and export flows

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -373,13 +373,21 @@ func runPackageExport(args []string, stdout, stderr io.Writer) error {
 		return err
 	}
 
+	report, err := packages.Validate(dir)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	portability := packages.NewPortabilityReport(report)
+	packages.WritePortabilityReport(stdout, portability)
+	if portability.HasBlockers() {
+		err := fmt.Errorf("package has unresolved portability blockers, refusing to export (%d blocker(s)); run `lineage package validate` for details", len(portability.Blockers))
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
 	if outPath == "" {
-		manifest, err := packages.LoadManifest(dir)
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return err
-		}
-		outPath = fmt.Sprintf("%s-%s.tgz", manifest.Name, manifest.Version)
+		outPath = fmt.Sprintf("%s-%s.tgz", report.Manifest.Name, report.Manifest.Version)
 	}
 
 	f, err := os.Create(outPath)
@@ -439,6 +447,7 @@ func runPackageValidate(dir string, yamlOutput bool, stdout, stderr io.Writer) e
 	fmt.Fprintf(stdout, "capabilities:\n")
 	fmt.Fprintf(stdout, "  filesystem.read: %s\n", listValue(report.Manifest.Capabilities.Filesystem.Read))
 	fmt.Fprintf(stdout, "  network: %s\n", listValue(report.Manifest.Capabilities.Network))
+	packages.WritePortabilityReport(stdout, packages.NewPortabilityReport(report))
 
 	if len(report.Notes) > 0 {
 		fmt.Fprintf(stdout, "notes:\n")

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -162,6 +162,53 @@ func TestPackageValidateFailsAndReportsErrors(t *testing.T) {
 	}
 }
 
+func TestPackageExportPrintsPortabilityReport(t *testing.T) {
+	root := t.TempDir()
+	pkgDir := filepath.Join(root, "export-report")
+	outPath := filepath.Join(root, "export-report.tgz")
+	if err := packages.InitPackage(pkgDir, "export-report"); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"package", "export", pkgDir, "-o", outPath}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("export error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "portability:\n  status: PASS") {
+		t.Fatalf("stdout = %q, want portability PASS report", stdout.String())
+	}
+	if _, err := os.Stat(outPath); err != nil {
+		t.Fatalf("expected export archive: %v", err)
+	}
+}
+
+func TestPackageExportRefusesPortabilityBlockersBeforeWritingArchive(t *testing.T) {
+	root := t.TempDir()
+	pkgDir := filepath.Join(root, "blocked-export-report")
+	outPath := filepath.Join(root, "blocked-export-report.tgz")
+	if err := packages.InitPackage(pkgDir, "blocked-export-report"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, ".env"), []byte("API_KEY=whatever"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := Execute(nil, []string{"package", "export", pkgDir, "-o", outPath}, nil, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("export error = nil, want portability blocker error")
+	}
+	if !strings.Contains(stdout.String(), "portability:\n  status: BLOCKED") {
+		t.Fatalf("stdout = %q, want portability BLOCKED report", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "unresolved portability blockers") {
+		t.Fatalf("stderr = %q, want portability blocker message", stderr.String())
+	}
+	if _, statErr := os.Stat(outPath); !os.IsNotExist(statErr) {
+		t.Fatalf("archive stat error = %v, want no archive written", statErr)
+	}
+}
+
 func TestRunUnknownProviderListsKnownProviders(t *testing.T) {
 	home := t.TempDir()
 	project := t.TempDir()

--- a/internal/cli/publish_pull_test.go
+++ b/internal/cli/publish_pull_test.go
@@ -85,6 +85,30 @@ func TestPackagePublishSucceeds(t *testing.T) {
 	}
 }
 
+func TestPackagePublishRefusesPortabilityBlockers(t *testing.T) {
+	root := t.TempDir()
+	pkgDir := filepath.Join(root, "blocked-publish")
+	if err := packages.InitPackage(pkgDir, "blocked-publish"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, ".env"), []byte("API_KEY=whatever"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(config.HomeEnv, filepath.Join(root, "home"))
+	t.Setenv("LINEAGE_PUBLISH_TOKEN", "test-token")
+	t.Setenv("LINEAGE_REGISTRY_URL", "http://unused.invalid")
+
+	var stdout, stderr bytes.Buffer
+	err := Execute(nil, []string{"package", "publish", pkgDir}, nil, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("publish error = nil, want portability blocker error")
+	}
+	if !strings.Contains(stderr.String(), "unresolved portability blockers") {
+		t.Fatalf("stderr = %q, want portability blocker message", stderr.String())
+	}
+}
+
 func TestPackagePullUsage(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	// Same top-level gate as TestPackagePublishUsage: a malformed --as flag

--- a/internal/cli/structured.go
+++ b/internal/cli/structured.go
@@ -18,21 +18,22 @@ import (
 // fails to discover cleanly; inspect has no pass/fail result) rather than
 // given a placeholder value that would look like real data.
 type PackageReport struct {
-	Name           string                    `yaml:"name"`
-	Version        string                    `yaml:"version"`
-	Schema         int                       `yaml:"schema"`
-	Path           string                    `yaml:"path,omitempty"`
-	Digest         string                    `yaml:"digest,omitempty"`
-	Description    string                    `yaml:"description,omitempty"`
-	Skills         []string                  `yaml:"skills,omitempty"`
-	Workflows      []string                  `yaml:"workflows,omitempty"`
-	Agents         []string                  `yaml:"agents,omitempty"`
-	Policies       []string                  `yaml:"policies,omitempty"`
-	RequiredSkills []string                  `yaml:"required_skills"`
-	Providers      []string                  `yaml:"providers"`
-	Capabilities   PackageReportCapabilities `yaml:"capabilities"`
-	Notes          []string                  `yaml:"notes,omitempty"`
-	Errors         []string                  `yaml:"errors,omitempty"`
+	Name           string                      `yaml:"name"`
+	Version        string                      `yaml:"version"`
+	Schema         int                         `yaml:"schema"`
+	Path           string                      `yaml:"path,omitempty"`
+	Digest         string                      `yaml:"digest,omitempty"`
+	Description    string                      `yaml:"description,omitempty"`
+	Skills         []string                    `yaml:"skills,omitempty"`
+	Workflows      []string                    `yaml:"workflows,omitempty"`
+	Agents         []string                    `yaml:"agents,omitempty"`
+	Policies       []string                    `yaml:"policies,omitempty"`
+	RequiredSkills []string                    `yaml:"required_skills"`
+	Providers      []string                    `yaml:"providers"`
+	Capabilities   PackageReportCapabilities   `yaml:"capabilities"`
+	Portability    *packages.PortabilityReport `yaml:"portability,omitempty"`
+	Notes          []string                    `yaml:"notes,omitempty"`
+	Errors         []string                    `yaml:"errors,omitempty"`
 	// Result is only meaningful for validate ("pass"/"fail"); inspect
 	// performs no validation, so it leaves this empty and omitted.
 	Result string `yaml:"result,omitempty"`
@@ -105,6 +106,8 @@ func validateReport(report packages.ValidateReport, discovered *packages.Package
 		Errors: nonNil(report.Errors),
 		Result: result,
 	}
+	portability := packages.NewPortabilityReport(report)
+	pr.Portability = &portability
 	if discovered != nil {
 		pr.Path = discovered.Path
 		pr.Skills = nonNil(discovered.Skills)

--- a/internal/cli/structured_test.go
+++ b/internal/cli/structured_test.go
@@ -62,6 +62,9 @@ func TestPackageValidateYAMLReportsFullPackage(t *testing.T) {
 	if len(report.Errors) != 0 {
 		t.Errorf("report.Errors = %v, want none", report.Errors)
 	}
+	if report.Portability == nil || report.Portability.Status != "PASS" {
+		t.Errorf("report.Portability = %+v, want PASS portability report", report.Portability)
+	}
 }
 
 func TestPackageValidateYAMLFailureExitsNonZeroWithErrors(t *testing.T) {
@@ -94,6 +97,9 @@ func TestPackageValidateYAMLFailureExitsNonZeroWithErrors(t *testing.T) {
 	}
 	if len(report.Errors) == 0 {
 		t.Error("report.Errors is empty, want the missing-export error listed")
+	}
+	if report.Portability == nil || report.Portability.Status != "BLOCKED" {
+		t.Errorf("report.Portability = %+v, want BLOCKED portability report", report.Portability)
 	}
 }
 

--- a/internal/packages/export.go
+++ b/internal/packages/export.go
@@ -31,8 +31,9 @@ func Export(dir string, w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	if !report.Passed() {
-		return fmt.Errorf("package failed validation, refusing to export (%d error(s)); run `lineage package validate` for details", len(report.Errors))
+	portability := NewPortabilityReport(report)
+	if portability.HasBlockers() {
+		return fmt.Errorf("package has unresolved portability blockers, refusing to export (%d blocker(s)); run `lineage package validate` for details", len(portability.Blockers))
 	}
 
 	files, err := contentFiles(dir)

--- a/internal/packages/export_test.go
+++ b/internal/packages/export_test.go
@@ -42,6 +42,23 @@ func TestExportRefusesWhenValidationFails(t *testing.T) {
 	}
 }
 
+func TestExportRefusesPortabilityBlockers(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "blocked-export")
+	if err := InitPackage(root, "blocked-export"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, ".env"), "API_KEY=whatever")
+
+	var buf bytes.Buffer
+	err := Export(root, &buf)
+	if err == nil {
+		t.Fatal("Export() error = nil, want error for unresolved portability blockers")
+	}
+	if !bytes.Contains([]byte(err.Error()), []byte("unresolved portability blockers")) {
+		t.Fatalf("Export() error = %v, want portability blocker message", err)
+	}
+}
+
 func TestExportIncludesManifestAndContentSortedOrder(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "content-pack")
 	if err := InitPackage(root, "content-pack"); err != nil {

--- a/internal/packages/portability.go
+++ b/internal/packages/portability.go
@@ -1,0 +1,85 @@
+package packages
+
+import (
+	"fmt"
+	"io"
+)
+
+type PortabilityReport struct {
+	Status                     string   `yaml:"status" json:"status"`
+	ValidationStatus           string   `yaml:"validation_status" json:"validation_status"`
+	Redactions                 []string `yaml:"redactions" json:"redactions"`
+	ParameterizedValues        []string `yaml:"parameterized_values" json:"parameterized_values"`
+	SetupRequirements          []string `yaml:"setup_requirements" json:"setup_requirements"`
+	ProviderCompatibilityNotes []string `yaml:"provider_compatibility_notes" json:"provider_compatibility_notes"`
+	Warnings                   []string `yaml:"warnings" json:"warnings"`
+	Blockers                   []string `yaml:"blockers" json:"blockers"`
+}
+
+func (r PortabilityReport) HasBlockers() bool {
+	return len(r.Blockers) > 0
+}
+
+func NewPortabilityReport(report ValidateReport) PortabilityReport {
+	portability := PortabilityReport{
+		Status:                     "PASS",
+		ValidationStatus:           "PASS",
+		Redactions:                 []string{},
+		ParameterizedValues:        []string{},
+		SetupRequirements:          []string{},
+		ProviderCompatibilityNotes: []string{},
+		Warnings:                   append([]string{}, report.Notes...),
+		Blockers:                   append([]string{}, report.Errors...),
+	}
+	if len(portability.Warnings) > 0 {
+		portability.Status = "WARN"
+	}
+	if len(portability.Blockers) > 0 {
+		portability.Status = "BLOCKED"
+		portability.ValidationStatus = "FAIL"
+	}
+
+	for _, f := range report.Manifest.Setup.Files {
+		portability.SetupRequirements = append(portability.SetupRequirements, describeSetupRequirement("file", f.Path, f.Description))
+	}
+	for _, d := range report.Manifest.Setup.Directories {
+		portability.SetupRequirements = append(portability.SetupRequirements, describeSetupRequirement("directory", d.Path, d.Description))
+	}
+	if report.Manifest.Entrypoints.Claude != "" {
+		portability.ProviderCompatibilityNotes = append(portability.ProviderCompatibilityNotes, "claude entrypoint: "+report.Manifest.Entrypoints.Claude)
+	}
+	if report.Manifest.Entrypoints.Codex != "" {
+		portability.ProviderCompatibilityNotes = append(portability.ProviderCompatibilityNotes, "codex entrypoint: "+report.Manifest.Entrypoints.Codex)
+	}
+	return portability
+}
+
+func describeSetupRequirement(kind, path, description string) string {
+	if description == "" {
+		return fmt.Sprintf("create %s %s", kind, path)
+	}
+	return fmt.Sprintf("create %s %s - %s", kind, path, description)
+}
+
+func WritePortabilityReport(w io.Writer, report PortabilityReport) {
+	fmt.Fprintln(w, "portability:")
+	fmt.Fprintf(w, "  status: %s\n", report.Status)
+	fmt.Fprintf(w, "  validation: %s\n", report.ValidationStatus)
+	writeReportList(w, "  redactions", report.Redactions)
+	writeReportList(w, "  parameterized values", report.ParameterizedValues)
+	writeReportList(w, "  setup requirements", report.SetupRequirements)
+	writeReportList(w, "  provider compatibility", report.ProviderCompatibilityNotes)
+	writeReportList(w, "  warnings", report.Warnings)
+	writeReportList(w, "  blockers", report.Blockers)
+}
+
+func writeReportList(w io.Writer, label string, values []string) {
+	if len(values) == 0 {
+		fmt.Fprintf(w, "%s: none\n", label)
+		return
+	}
+	fmt.Fprintf(w, "%s:\n", label)
+	for _, value := range values {
+		fmt.Fprintf(w, "    - %s\n", value)
+	}
+}

--- a/internal/packages/portability_test.go
+++ b/internal/packages/portability_test.go
@@ -1,0 +1,76 @@
+package packages
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPortabilityReportCleanPackage(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "clean-portable")
+	if err := InitPackage(root, "clean-portable"); err != nil {
+		t.Fatal(err)
+	}
+
+	validateReport, err := Validate(root)
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	report := NewPortabilityReport(validateReport)
+	if report.Status != "PASS" || report.ValidationStatus != "PASS" || report.HasBlockers() {
+		t.Fatalf("portability report = %+v, want clean pass", report)
+	}
+}
+
+func TestPortabilityReportWarningOnlyPackage(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "warning-portable")
+	if err := InitPackage(root, "warning-portable"); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := LoadManifest(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest.Requires.Skills = []string{"security-basics"}
+	manifest.Setup.Files = []SetupFile{{Path: "tasks.csv", Description: "tracks work"}}
+	manifest.Entrypoints.Codex = "skills/security-basics/SKILL.md"
+	if err := SaveManifest(root, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	validateReport, err := Validate(root)
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	report := NewPortabilityReport(validateReport)
+	if report.Status != "WARN" || report.ValidationStatus != "PASS" || report.HasBlockers() {
+		t.Fatalf("portability report = %+v, want warning-only pass", report)
+	}
+	if len(report.Warnings) != 1 || len(report.SetupRequirements) != 1 || len(report.ProviderCompatibilityNotes) != 1 {
+		t.Fatalf("portability report = %+v, want validation note, setup requirement, and provider note", report)
+	}
+}
+
+func TestPortabilityReportBlockerPackage(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "blocked-portable")
+	if err := InitPackage(root, "blocked-portable"); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, ".env"), "API_KEY=whatever")
+
+	validateReport, err := Validate(root)
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	report := NewPortabilityReport(validateReport)
+	if report.Status != "BLOCKED" || report.ValidationStatus != "FAIL" || !report.HasBlockers() {
+		t.Fatalf("portability report = %+v, want blocked fail", report)
+	}
+
+	var out bytes.Buffer
+	WritePortabilityReport(&out, report)
+	if !strings.Contains(out.String(), "blockers:") || !strings.Contains(out.String(), ".env:") {
+		t.Fatalf("rendered portability report = %q, want blocker details", out.String())
+	}
+}

--- a/internal/packages/registry.go
+++ b/internal/packages/registry.go
@@ -55,8 +55,9 @@ func Publish(dir string, cfg RegistryConfig) (PublishResult, error) {
 	if err != nil {
 		return PublishResult{}, err
 	}
-	if !report.Passed() {
-		return PublishResult{}, fmt.Errorf("package failed validation, refusing to publish (%d error(s)); run `lineage package validate` for details", len(report.Errors))
+	portability := NewPortabilityReport(report)
+	if portability.HasBlockers() {
+		return PublishResult{}, fmt.Errorf("package has unresolved portability blockers, refusing to publish (%d blocker(s)); run `lineage package validate` for details", len(portability.Blockers))
 	}
 	if cfg.Token == "" {
 		return PublishResult{}, fmt.Errorf("no publish token configured; set LINEAGE_PUBLISH_TOKEN")


### PR DESCRIPTION
Closes #112.

Verified against the pinned tree: the patch applies cleanly and the issue's post-fix check passes.

Relevant test cases:

- Clean portability report state.
- Warning-only portability report state.
- Blocker portability report state.
- Export/publish gating preserves PASS/WARN/BLOCKED behavior.

Verification:

```text
go test ./...
```

Maintainer note: I updated this PR description so the repository PR Policy check can evaluate the already-reviewed contribution.

Written by an AI coding agent (Sloppy) and opened under my account.
