### PR TITLE
fix: secret content scan checks a bounded prefix instead of skipping large files

### DIFF
--- a/internal/packages/secrets.go
+++ b/internal/packages/secrets.go
@@ -1,6 +1,7 @@
 package packages
 
 import (
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -15,9 +16,12 @@ type SecretFinding struct {
 	Reason string
 }
 
-// maxScannedFileSize caps how much of a file's content gets pattern-matched.
-// Secret-shaped strings are text and small; skipping large files avoids
-// reading big binaries into memory for no benefit.
+// maxScannedFileSize caps how much of a file's content gets pattern-matched:
+// the first maxScannedFileSize bytes, not the whole file. Secret-shaped
+// strings are text, small, and tend to appear early in a file (env var
+// assignments, key headers), so scanning a bounded prefix catches them in
+// large files too, without reading an arbitrarily large file fully into
+// memory.
 const maxScannedFileSize = 5 << 20 // 5MB
 
 // deniedFilenames are exact, case-insensitive filename matches that are
@@ -81,10 +85,10 @@ func ScanForSecrets(dir string) ([]SecretFinding, error) {
 		}
 
 		info, statErr := d.Info()
-		if statErr != nil || info.Size() > maxScannedFileSize {
+		if statErr != nil {
 			return nil
 		}
-		data, readErr := os.ReadFile(path)
+		data, readErr := readScanPrefix(path, info.Size())
 		if readErr != nil {
 			return nil
 		}
@@ -99,6 +103,30 @@ func ScanForSecrets(dir string) ([]SecretFinding, error) {
 
 	sort.Slice(findings, func(i, j int) bool { return findings[i].Path < findings[j].Path })
 	return findings, nil
+}
+
+// readScanPrefix reads up to maxScannedFileSize bytes from the start of
+// path. size is the file's already-known length, used only to avoid
+// allocating a buffer larger than the file actually is; a short read (the
+// file being smaller than size, or than the cap) is not an error - it's
+// what happens for every file smaller than the cap, which is most of them.
+func readScanPrefix(path string, size int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	limit := size
+	if limit > maxScannedFileSize {
+		limit = maxScannedFileSize
+	}
+	buf := make([]byte, limit)
+	n, err := io.ReadFull(f, buf)
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+		return nil, err
+	}
+	return buf[:n], nil
 }
 
 func matchesDeniedFilename(name string) (string, bool) {

--- a/internal/packages/secrets_test.go
+++ b/internal/packages/secrets_test.go
@@ -62,6 +62,28 @@ func TestScanForSecretsFlagsAWSKeyID(t *testing.T) {
 	}
 }
 
+func TestScanForSecretsCatchesContentInFilesOverSizeCap(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "big-pack")
+	if err := InitPackage(root, "big-pack"); err != nil {
+		t.Fatal(err)
+	}
+	// Split so this fixture's literal bytes never form a real key-shaped
+	// string in the source file itself (see the AWS key ID test above).
+	fakeAWSKeyID := "AKIA" + "ABCDEFGHIJKLMNOP"
+	var b strings.Builder
+	b.WriteString("aws_access_key_id = " + fakeAWSKeyID + "\n")
+	b.WriteString(strings.Repeat("x", 6<<20)) // padding past the 5MB scan cap
+	mustWrite(t, filepath.Join(root, "references", "vendor-bundle.txt"), b.String())
+
+	findings, err := ScanForSecrets(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasFindingForPath(findings, filepath.ToSlash(filepath.Join("references", "vendor-bundle.txt"))) {
+		t.Fatalf("findings = %#v, want a finding for content within the scanned prefix even though the file is over the size cap", findings)
+	}
+}
+
 func TestScanForSecretsIgnoresSafeContent(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "clean-pack")
 	if err := InitPackage(root, "clean-pack"); err != nil {


### PR DESCRIPTION
## Summary

What changed, and why?

`ScanForSecrets` (`internal/packages/secrets.go`) skipped content scanning entirely for any file over `maxScannedFileSize` (5MB) - not truncated or sampled, just excluded. Filename-based checks (`.env`, `.pem`, etc.) still applied, but content patterns (private key headers, AWS key IDs, GitHub tokens) did not. A private key or token embedded in a large file - a vendor bundle, a generated data file, anything padded past 5MB - shipped through `validate`/`export`/`publish` undetected.

Changed the size cap to bound how much of a file gets scanned rather than whether it gets scanned at all: `readScanPrefix` now reads up to 5MB from the start of every file (a plain `io.ReadFull` into a fixed buffer, tolerating a short read for files smaller than the cap), and that prefix goes through the same content-pattern matching as before. Secret-shaped strings are text and small, and tend to appear early in a file (env var assignments, key headers), so this catches the failure mode above without reading an arbitrarily large file fully into memory.

## Linked Issue

Closes #151

## Package Impact

- [x] Package format or manifest behavior

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- TestScanForSecretsCatchesContentInFilesOverSizeCap

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- N/A, test included above.

## Notes For Reviewers

Verified the new test is a real regression test: ran it against the pre-fix skip-if-oversized logic with `git stash`, confirmed it fails (`findings = nil, want a finding...`), then restored the fix and confirmed it passes. Content past the first 5MB of a file is still not scanned - that's the documented tradeoff, matching how the size cap already worked for the "don't read arbitrarily large files into memory" concern, just no longer at the cost of skipping matchable content entirely.