### PR TITLE
fix: confirm() shares one buffered reader across a command's prompts

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -50,15 +50,26 @@ func Execute(ctx context.Context, args []string, stdin io.Reader, stdout, stderr
 		return err
 	}
 
+	// Wrapped once here, then threaded through as *bufio.Reader rather than
+	// io.Reader, so every confirm() prompt within this single invocation
+	// reads from the same buffer. A command that prompts more than once
+	// (e.g. `add`, which can ask about both enabling and setup) would
+	// otherwise have each confirm() call construct its own bufio.Reader,
+	// silently discarding whatever that call buffered but didn't consume.
+	var in *bufio.Reader
+	if stdin != nil {
+		in = bufio.NewReader(stdin)
+	}
+
 	switch args[0] {
 	case "init":
 		return runInit(args[1:], home, stdout, stderr)
 	case "package":
 		return runPackage(args[1:], home, stdout, stderr)
 	case "add":
-		return runAdd(args[1:], home, stdin, stdout, stderr)
+		return runAdd(args[1:], home, in, stdout, stderr)
 	case "enable":
-		return runEnable(args[1:], home, stdin, stdout, stderr)
+		return runEnable(args[1:], home, in, stdout, stderr)
 	case "list":
 		return runList(home, stdout, stderr)
 	case "disable":
@@ -66,9 +77,9 @@ func Execute(ctx context.Context, args []string, stdin io.Reader, stdout, stderr
 	case "inspect":
 		return runInspect(args[1:], home, stdout, stderr)
 	case "run":
-		return runProvider(ctx, args[1:], home, stdin, stdout, stderr)
+		return runProvider(ctx, args[1:], home, in, stdout, stderr)
 	case "workflow":
-		return runWorkflow(args[1:], home, stdin, stdout, stderr)
+		return runWorkflow(args[1:], home, in, stdout, stderr)
 	case "install-shims":
 		return runInstallShims(home, stdout, stderr)
 	case "doctor":
@@ -494,7 +505,7 @@ func describeSuffix(description string) string {
 	return " - " + description
 }
 
-func runEnable(args []string, home string, stdin io.Reader, stdout, stderr io.Writer) error {
+func runEnable(args []string, home string, stdin *bufio.Reader, stdout, stderr io.Writer) error {
 	if len(args) > 0 && isHelpFlag(args[0]) {
 		fmt.Fprintln(stdout, "usage: lineage enable <package-path-or-id> [--yes]\n\nEnable a package in the current project. If the package declares setup - tracker files or directories its workflow expects - shows the plan and asks permission before creating anything; --yes skips that prompt.")
 		return nil
@@ -525,7 +536,7 @@ func runEnable(args []string, home string, stdin io.Reader, stdout, stderr io.Wr
 // (which pulls a package and then enables it in one command) shares the
 // exact same project-root resolution, dependency validation, and setup
 // handling instead of a second, drifting implementation.
-func enableRef(ref, home string, autoApprove bool, stdin io.Reader, stdout, stderr io.Writer) error {
+func enableRef(ref, home string, autoApprove bool, stdin *bufio.Reader, stdout, stderr io.Writer) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		fmt.Fprintln(stderr, err)
@@ -701,7 +712,7 @@ func importAddSource(ref, destParent string) (name, action string, err error) {
 	return name, action, err
 }
 
-func runAdd(args []string, home string, stdin io.Reader, stdout, stderr io.Writer) error {
+func runAdd(args []string, home string, stdin *bufio.Reader, stdout, stderr io.Writer) error {
 	if len(args) > 0 && isHelpFlag(args[0]) {
 		fmt.Fprintln(stdout, "usage: lineage add <package-ref> [--yes]\n\nFetch a published package, show what it contains, ask permission, then enable it in the current project - the one-command receiver path. <package-ref> is a registry ref (name or name@version), or the path to a local .tgz archive from `lineage package export`.")
 		return nil
@@ -951,7 +962,7 @@ func runInspect(args []string, home string, stdout, stderr io.Writer) error {
 	return nil
 }
 
-func runProvider(ctx context.Context, args []string, home string, stdin io.Reader, stdout, stderr io.Writer) error {
+func runProvider(ctx context.Context, args []string, home string, stdin *bufio.Reader, stdout, stderr io.Writer) error {
 	_ = ctx
 	if len(args) == 0 {
 		err := fmt.Errorf("usage: lineage run <%s> [--dry-run] [--yes] [-- provider args...]", providerNameList())
@@ -1018,7 +1029,7 @@ func runProvider(ctx context.Context, args []string, home string, stdin io.Reade
 	return nil
 }
 
-func runWorkflow(args []string, home string, stdin io.Reader, stdout, stderr io.Writer) error {
+func runWorkflow(args []string, home string, stdin *bufio.Reader, stdout, stderr io.Writer) error {
 	usage := fmt.Errorf("usage: lineage workflow run <workflow-name> <%s> [--dry-run] [--yes] [-- provider args...]", providerNameList())
 	if len(args) < 3 || args[0] != "run" {
 		fmt.Fprintln(stderr, usage)
@@ -1120,11 +1131,19 @@ func workflowPlanString(wf packages.Workflow, pkg packages.Package, providerName
 // affirmative answer ("y" or "yes", case-insensitive). Anything else,
 // including EOF or a nil reader, is treated as a decline - approval must be
 // explicit.
-func confirm(stdin io.Reader) bool {
+//
+// Takes the caller's own *bufio.Reader rather than wrapping an io.Reader
+// itself: a command that prompts more than once in one run (e.g. `add`,
+// which can ask about both enabling and setup) must read successive lines
+// off the same buffer. Constructing a fresh bufio.Reader per call would
+// silently discard whatever the previous call had already buffered but not
+// consumed if a single Read from stdin returned more than one line's worth
+// of bytes at once - the exact shape piped/scripted stdin takes.
+func confirm(stdin *bufio.Reader) bool {
 	if stdin == nil {
 		return false
 	}
-	line, err := bufio.NewReader(stdin).ReadString('\n')
+	line, err := stdin.ReadString('\n')
 	if err != nil && line == "" {
 		return false
 	}

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -257,3 +257,55 @@ func TestAddWithSetupYesAppliesWithoutPrompt(t *testing.T) {
 		t.Errorf("expected tasks.csv to be created via add --yes without a prompt: %v", err)
 	}
 }
+
+// TestAddRespectsBothPromptsFromSingleBufferedStdin covers a regression
+// where `add` (no --yes) answers two prompts in one run - "enable this
+// package?" then, for a package with setup, "create these files?" - and
+// each confirm() call used to construct its own bufio.Reader over the same
+// stdin. A single Read() delivering both answered lines at once (true for
+// strings.Reader, and for real piped/scripted stdin) meant the first
+// bufio.Reader buffered and discarded the second line before the second
+// confirm() call ever saw it, so a real "y\ny\n" silently behaved as if
+// the setup prompt had been declined.
+func TestAddRespectsBothPromptsFromSingleBufferedStdin(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	srcDir := filepath.Join(tmp, "tracker-pack")
+	initPackageWithSetup(t, srcDir, "tracker-pack")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ref := "tracker-pack@0.1.0"
+	srv := addTestServer(t, ref, srcDir)
+	defer srv.Close()
+
+	t.Setenv(config.HomeEnv, home)
+	t.Setenv("LINEAGE_REGISTRY_URL", srv.URL)
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	var stdout, stderr bytes.Buffer
+	stdin := strings.NewReader("y\ny\n")
+	if err := Execute(nil, []string{"add", ref}, stdin, &stdout, &stderr); err != nil {
+		t.Fatalf("add error = %v stderr=%s", err, stderr.String())
+	}
+
+	found, err := config.FindProjectConfig(project)
+	if err != nil {
+		t.Fatalf("expected a project config after answering yes to both prompts: %v", err)
+	}
+	if !contains(found.Config.EnabledPackages, "tracker-pack") {
+		t.Errorf("enabled packages = %v, want tracker-pack (the enable prompt's \"y\" must not be lost)", found.Config.EnabledPackages)
+	}
+	if _, err := os.Stat(filepath.Join(project, "tasks.csv")); err != nil {
+		t.Errorf("expected tasks.csv to be created: the setup prompt's \"y\" must not be lost: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Ready. Run `lineage run") {
+		t.Errorf("stdout = %q, want the success message once setup was actually approved and applied", stdout.String())
+	}
+}


### PR DESCRIPTION
## Summary

What changed, and why?

`confirm()` (`internal/cli/cli.go`) wrapped its `stdin` argument in a fresh `bufio.NewReader` on every call. `lineage add` calls it up to twice in one run - once to confirm enabling, and again (inside `enableRef`) to confirm creating a package's declared setup files. If both answers arrive in a single buffered `Read()` - true for `strings.Reader`, and for real piped/scripted stdin such as `printf "y\ny\n" | lineage add ...` - the first `bufio.Reader` consumes and buffers both lines, returns only the first, and silently discards the rest when it goes out of scope. The second `confirm()` call then reads EOF and is treated as a decline, even though the user answered yes to both.

Fix: `Execute` now wraps `stdin` in one `*bufio.Reader` and threads that through `runAdd`, `runEnable`, `enableRef`, `runProvider`, and `runWorkflow` instead of the raw `io.Reader`, so every `confirm()` call within a single invocation reads sequential lines off the same shared buffer. `Execute`'s own public signature (`stdin io.Reader`) is unchanged.

## Linked Issue

Closes #149

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`, or it is a release-tracked promotion into `master`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [x] Setup or permission flow

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- TestAddRespectsBothPromptsFromSingleBufferedStdin

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- N/A, test included above.

## Notes For Reviewers

Verified the new test is a real regression test, not a trivially-passing one: ran it against the pre-fix `confirm()`/`Execute` with `git stash`, confirmed it fails there (`no .lineage/config.yaml found`), then restored the fix and confirmed it passes.

This only changes internal plumbing between `Execute` and `confirm()` - no test outside `internal/cli` calls any of the five updated functions directly (checked via grep), and `Execute`'s public `io.Reader` parameter is untouched, so this shouldn't affect anything outside this package.