### PR TITLE
fix: reject unsafe characters in manifest name/version at load time

### DIFF
--- a/internal/packages/manifest.go
+++ b/internal/packages/manifest.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"gopkg.in/yaml.v3"
 )
@@ -14,6 +15,22 @@ const ManifestFileName = "lineage.yaml"
 // schema describes how to interpret the manifest; version describes the
 // package itself — the two change independently.
 const CurrentSchema = 1
+
+// identifierPattern bounds Manifest.Name and Manifest.Version: no path
+// separators, no leading '.'/'-'/'+' (so a value can never start with ".."
+// or look like a CLI flag), nothing that would change meaning if joined
+// into a filesystem path or a filename. Both values flow unvalidated into
+// filepath.Join elsewhere (materialization's staged skill directories,
+// package export's default output filename), so this is enforced once
+// here rather than at every downstream call site.
+var identifierPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._+-]*$`)
+
+func validateIdentifier(field, path, value string) error {
+	if !identifierPattern.MatchString(value) {
+		return fmt.Errorf("manifest %s: %s %q must start with a letter or digit and contain only letters, digits, '.', '_', '-', or '+'", path, field, value)
+	}
+	return nil
+}
 
 type Manifest struct {
 	Schema       int          `yaml:"schema"`
@@ -137,8 +154,14 @@ func LoadManifest(dir string) (Manifest, error) {
 	if manifest.Name == "" {
 		return Manifest{}, fmt.Errorf("manifest %s missing name", path)
 	}
+	if err := validateIdentifier("name", path, manifest.Name); err != nil {
+		return Manifest{}, err
+	}
 	if manifest.Version == "" {
 		manifest.Version = "0.1.0"
+	}
+	if err := validateIdentifier("version", path, manifest.Version); err != nil {
+		return Manifest{}, err
 	}
 	// schema 0 means the manifest predates the schema field; treat that as
 	// schema 1, the only schema that ever existed before it was added.

--- a/internal/packages/manifest_test.go
+++ b/internal/packages/manifest_test.go
@@ -27,6 +27,46 @@ func TestLoadManifestRejectsUnsupportedSchema(t *testing.T) {
 	}
 }
 
+func TestLoadManifestRejectsPathTraversalInName(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ManifestFileName), "name: ../../../../tmp/evil\nversion: 1.0.0\n")
+
+	if _, err := LoadManifest(dir); err == nil {
+		t.Fatal("LoadManifest() error = nil, want error for a name containing path traversal")
+	}
+}
+
+func TestLoadManifestRejectsPathTraversalInVersion(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ManifestFileName), "name: safe-pack\nversion: ../escaped\n")
+
+	if _, err := LoadManifest(dir); err == nil {
+		t.Fatal("LoadManifest() error = nil, want error for a version containing path traversal")
+	}
+}
+
+func TestLoadManifestRejectsSlashInName(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ManifestFileName), "name: nested/name\nversion: 1.0.0\n")
+
+	if _, err := LoadManifest(dir); err == nil {
+		t.Fatal("LoadManifest() error = nil, want error for a name containing a path separator")
+	}
+}
+
+func TestLoadManifestAcceptsSemverStyleVersion(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ManifestFileName), "name: safe-pack\nversion: 1.0.0-beta.1+build.7\n")
+
+	manifest, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("LoadManifest() error = %v, want a semver-with-metadata version to be accepted", err)
+	}
+	if manifest.Version != "1.0.0-beta.1+build.7" {
+		t.Fatalf("Version = %q, want %q", manifest.Version, "1.0.0-beta.1+build.7")
+	}
+}
+
 func TestDefaultManifestRoundTripsCapabilities(t *testing.T) {
 	dir := t.TempDir()
 	manifest := DefaultManifest("cap-pack")


### PR DESCRIPTION
## Summary

What changed, and why?

`Manifest.Name`/`Version` were only checked for non-emptiness, then flowed unvalidated into `filepath.Join` in two places: materialization's staged skill directory names (`internal/materialize/materialize.go:163`) and package export's default output filename (`internal/cli/cli.go:390-394`). A manifest with `name: ../../../../tmp/evil` could make both escape their intended directory - materialization would stage (and on a later re-apply, `os.RemoveAll`) outside the project; export would write outside the working directory. Validating once at the `LoadManifest` boundary closes both, since every code path that reads a manifest (discovery, validate, export, import, enable) goes through it.

## Linked Issue

Closes #147

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`, or it is a release-tracked promotion into `master`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [x] Package format or manifest behavior

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- TestLoadManifestRejectsPathTraversalInName
- TestLoadManifestRejectsPathTraversalInVersion
- TestLoadManifestRejectsSlashInName
- TestLoadManifestAcceptsSemverStyleVersion

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- N/A, tests included above.

## Notes For Reviewers

The allowed charset (`[a-zA-Z0-9][a-zA-Z0-9._+-]*`) permits full semver including pre-release/build metadata (`1.0.0-beta.1+build.7`) while rejecting anything that could change meaning when joined into a path: no `/`, no leading `.`/`-`/`+` (so a value can never start with `..` or look like a CLI flag). Existing manifests in the repo (examples/, test fixtures) all already conform, confirmed by the full suite passing unchanged.