### PR TITLE
fix: write files atomically everywhere state actually matters

### DIFF
--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -1,0 +1,105 @@
+// Package atomicfile writes files so a crash, kill, or disk-full error
+// mid-write can never leave a corrupt or truncated file at the destination
+// path - a reader always sees either the previous content or the complete
+// new content, never a mix. It does this the standard way: write to a temp
+// file in the same directory (so the final rename stays on one filesystem),
+// then atomically rename that temp file over the destination.
+//
+// Nothing in this codebase should write a file that matters - staged
+// package content, generated context files, project config, shims,
+// imported/exported archives - with a plain os.WriteFile or os.Create.
+package atomicfile
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// File is an in-progress atomic write. Call Write (directly, or via
+// io.Copy) to stream content into it, then exactly one of Commit (to
+// atomically publish it at the destination path) or Close (to discard it).
+// Calling Close after a successful Commit is a safe no-op, so a deferred
+// Close alongside an explicit Commit is the normal usage pattern - the
+// defer only does anything if the function returns before Commit runs.
+type File struct {
+	f       *os.File
+	tmpPath string
+	path    string
+	perm    os.FileMode
+	closed  bool
+}
+
+// Create opens a new temp file in the same directory as path, ready to be
+// written to and later committed there. The directory is created if it
+// doesn't already exist.
+func Create(path string, perm os.FileMode) (*File, error) {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+	tmp, err := os.CreateTemp(dir, ".atomicfile-*")
+	if err != nil {
+		return nil, err
+	}
+	return &File{f: tmp, tmpPath: tmp.Name(), path: path, perm: perm}, nil
+}
+
+// Write implements io.Writer against the underlying temp file.
+func (f *File) Write(p []byte) (int, error) {
+	return f.f.Write(p)
+}
+
+// Commit flushes and closes the temp file, sets its final permissions, and
+// atomically renames it into place at the destination path. The File must
+// not be used after Commit returns, successfully or not.
+func (f *File) Commit() error {
+	defer func() { f.closed = true }()
+
+	if err := f.f.Sync(); err != nil {
+		f.f.Close()
+		os.Remove(f.tmpPath)
+		return err
+	}
+	if err := f.f.Close(); err != nil {
+		os.Remove(f.tmpPath)
+		return err
+	}
+	if err := os.Chmod(f.tmpPath, f.perm); err != nil {
+		os.Remove(f.tmpPath)
+		return err
+	}
+	if err := os.Rename(f.tmpPath, f.path); err != nil {
+		os.Remove(f.tmpPath)
+		return err
+	}
+	return nil
+}
+
+// Close discards the write: closes and removes the temp file without ever
+// touching the destination path. A no-op if Commit already ran (whether it
+// succeeded or failed - both leave nothing at tmpPath to clean up), so it's
+// safe to defer unconditionally alongside an explicit Commit call.
+func (f *File) Close() error {
+	if f.closed {
+		return nil
+	}
+	f.closed = true
+	f.f.Close()
+	return os.Remove(f.tmpPath)
+}
+
+// WriteFile atomically writes data to path: the equivalent of os.WriteFile,
+// but via Create/Write/Commit so a failure or interruption partway through
+// never leaves a partially-written file at path.
+func WriteFile(path string, data []byte, perm os.FileMode) error {
+	f, err := Create(path, perm)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.Write(data); err != nil {
+		return err
+	}
+	return f.Commit()
+}

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -1,0 +1,136 @@
+package atomicfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteFileCreatesNewFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	if err := WriteFile(path, []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello\n" {
+		t.Errorf("content = %q, want %q", got, "hello\n")
+	}
+}
+
+func TestWriteFileReplacesExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteFile(path, []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new\n" {
+		t.Errorf("content = %q, want %q", got, "new\n")
+	}
+}
+
+func TestWriteFileLeavesNoTempFilesBehind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := WriteFile(path, []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "config.yaml" {
+		t.Fatalf("directory entries = %v, want only config.yaml (no leftover temp files)", entries)
+	}
+}
+
+func TestCloseWithoutCommitLeavesDestinationUntouched(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("original\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := Create(path, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("never committed\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "original\n" {
+		t.Errorf("content = %q, want the original content untouched by an aborted write", got)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("directory entries = %v, want only the original file (no leftover temp file after Close)", entries)
+	}
+}
+
+func TestCloseAfterCommitIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	f, err := Create(path, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("hello\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close() after a successful Commit() error = %v, want nil (no-op)", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello\n" {
+		t.Errorf("content = %q, want %q", got, "hello\n")
+	}
+}
+
+func TestWriteFileSetsPermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shim.sh")
+
+	if err := WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Errorf("mode = %v, want 0755", info.Mode().Perm())
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/agentic-lineage/lineage/internal/atomicfile"
 	"github.com/agentic-lineage/lineage/internal/auth"
 	"github.com/agentic-lineage/lineage/internal/config"
 	"github.com/agentic-lineage/lineage/internal/graph"
@@ -405,20 +406,18 @@ func runPackageExport(args []string, stdout, stderr io.Writer) error {
 		outPath = fmt.Sprintf("%s-%s.tgz", report.Manifest.Name, report.Manifest.Version)
 	}
 
-	f, err := os.Create(outPath)
+	f, err := atomicfile.Create(outPath, 0o644)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return err
 	}
