### PR TITLE
fix: add stops claiming readiness for a package that was never enabled

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -533,18 +533,25 @@ func runEnable(args []string, home string, stdin *bufio.Reader, stdout, stderr i
 		fmt.Fprintln(stderr, err)
 		return err
 	}
-	return enableRef(ref, home, autoApprove, stdin, stdout, stderr)
+	_, err := enableRef(ref, home, autoApprove, stdin, stdout, stderr)
+	return err
 }
 
 // enableRef is runEnable's actual work, factored out so `lineage add`
 // (which pulls a package and then enables it in one command) shares the
 // exact same project-root resolution, dependency validation, and setup
 // handling instead of a second, drifting implementation.
-func enableRef(ref, home string, autoApprove bool, stdin *bufio.Reader, stdout, stderr io.Writer) error {
+//
+// The bool return reports whether the package actually ended up enabled: a
+// declined setup prompt is not an error (enableRef already printed why and
+// left the workspace unchanged), but it is also not success - callers like
+// runAdd need to tell the two apart instead of treating "no error" as
+// "enabled" and reporting readiness for a package that was never turned on.
+func enableRef(ref, home string, autoApprove bool, stdin *bufio.Reader, stdout, stderr io.Writer) (bool, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		fmt.Fprintln(stderr, err)
-		return err
+		return false, err
 	}
 
 	// Reuse the project config an enclosing `lineage run` would find (it
@@ -562,7 +569,7 @@ func enableRef(ref, home string, autoApprove bool, stdin *bufio.Reader, stdout, 
 		cfg = found.Config
 	} else if !errors.Is(err, config.ErrProjectConfigNotFound) {
 		fmt.Fprintln(stderr, err)
-		return err
+		return false, err
 	}
 
 	// A "./" or "../" style ref is relative to where the user typed it
@@ -579,7 +586,7 @@ func enableRef(ref, home string, autoApprove bool, stdin *bufio.Reader, stdout, 
 	resolvedPath, err := packages.ResolveReference(home, cfg.Workspace, resolveRoot, ref)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
-		return err
+		return false, err
 	}
 
 	// The config we're about to save lives at the project root, and
@@ -609,11 +616,11 @@ func enableRef(ref, home string, autoApprove bool, stdin *bufio.Reader, stdout, 
 	resolvedForValidation, err := packages.ResolveEnabled(home, cfg.Workspace, projectRoot, newEnabled)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
-		return err
+		return false, err
 	}
 	if err := packages.ValidateDependencies(resolvedForValidation); err != nil {
 		fmt.Fprintln(stderr, err)
-		return err
+		return false, err
 	}
 
 	// A package can declare local setup (#72) - tracker files or
@@ -624,12 +631,12 @@ func enableRef(ref, home string, autoApprove bool, stdin *bufio.Reader, stdout, 
 	manifest, err := packages.LoadManifest(resolvedPath)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
-		return err
+		return false, err
 	}
 	setupPlan, err := packages.PlanSetup(projectRoot, manifest.Setup)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
-		return err
+		return false, err
 	}
 	if setupPlan.NeedsAction() {
 		fmt.Fprintf(stdout, "%s wants to set up:\n", manifest.Name)
@@ -649,12 +656,12 @@ func enableRef(ref, home string, autoApprove bool, stdin *bufio.Reader, stdout, 
 			fmt.Fprint(stdout, "Create these? [y/N] ")
 			if !confirm(stdin) {
 				fmt.Fprintln(stdout, "not enabled - setup was declined. Nothing was created or changed.")
-				return nil
+				return false, nil
 			}
 		}
 		if err := packages.ApplySetup(projectRoot, setupPlan); err != nil {
 			fmt.Fprintln(stderr, err)
-			return err
+			return false, err
 		}
 		fmt.Fprintln(stdout, "setup complete.")
 	}
@@ -662,7 +669,7 @@ func enableRef(ref, home string, autoApprove bool, stdin *bufio.Reader, stdout, 
 	cfg.EnabledPackages = newEnabled
 	if err := config.SaveProjectConfig(configPath, cfg); err != nil {
 		fmt.Fprintln(stderr, err)
-		return err
+		return false, err
 	}
 
 	// Record that this project's local environment now descends from
@@ -673,7 +680,7 @@ func enableRef(ref, home string, autoApprove bool, stdin *bufio.Reader, stdout, 
 	digest, err := packages.ComputeDigest(resolvedPath)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
-		return err
+		return false, err
 	}
 
 	// Also take a durable, content-addressed snapshot of exactly what was
@@ -683,7 +690,7 @@ func enableRef(ref, home string, autoApprove bool, stdin *bufio.Reader, stdout, 
 	_, snapshotID, err := snapshot.Create(home, resolvedPath)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
-		return err
+		return false, err
 	}
 
 	if _, err := graph.Append(projectRoot, graph.Record{
@@ -699,11 +706,11 @@ func enableRef(ref, home string, autoApprove bool, stdin *bufio.Reader, stdout, 
 		},
 	}); err != nil {
 		fmt.Fprintln(stderr, err)
-		return err
+		return false, err
 	}
 
 	fmt.Fprintf(stdout, "enabled package %s in %s\n", storedRef, configPath)
-	return nil
+	return true, nil
 }
 
 // runAdd is the one-command receiver path (#77): pull a published package,
