### PR TITLE
fix: reject a symlinked entrypoint, not just a traversing one

### DIFF
--- a/internal/packages/discovery.go
+++ b/internal/packages/discovery.go
@@ -97,8 +97,26 @@ func validateEntrypoint(dir, provider, entrypoint string) error {
 	if entrypoint == "" {
 		return nil
 	}
-	if _, err := SafeJoin(dir, entrypoint); err != nil {
+	abs, err := SafeJoin(dir, entrypoint)
+	if err != nil {
 		return fmt.Errorf("entrypoints.%s: %w", provider, err)
+	}
+	// SafeJoin is a lexical check - it can't see a symlink that resolves
+	// outside the package on disk. contentFiles rejects symlinks the same
+	// way when walking the standard content directories; entrypoints
+	// aren't required to live inside one of those, so they need their own
+	// check here rather than relying on contentFiles to have already
+	// caught it. A missing entrypoint file is left to whatever reads it
+	// later - this only rejects one that exists and is a symlink.
+	info, statErr := os.Lstat(abs)
+	if statErr != nil {
+		if os.IsNotExist(statErr) {
+			return nil
+		}
+		return fmt.Errorf("entrypoints.%s: %w", provider, statErr)
+	}
+	if info.Mode()&fs.ModeSymlink != 0 {
+		return fmt.Errorf("entrypoints.%s: refusing to use symlink %q as an entrypoint", provider, entrypoint)
 	}
 	return nil
 }

--- a/internal/packages/safepath_test.go
+++ b/internal/packages/safepath_test.go
@@ -1,6 +1,7 @@
 package packages
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -81,5 +82,37 @@ func TestDiscoverAllowsInBoundsEntrypoint(t *testing.T) {
 
 	if _, err := Discover(root); err != nil {
 		t.Fatalf("Discover() error = %v, want no error for in-bounds entrypoint", err)
+	}
+}
+
+// TestDiscoverRejectsSymlinkedEntrypoint covers a regression where entrypoint
+// safety was purely lexical (SafeJoin only). SafeJoin correctly rejects a
+// literal "../" in the declared path, but can't see that an in-bounds-looking
+// path is actually a symlink resolving somewhere else entirely - a package
+// root entrypoint isn't required to live inside one of the content
+// directories contentFiles already walks and rejects symlinks in.
+func TestDiscoverRejectsSymlinkedEntrypoint(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "symlink-pack")
+	if err := InitPackage(root, "symlink-pack"); err != nil {
+		t.Fatal(err)
+	}
+
+	outside := filepath.Join(t.TempDir(), "outside.md")
+	mustWrite(t, outside, "# Not part of the package")
+	if err := os.Symlink(outside, filepath.Join(root, "entry.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest, err := LoadManifest(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest.Entrypoints.Claude = "entry.md"
+	if err := SaveManifest(root, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Discover(root); err == nil {
+		t.Fatal("Discover() error = nil, want error for a symlinked entrypoint")
 	}
 }


### PR DESCRIPTION
## Summary

What changed, and why?

`validateEntrypoint` (`internal/packages/discovery.go`) only called `SafeJoin` - a lexical path check. `SafeJoin` correctly rejects a literal `../` in a declared `entrypoints.claude`/`entrypoints.codex` path, but can't see that an in-bounds-looking path is actually a symlink resolving somewhere else entirely. `contentFiles` already rejects symlinks the same way when walking the standard content directories (`skills`, `workflows`, `agents`, `policies`, `references`, `adapters`), but an entrypoint isn't required to live inside one of those, so that protection doesn't cover it.

Scope note: this was already closed for anything obtained via `lineage package import`/`pull`, since `extractArchive` rejects `tar.TypeSymlink` entries outright. Open for package directories obtained any other way - hand-placed, git-cloned, or locally authored.

`validateEntrypoint` now `os.Lstat`s the resolved path and rejects it if it's a symlink. A missing entrypoint file is left alone (returns nil, same as before) - this only rejects one that exists and is a symlink, not a behavior change for the "doesn't exist yet" case.

## Linked Issue

Closes #156

## Package Impact

- [x] Package format or manifest behavior
- [x] Package discovery or enablement

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- TestDiscoverRejectsSymlinkedEntrypoint

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- N/A, test included above.

## Notes For Reviewers

Verified the new test is a real regression test: ran it against the pre-fix lexical-only `validateEntrypoint` with `git stash`, confirmed it fails (`Discover() error = nil, want error for a symlinked entrypoint`), then restored the fix and confirmed it passes.