+	defer f.Close()
 
 	if err := packages.Export(dir, f); err != nil {
-		f.Close()
-		os.Remove(outPath)
 		fmt.Fprintln(stderr, err)
 		return err
 	}
-	if err := f.Close(); err != nil {
-		os.Remove(outPath)
+	if err := f.Commit(); err != nil {
 		fmt.Fprintln(stderr, err)
 		return err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/agentic-lineage/lineage/internal/atomicfile"
 	"gopkg.in/yaml.v3"
 )
 
@@ -91,14 +92,11 @@ func LoadProjectConfig(path string) (ProjectConfig, error) {
 }
 
 func SaveProjectConfig(path string, cfg ProjectConfig) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("create config directory: %w", err)
-	}
 	data, err := yaml.Marshal(cfg)
 	if err != nil {
 		return fmt.Errorf("encode project config: %w", err)
 	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	if err := atomicfile.WriteFile(path, data, 0o644); err != nil {
 		return fmt.Errorf("write project config: %w", err)
 	}
 	return nil

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/agentic-lineage/lineage/internal/atomicfile"
 )
 
 const (
@@ -135,12 +137,9 @@ func ForPackage(projectRoot, name string) ([]Record, error) {
 
 func save(projectRoot string, records []Record) error {
 	path := statePath(projectRoot)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
 	data, err := json.MarshalIndent(records, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o644)
+	return atomicfile.WriteFile(path, data, 0o644)
 }

--- a/internal/materialize/materialize.go
+++ b/internal/materialize/materialize.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/agentic-lineage/lineage/internal/atomicfile"
 	"github.com/agentic-lineage/lineage/internal/packages"
 	"github.com/agentic-lineage/lineage/internal/provider"
 )
@@ -203,7 +204,7 @@ func saveState(projectRoot, providerName string, s state) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o644)
+	return atomicfile.WriteFile(path, data, 0o644)
 }
 
 func writeSummary(path string, pkgs []packages.Package, wf *WorkflowSequence) error {
@@ -219,10 +220,7 @@ func writeSummary(path string, pkgs []packages.Package, wf *WorkflowSequence) er
 		next = replaceBlock(string(existing), block)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	return os.WriteFile(path, []byte(next), 0o644)
+	return atomicfile.WriteFile(path, []byte(next), 0o644)
 }
 
 func renderSummaryBlock(pkgs []packages.Package, wf *WorkflowSequence) string {
@@ -312,15 +310,14 @@ func copyFile(src, dest string) error {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
-		return err
-	}
-	out, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	out, err := atomicfile.Create(dest, info.Mode().Perm())
 	if err != nil {
 		return err
 	}
 	defer out.Close()
 
-	_, err = io.Copy(out, in)
-	return err
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Commit()
 }

--- a/internal/packages/import.go
+++ b/internal/packages/import.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/agentic-lineage/lineage/internal/atomicfile"
 )
 
 // Import extracts an archive produced by Export into a new directory under
