### PR TITLE
fix: Pull fails closed when the registry response omits a digest

### DIFF
--- a/internal/packages/registry.go
+++ b/internal/packages/registry.go
@@ -134,7 +134,8 @@ type packageMetadata struct {
 // The digest the registry reports for ref is untrusted the same way the
 // archive bytes are: after import, Pull recomputes the digest from the
 // content Import actually kept and fails closed - removing what was
-// imported - if it doesn't match what the registry claimed.
+// imported - if it doesn't match what the registry claimed, or if the
+// registry didn't report a digest at all.
 func Pull(ref string, cfg RegistryConfig, destParent, asName string) (string, error) {
 	meta, err := fetchPackageMetadata(ref, cfg)
 	if err != nil {
@@ -162,7 +163,11 @@ func Pull(ref string, cfg RegistryConfig, destParent, asName string) (string, er
 		os.RemoveAll(importedDir)
 		return "", fmt.Errorf("verify digest for %s: %w", ref, err)
 	}
-	if meta.Digest != "" && actualDigest != meta.Digest {
+	if meta.Digest == "" {
+		os.RemoveAll(importedDir)
+		return "", fmt.Errorf("registry response for %s did not report a digest; refusing to keep unverified content", ref)
+	}
+	if actualDigest != meta.Digest {
 		os.RemoveAll(importedDir)
 		return "", fmt.Errorf("digest mismatch for %s: registry reported %s, imported content hashes to %s; refusing to keep it", ref, meta.Digest, actualDigest)
 	}

--- a/internal/packages/registry_test.go
+++ b/internal/packages/registry_test.go
@@ -239,6 +239,32 @@ func TestPullFailsClosedOnDigestMismatch(t *testing.T) {
 	}
 }
 
+func TestPullFailsClosedOnMissingDigest(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "no-digest-pack")
+	if err := InitPackage(src, "no-digest-pack"); err != nil {
+		t.Fatal(err)
+	}
+	var archive bytes.Buffer
+	if err := Export(src, &archive); err != nil {
+		t.Fatal(err)
+	}
+
+	ref := "no-digest-pack@0.1.0"
+	srv := pullTestServer(t, ref, map[string]any{
+		"name": "no-digest-pack", "version": "0.1.0",
+		"downloadPath": "/api/packages/" + ref + "/download",
+	}, archive.Bytes())
+	defer srv.Close()
+
+	destParent := t.TempDir()
+	if _, err := Pull(ref, RegistryConfig{URL: srv.URL}, destParent, ""); err == nil {
+		t.Fatal("Pull() error = nil, want error when the registry omits the digest")
+	}
+	if _, err := os.Stat(filepath.Join(destParent, "no-digest-pack")); !os.IsNotExist(err) {
+		t.Errorf("Pull() left a package directory behind after a missing-digest response: err = %v", err)
+	}
+}
+
 func TestPullReportsMissingRef(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
## Summary

What changed, and why?

`Pull`'s digest check (`internal/packages/registry.go`) only ran `if meta.Digest != "" && actualDigest != meta.Digest`. A registry response missing the `digest` field skipped verification entirely rather than being rejected - the opposite of ADR 0012's "website/API metadata is advisory, the package digest is authoritative" fail-closed requirement. A registry bug, misconfiguration, or tampered response with an empty digest would previously cause `lineage add`/`lineage package pull` to import and keep the content with zero integrity checking.

## Linked Issue

Closes #148

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`, or it is a release-tracked promotion into `master`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [x] Package format or manifest behavior

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- TestPullFailsClosedOnMissingDigest

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- N/A, test included above.

## Notes For Reviewers

Mirrors the existing `TestPullFailsClosedOnDigestMismatch` shape exactly, just with the digest field omitted from the mocked registry response instead of wrong.