@@ -817,8 +824,15 @@ func runAdd(args []string, home string, stdin *bufio.Reader, stdout, stderr io.W
 	}
 
 	fmt.Fprintln(stdout)
-	if err := enableRef(name, home, autoApprove, stdin, stdout, stderr); err != nil {
+	enabled, err := enableRef(name, home, autoApprove, stdin, stdout, stderr)
+	if err != nil {
 		return err
+	}
+	if !enabled {
+		// enableRef already explained why (a declined setup prompt) and
+		// left the workspace unchanged - reporting readiness here would
+		// tell the user to run a package that was never actually enabled.
+		return nil
 	}
 
 	fmt.Fprintf(stdout, "\nReady. Run `lineage run <%s>` to use it.\n", providerNameList())

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -258,6 +258,56 @@ func TestAddWithSetupYesAppliesWithoutPrompt(t *testing.T) {
 	}
 }
 
+// TestAddDecliningSetupDoesNotReportReady covers a regression where `add`
+// (no --yes), for a package with setup, answered "yes" to enabling but "no"
+// to creating its setup files - enableRef correctly declined and left the
+// workspace unchanged, but runAdd only checked enableRef's error (nil, by
+// design, since a declined prompt isn't a failure) and unconditionally
+// printed "Ready. Run `lineage run ...`" anyway, telling the user a package
+// was ready to use when it was never actually enabled.
+func TestAddDecliningSetupDoesNotReportReady(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	srcDir := filepath.Join(tmp, "tracker-pack")
+	initPackageWithSetup(t, srcDir, "tracker-pack")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ref := "tracker-pack@0.1.0"
+	srv := addTestServer(t, ref, srcDir)
+	defer srv.Close()
+
+	t.Setenv(config.HomeEnv, home)
+	t.Setenv("LINEAGE_REGISTRY_URL", srv.URL)
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	var stdout, stderr bytes.Buffer
+	stdin := strings.NewReader("y\nn\n") // yes to enabling, no to setup
+	if err := Execute(nil, []string{"add", ref}, stdin, &stdout, &stderr); err != nil {
+		t.Fatalf("add error = %v stderr=%s", err, stderr.String())
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "not enabled - setup was declined") {
+		t.Errorf("stdout = %q, want it to explain setup was declined", out)
+	}
+	if strings.Contains(out, "Ready.") {
+		t.Errorf("stdout = %q, must not claim readiness for a package that was never enabled", out)
+	}
+	if _, err := config.FindProjectConfig(project); err == nil {
+		t.Error("expected no project config after declining setup - the package must not be marked enabled")
+	}
+	if _, err := os.Stat(filepath.Join(project, "tasks.csv")); !os.IsNotExist(err) {
+		t.Errorf("tasks.csv should not have been created after declining setup: err = %v", err)
+	}
+}
+
 // TestAddRespectsBothPromptsFromSingleBufferedStdin covers a regression
 // where `add` (no --yes) answers two prompts in one run - "enable this
 // package?" then, for a package with setup, "create these files?" - and


### PR DESCRIPTION
## Summary

What changed, and why?

`enableRef` signals a declined setup prompt (a package that declares setup files/directories, where the user answers no to creating them) by printing an explanation and returning `nil` - by design, since declining isn't a hard failure, just an unchanged workspace. `runAdd` only checked whether `enableRef` returned an error, so it unconditionally printed `"Ready. Run \`lineage run <claude|codex>\` to use it."` immediately afterward - even when the package was never actually enabled and no `.lineage/config.yaml` was written.

`enableRef` now returns `(bool, error)`: whether the package actually ended up enabled, distinct from whether the call errored. `runAdd` only prints the readiness message when it's `true`; `runEnable` (the plain `lineage enable` command) doesn't need the distinction, since `enableRef` already prints its own accurate message either way, so it just discards the bool and returns the error as before.

## Linked Issue

Closes #153

## Package Impact

- [x] Setup or permission flow

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- TestAddDecliningSetupDoesNotReportReady

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- N/A, test included above.

## Notes For Reviewers

Verified the new test is a real regression test: ran it against the pre-fix `runAdd` with `git stash`, confirmed it fails with the actual misleading output (`...not enabled - setup was declined...\n\nReady. Run \`lineage run <claude|codex>\` to use it.\n`), then restored the fix and confirmed it passes.

Checked for other callers of `enableRef` (`grep -rn "enableRef("`) - only `runEnable` and `runAdd`, both updated, both covered by the full suite passing.