### PR TITLE
fix: ApplySetup no longer trusts a stale Exists snapshot (TOCTOU)

### DIFF
--- a/internal/packages/setup.go
+++ b/internal/packages/setup.go
@@ -106,7 +106,7 @@ func ApplySetup(projectRoot string, plan SetupPlan) error {
 		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
 			return fmt.Errorf("create directory for %q: %w", f.Path, err)
 		}
-		if err := os.WriteFile(abs, []byte(f.Template), 0o644); err != nil {
+		if err := createIfMissing(abs, f.Template); err != nil {
 			return fmt.Errorf("create %q: %w", f.Path, err)
 		}
 	}
@@ -118,9 +118,36 @@ func ApplySetup(projectRoot string, plan SetupPlan) error {
 		if err != nil {
 			return fmt.Errorf("setup directory %q: %w", d.Path, err)
 		}
+		// MkdirAll is naturally safe against the same staleness ApplySetup's
+		// file case has to guard against explicitly: it succeeds without
+		// modifying anything if the directory now already exists (created
+		// in the window between PlanSetup and ApplySetup), rather than
+		// overwriting existing content the way a plain file write would.
 		if err := os.MkdirAll(abs, 0o755); err != nil {
 			return fmt.Errorf("create directory %q: %w", d.Path, err)
 		}
 	}
 	return nil
+}
+
+// createIfMissing writes template to abs only if it doesn't already exist,
+// using O_EXCL so the check-and-create is atomic. PlanSetup's Exists
+// snapshot can be stale by the time ApplySetup runs - the two are
+// deliberately split around a confirmation prompt (#72) - so re-trusting
+// that snapshot here could silently overwrite a file that was created in
+// that window. A file that already exists by the time we get here is
+// treated the same as one PlanSetup already knew about: left untouched,
+// consistent with ApplySetup's "anything already present is left
+// completely untouched" contract, not an error.
+func createIfMissing(abs, template string) error {
+	f, err := os.OpenFile(abs, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		if os.IsExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(template)
+	return err
 }

--- a/internal/packages/setup_test.go
+++ b/internal/packages/setup_test.go
@@ -110,6 +110,46 @@ func TestApplySetupCreatesOnlyWhatsMissing(t *testing.T) {
 	}
 }
 
+// TestApplySetupDoesNotOverwriteFileCreatedAfterPlan covers a regression
+// where ApplySetup trusted PlanSetup's Exists snapshot instead of
+// re-checking at apply time. PlanSetup and ApplySetup are deliberately
+// split around a confirmation prompt (#72), so a file can legitimately be
+// created in that window - by the receiver, or by a second package. The
+// stale Exists=false from the plan must not cause ApplySetup to overwrite
+// whatever showed up there in the meantime.
+func TestApplySetupDoesNotOverwriteFileCreatedAfterPlan(t *testing.T) {
+	root := t.TempDir()
+	setup := Setup{
+		Files: []SetupFile{{Path: "notes/log.md", Template: "# Log\n"}},
+	}
+	plan, err := PlanSetup(root, setup)
+	if err != nil {
+		t.Fatalf("PlanSetup() error = %v", err)
+	}
+	if plan.Files[0].Exists {
+		t.Fatalf("plan.Files[0].Exists = %v, want false (file doesn't exist yet)", plan.Files[0].Exists)
+	}
+
+	// Simulate the race: the file gets created in the window between plan
+	// and apply.
+	if err := os.MkdirAll(filepath.Join(root, "notes"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, "notes", "log.md"), "written in the window between plan and apply\n")
+
+	if err := ApplySetup(root, plan); err != nil {
+		t.Fatalf("ApplySetup() error = %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(root, "notes", "log.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "written in the window between plan and apply\n" {
+		t.Errorf("notes/log.md content = %q, want the racing write preserved, not overwritten by the template", got)
+	}
+}
+
 func TestApplySetupIsIdempotent(t *testing.T) {
 	root := t.TempDir()
 	setup := Setup{


### PR DESCRIPTION
## Summary

What changed, and why?

`PlanSetup` and `ApplySetup` (`internal/packages/setup.go`) are deliberately split so the CLI can show a confirmation prompt between them. `ApplySetup` trusted the `Exists` flag `PlanSetup` computed earlier and never re-checked it - for a file plan said was missing, it went straight to a plain `os.WriteFile`, which truncates and overwrites unconditionally. If the target file was created in the window between the two calls (by the user, by a concurrently-enabled package, or a second `lineage` invocation), `ApplySetup` would silently overwrite it - contradicting the documented "anything already present is left completely untouched" guarantee.

File creation now goes through `createIfMissing`, which opens with `O_WRONLY|O_CREATE|O_EXCL` so the check-and-create is atomic at the OS level instead of trusting a snapshot that can be stale by the time it's used; a file that already exists by the time we get here is treated the same as one `PlanSetup` already knew about - left untouched, not an error. Directory creation already gets this for free from `os.MkdirAll`'s natural idempotency (it succeeds without modifying anything if the directory already exists), so no change was needed there.

## Linked Issue

Closes #155

## Package Impact

- [x] Setup or permission flow

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- TestApplySetupDoesNotOverwriteFileCreatedAfterPlan

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- N/A, test included above.

## Notes For Reviewers

Verified the new test is a real regression test: ran it against the pre-fix `os.WriteFile` with `git stash`, confirmed it fails (`content = "# Log\n", want the racing write preserved`), then restored the fix and confirmed it passes.