@@ -127,7 +129,7 @@ func extractArchive(r io.Reader, destDir string) error {
 }
 
 func writeArchiveFile(target string, r io.Reader, size int64) error {
-	out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	out, err := atomicfile.Create(target, 0o644)
 	if err != nil {
 		return err
 	}
@@ -136,7 +138,7 @@ func writeArchiveFile(target string, r io.Reader, size int64) error {
 	if _, err := io.CopyN(out, r, size); err != nil {
 		return err
 	}
-	return nil
+	return out.Commit()
 }
 
 // copyTree recursively copies every file under src into dest, preserving
@@ -159,9 +161,6 @@ func copyTree(src, dest string) error {
 		if err != nil {
 			return err
 		}
-		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-			return err
-		}
-		return os.WriteFile(target, data, 0o644)
+		return atomicfile.WriteFile(target, data, 0o644)
 	})
 }

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/agentic-lineage/lineage/internal/atomicfile"
 	"github.com/agentic-lineage/lineage/internal/provider"
 )
 
@@ -42,7 +43,7 @@ func FileName(providerName, goos string) string {
 func writeShim(binDir, lineageBinary, providerName, goos string) error {
 	path := filepath.Join(binDir, FileName(providerName, goos))
 	content, perm := shimContent(lineageBinary, providerName, goos)
-	if err := os.WriteFile(path, []byte(content), perm); err != nil {
+	if err := atomicfile.WriteFile(path, []byte(content), perm); err != nil {
 		return fmt.Errorf("write %s shim: %w", providerName, err)
 	}
 	return nil


### PR DESCRIPTION
## Summary

What changed, and why?

No write path in the codebase used a temp-file-then-rename pattern: provider staging (`internal/materialize`), the generated `CLAUDE.md`/`AGENTS.md` context files, `.lineage/config.yaml`, generated shims, package import, package export, and the local lineage graph all wrote directly to their final path with a plain `os.WriteFile`/`os.Create`. A crash, kill, or disk-full error partway through any of these could leave a corrupted or truncated file at the destination instead of either the old or new content - most visibly for `CLAUDE.md`/`AGENTS.md`, which can carry hand-authored content outside the generated markers (`TestApplyPreservesUserContentAroundMarkers`), and for `.lineage/graph.json`, whose corruption is the exact scenario `#150`'s fix defends `enableRef` against.

Added `internal/atomicfile`: write to a temp file in the same directory, sync, close, chmod, then atomically rename over the destination. Applied it everywhere a write actually matters:

- `materialize.saveState`, `materialize.writeSummary`, `materialize.copyFile` (provider staging)
- `config.SaveProjectConfig`
- `shim.writeShim`
- `graph.save`
- `packages.writeArchiveFile`, `packages.copyTree` (package import)
- `cli`'s package export

This is one fix pattern applied consistently rather than six separate ad-hoc changes, per the issue's own framing.

## Linked Issue

Closes #154

## Package Impact

- [x] Package format or manifest behavior
- [x] Package discovery or enablement
- [x] Provider launch/shim behavior

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- TestWriteFileCreatesNewFile
- TestWriteFileReplacesExistingFile
- TestWriteFileLeavesNoTempFilesBehind
- TestCloseWithoutCommitLeavesDestinationUntouched
- TestCloseAfterCommitIsNoOp
- TestWriteFileSetsPermissions

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- N/A, tests included above for the new atomicfile package itself.

## Notes For Reviewers

No behavior change on any success path - confirmed by the full existing suite (11 packages, including every test that exercises these write call sites: materialize's marker-preservation and idempotency tests, config round-trips, shim generation, package import/export, the graph tests from `#150`'s fix) passing unchanged. `internal/atomicfile` has zero internal dependencies (only `os`/`path/filepath`), so importing it from `materialize`/`config`/`shim`/`graph`/`packages`/`cli` carries no cycle risk.

Actually simulating a crash mid-write isn't practical to assert in a test, so verification here is: (1) `internal/atomicfile`'s own tests prove the primitive itself is correct (no temp file leftover, destination untouched until `Commit`, `Close` after `Commit` is a safe no-op), and (2) every existing behavioral test at each call site still passes, proving no regression on the success path.