### PR TITLE
fix: enableRef only saves config after digest/snapshot/graph all succeed

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -659,11 +659,14 @@ func enableRef(ref, home string, autoApprove bool, stdin *bufio.Reader, stdout, 
 		fmt.Fprintln(stdout, "setup complete.")
 	}
 
-	cfg.EnabledPackages = newEnabled
-	if err := config.SaveProjectConfig(configPath, cfg); err != nil {
-		fmt.Fprintln(stderr, err)
-		return err
-	}
+	// Everything from here on must succeed before config is saved: once
+	// SaveProjectConfig runs, the package is durably marked enabled, so any
+	// step that can still fail (digest computation, the snapshot, the graph
+	// append) has to happen first. Otherwise a failure here - e.g. a
+	// corrupt .lineage/graph.json from an earlier partial write - would
+	// report enable as failed while having already left the package
+	// enabled in config, with no way back short of manually editing the
+	// file.
 
 	// Record that this project's local environment now descends from
 	// manifest, so `lineage graph list` can later explain where it came
@@ -677,7 +680,7 @@ func enableRef(ref, home string, autoApprove bool, stdin *bufio.Reader, stdout, 
 	}
 
 	// Also take a durable, content-addressed snapshot of exactly what was
-	// enabled (#7), so the graph record above can point at something that
+	// enabled (#7), so the graph record below can point at something that
 	// can later be inspected, copied, or reconstructed byte-for-byte
 	// instead of only naming a version.
 	_, snapshotID, err := snapshot.Create(home, resolvedPath)
@@ -698,6 +701,12 @@ func enableRef(ref, home string, autoApprove bool, stdin *bufio.Reader, stdout, 
 			Workspace: cfg.Workspace,
 		},
 	}); err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+
+	cfg.EnabledPackages = newEnabled
+	if err := config.SaveProjectConfig(configPath, cfg); err != nil {
 		fmt.Fprintln(stderr, err)
 		return err
 	}

--- a/internal/cli/graph_test.go
+++ b/internal/cli/graph_test.go
@@ -47,6 +47,68 @@ func TestEnableRecordsGraphEntry(t *testing.T) {
 	}
 }
 
+// TestEnableFailingGraphAppendDoesNotPersistConfig covers a regression
+// where enableRef saved .lineage/config.yaml (marking the package enabled)
+// before computing the digest, taking the snapshot, and appending to the
+// graph - any of which can still fail. A corrupt .lineage/graph.json (the
+// kind a prior crash mid-write could leave behind) made graph.Append fail
+// after config had already been saved: `enable` reported a non-zero exit
+// while the package was already durably marked enabled, with every
+// subsequent enable in the project failing the same opaque way.
+func TestEnableFailingGraphAppendDoesNotPersistConfig(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	pkgDir := filepath.Join(project, "agent-pack")
+
+	if err := os.MkdirAll(filepath.Join(pkgDir, "skills", "hello"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "lineage.yaml"), []byte("name: agent-pack\nversion: 0.1.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "skills", "hello", "SKILL.md"), []byte("# Hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A corrupt graph.json - the kind a crash mid-write could leave behind
+	// - makes graph.Append fail at the Load step, before it ever writes
+	// anything.
+	if err := os.MkdirAll(filepath.Join(project, ".lineage"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".lineage", "graph.json"), []byte("not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldHome := os.Getenv(config.HomeEnv)
+	t.Setenv(config.HomeEnv, home)
+	t.Cleanup(func() { os.Setenv(config.HomeEnv, oldHome) })
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(oldWd) })
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"enable", "./agent-pack"}, nil, &stdout, &stderr); err == nil {
+		t.Fatal("enable error = nil, want error from the corrupt graph file")
+	}
+
+	found, err := config.FindProjectConfig(project)
+	if err != nil {
+		// No config was ever written - the ideal outcome for a first
+		// enable that failed before completing.
+		return
+	}
+	if contains(found.Config.EnabledPackages, "./agent-pack") {
+		t.Errorf("enabled packages = %v, want agent-pack NOT enabled after a failed enable", found.Config.EnabledPackages)
+	}
+}
+
 func TestEnableTwiceAppendsSecondRecord(t *testing.T) {
 	project, _ := setUpEnabledProject(t)
 


### PR DESCRIPTION
## Summary

What changed, and why?

`enableRef` (`internal/cli/cli.go`) called `config.SaveProjectConfig` - marking the package enabled - *before* three steps that can each independently fail: `packages.ComputeDigest`, `snapshot.Create` (#7), and `graph.Append` (#6). If any of them failed, `enable` returned a non-zero exit, but the config file had already been saved with the package listed as enabled. A corrupt `.lineage/graph.json` (plausible from any earlier partial write, since graph saves aren't atomic) reproduces this today - every subsequent `enable` in that project then fails the same opaque way until someone manually finds and fixes the graph file.

Reordered so all three steps run first, and `config.SaveProjectConfig` only runs once they've all succeeded. A failed `enable` now leaves the project genuinely unchanged, matching the existing "declining setup leaves the workspace completely unchanged" behavior a few lines above it.

## Linked Issue

Closes #150

## Package Impact

- [x] Package discovery or enablement

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- TestEnableFailingGraphAppendDoesNotPersistConfig

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- N/A, test included above.

## Notes For Reviewers

Verified the new test is a real regression test: ran it against the pre-fix ordering with `git stash`, confirmed it fails (`enabled packages = [./agent-pack], want agent-pack NOT enabled after a failed enable`), then restored the fix and confirmed it passes.

Pure reordering - no new branches, no behavior change on the success path. `#150` was originally filed against a stale read of this function (before #6/#7 had merged) and briefly closed as not-yet-applicable; it's back open and this is the actual fix now that both are on `develop`.