### PR TITLE
docs: refresh ROADMAP.md against shipped work and the consolidation audit

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,9 @@ This roadmap is intentionally limited to the public local package runtime.
 - Secret scanning and path-traversal protection for package-controlled input.
 - `lineage package validate`, `lineage package export`, `lineage package import`.
 - Registry publish and pull backed by the Lineage website API.
-- `lineage add` as the one-command receiver path for published packages.
+- `lineage add` as the one-command receiver path for published packages,
+  converging local `.tgz` archives and registry refs through the same
+  validate → inspect → setup → enable flow, idempotent on repeat.
 - GitHub device-flow login, logout, and publisher identity checks.
 - `lineage list`, `lineage disable`, `lineage inspect`, and `lineage doctor`.
 - Workflow execution through `lineage workflow run`.
@@ -17,28 +19,51 @@ This roadmap is intentionally limited to the public local package runtime.
 - Permission-gated materialization: enabling a package actually stages skills
   into a provider's own directory and generates its context file, with an
   explicit confirmation before anything is written.
+- Package-declared setup files/directories, created through their own
+  explicit permission-gated prompt.
+- Provider entrypoints and capabilities surfaced in the registry and on
+  package pages.
+- A portability report (blockers/warnings) computed during export and
+  publish.
 
 ## Next
 
-- Finish the active receiver-path hardening work:
-  - local `.tgz` archives through `lineage add`;
-  - idempotent repeated `add`;
-  - package-declared setup files/directories with an explicit creation prompt;
-  - provider entrypoints and capabilities surfaced in the registry and package pages.
+An August 2026 consolidation pass audited every shipped surface (CLI,
+package lifecycle, materialization/runtime, and the registry backend) for
+correctness and security bugs rather than new features, and filed the
+result as individual issues instead of one grab-bag. That work takes
+priority over new feature surface:
+
+- Critical/high fixes: unvalidated package names enabling path escapes
+  (#147), digest verification skipped on an empty registry response (#148),
+  a stdin-buffering bug that silently drops the second of two prompts in
+  one command (#149), `enable` persisting state before a later step that
+  can fail (#150), secret scanning gaps (#151, #152), `lineage add`
+  reporting success when nothing was enabled (#153), and no write path in
+  the codebase being crash-safe (#154).
+- The rest of that audit's medium/low findings are filed individually
+  (#155-#172) so they can be picked up independently; several are tagged
+  `good first issue`.
+- Add a Windows CI job (#174) so the shim `.cmd` generation and `PATHEXT`
+  binary-resolution code this repo already ships actually run somewhere
+  before merge, instead of only on ubuntu-latest.
+- Add an end-to-end integration fixture covering the full author-to-receiver
+  flow through the real CLI (#12).
 - Keep public docs synchronized across README, Wiki, Discussions, and the
   website whenever the receiver flow changes.
-- Verify the CLI on Windows, including shim generation and binary
-  resolution.
-- Add an end-to-end integration fixture covering the full author-to-receiver
-  flow through the real CLI.
 - Add automated drift checks for the bootstrap prompt copy embedded on package
   pages.
 
 ## Later
 
 - Design the `.lineage` artifact (project- and user-level state) as a
-  deliberate whole, rather than one field at a time.
-- Broaden provider adapter coverage while keeping the core package format
-  provider-neutral.
-- Add stronger capability enforcement if declarative capability visibility is
-  not enough for real receiver trust.
+  deliberate whole, rather than one field at a time (#59).
+- Broaden provider adapter coverage (Cursor, Windsurf, Auggie, Cline, Aider,
+  GitHub Copilot) while keeping the core package format provider-neutral.
+- Add stronger capability enforcement if declarative capability visibility
+  is not enough for real receiver trust.
+- The "safety compliance" (#127-#142) and "compile existing workflows into
+  packages" (#101-#116) epics are deliberately parked here rather than in
+  Next: both are net-new feature surface, and the project's stated priority
+  right now is consolidating what's already shipped, not expanding it
+  further.


### PR DESCRIPTION
## Summary

What changed, and why?

ROADMAP.md's "Next" section still listed items that were already closed
(#71, #72, #90, #112) and no longer reflected the actual state of the
project. This moves those into Done and replaces Next with what's
actually outstanding: the issues filed from an August 2026 consolidation
audit of the shipped CLI/registry surface (#147-#174), Windows CI
coverage (#174), and the still-open integration-fixture item (#12). The
two large net-new feature epics (safety compliance #127-#142, compile
packages #101-#116) are moved explicitly under Later with a note that
they're deliberately deprioritized while the project consolidates what's
already shipped.

## Linked Issue

Closes #173

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`, or it is a release-tracked promotion into `master`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [x] Documentation only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

List the relevant test cases added or updated, then paste the commands or checks you ran.

Relevant test cases:

- N/A, documentation-only change

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- This only edits ROADMAP.md's prose; there is no behavior to test. `go test ./...` was still run locally against develop and passes, unaffected by this change.

## Notes For Reviewers

Issue numbers cited in the new Next section (#147-#174) were filed in the same session from a source-level audit of internal/cli, internal/packages, internal/materialize, internal/auth, internal/provider, internal/runtime, internal/shim, and internal/config - each has its own repro/fix-direction writeup. Happy to adjust which of them belong in Next vs Later if the prioritization call should go differently.