### PR TITLE
fix: cap archive extraction size against decompression bombs

### DIFF
--- a/internal/packages/import.go
+++ b/internal/packages/import.go
@@ -77,11 +77,30 @@ func Import(r io.Reader, destParent, asName string) (string, error) {
 	return name, nil
 }
 
+// maxExtractedFileSize caps how large any single extracted file may be.
+// Lineage packages are skills, workflows, and reference text - nothing
+// legitimate needs anywhere near this much space in one file. A var, not a
+// const, so tests can shrink it instead of needing real multi-megabyte
+// fixtures to exercise the limit.
+var maxExtractedFileSize int64 = 50 << 20 // 50MB
+
+// maxExtractedTotalSize caps how much a whole archive may expand to once
+// every entry is extracted. A tar header's declared size is trusted input
+// the same way its path is: a small, highly-compressible archive can
+// truthfully declare gigabytes of decompressed content, and io.CopyN will
+// faithfully write exactly that many bytes if nothing stops it first -
+// this is the classic decompression-bomb shape. Checked against the
+// declared size before any of it is written, not after.
+var maxExtractedTotalSize int64 = 200 << 20 // 200MB
+
 // extractArchive unpacks a tar.gz stream into destDir. Every entry's path
 // is validated with SafeJoin before it's used — the archive is untrusted,
 // package-controlled input, exactly like a manifest field. Only regular
 // files and directories are accepted; anything else (symlinks, devices,
-// hard links) is rejected outright rather than silently skipped.
+// hard links) is rejected outright rather than silently skipped. Declared
+// entry sizes are checked against maxExtractedFileSize/maxExtractedTotalSize
+// before anything is written, so a maliciously small archive can't expand
+// to fill the receiver's disk.
 func extractArchive(r io.Reader, destDir string) error {
 	gz, err := gzip.NewReader(r)
 	if err != nil {
@@ -90,6 +109,7 @@ func extractArchive(r io.Reader, destDir string) error {
 	defer gz.Close()
 
 	tr := tar.NewReader(gz)
+	var totalSize int64
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -109,6 +129,17 @@ func extractArchive(r io.Reader, destDir string) error {
 			// handled below
 		default:
 			return fmt.Errorf("archive entry %q has unsupported type; only regular files and directories are allowed", hdr.Name)
+		}
+
+		if hdr.Size < 0 {
+			return fmt.Errorf("archive entry %q declares a negative size", hdr.Name)
+		}
+		if hdr.Size > maxExtractedFileSize {
+			return fmt.Errorf("archive entry %q is %d bytes, over the %d byte per-file limit", hdr.Name, hdr.Size, maxExtractedFileSize)
+		}
+		totalSize += hdr.Size
+		if totalSize > maxExtractedTotalSize {
+			return fmt.Errorf("archive would extract to more than %d bytes total, refusing (possible decompression bomb)", maxExtractedTotalSize)
 		}
 
 		target, err := SafeJoin(destDir, hdr.Name)

--- a/internal/packages/import_test.go
+++ b/internal/packages/import_test.go
@@ -126,6 +126,94 @@ func TestImportRejectsPathTraversalEntries(t *testing.T) {
 	}
 }
 
+// TestImportRejectsArchiveEntryOverPerFileSizeCap and
+// TestImportRejectsArchiveOverTotalSizeCap cover a regression where
+// extractArchive had no size limit at all: a tar header's declared Size is
+// attacker-controlled input, and a small, highly-compressible .tar.gz can
+// truthfully declare an enormous decompressed size (a classic
+// decompression bomb). Both shrink the package-level caps for the
+// duration of the test so the fixtures stay small and fast instead of
+// needing real multi-megabyte payloads to exercise real-sized limits.
+
+func TestImportRejectsArchiveEntryOverPerFileSizeCap(t *testing.T) {
+	oldMax := maxExtractedFileSize
+	maxExtractedFileSize = 100
+	t.Cleanup(func() { maxExtractedFileSize = oldMax })
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	// The header declares more than the (shrunk) per-file cap; extractArchive
+	// must reject it based on the declared size alone, before ever reading
+	// the body - so the body itself doesn't need to actually be that large.
+	oversized := bytes.Repeat([]byte("x"), 200)
+	if err := tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     "references/huge.txt",
+		Size:     int64(len(oversized)),
+		Mode:     0o644,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(oversized); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	destParent := t.TempDir()
+	if _, err := Import(bytes.NewReader(buf.Bytes()), destParent, ""); err == nil {
+		t.Fatal("Import() error = nil, want error for an archive entry over the per-file size cap")
+	}
+}
+
+func TestImportRejectsArchiveOverTotalSizeCap(t *testing.T) {
+	oldFileMax, oldTotalMax := maxExtractedFileSize, maxExtractedTotalSize
+	maxExtractedFileSize = 100
+	maxExtractedTotalSize = 150
+	t.Cleanup(func() {
+		maxExtractedFileSize = oldFileMax
+		maxExtractedTotalSize = oldTotalMax
+	})
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	// Two entries, each under the per-file cap on its own, but summing to
+	// more than the total cap.
+	for i, name := range []string{"references/a.txt", "references/b.txt"} {
+		content := bytes.Repeat([]byte("x"), 90)
+		if err := tw.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeReg,
+			Name:     name,
+			Size:     int64(len(content)),
+			Mode:     0o644,
+		}); err != nil {
+			t.Fatalf("entry %d: %v", i, err)
+		}
+		if _, err := tw.Write(content); err != nil {
+			t.Fatalf("entry %d: %v", i, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	destParent := t.TempDir()
+	if _, err := Import(bytes.NewReader(buf.Bytes()), destParent, ""); err == nil {
+		t.Fatal("Import() error = nil, want error for an archive over the total size cap")
+	}
+}
+
 func TestImportRefusesArchiveThatFailsValidation(t *testing.T) {
 	var buf bytes.Buffer
 	gz := gzip.NewWriter(&buf)


### PR DESCRIPTION
## Summary

What changed, and why?

`extractArchive` (`internal/packages/import.go`) had no size limit anywhere. A tar entry's declared `Size` comes from the archive itself - attacker-controlled, untrusted input the same way its path is - and `writeArchiveFile`'s `io.CopyN(out, r, size)` faithfully writes exactly that many bytes if nothing stops it first. A small, highly-compressible `.tar.gz` (e.g. a large run of repeated bytes) can truthfully declare an enormous decompressed size while staying tiny on disk - the classic decompression-bomb shape - and fill the receiver's disk during `lineage package import` or `lineage add <ref>`.

Added two checks, both against each entry's *declared* size before anything is written (not measured after the fact, since the declared size is exactly what bounds `io.CopyN`'s write):

- **Per-file cap** (50MB): rejects any single entry over that size. Lineage packages are skills, workflows, and reference text - nothing legitimate needs more.
- **Cumulative total cap** (200MB): rejects an archive whose entries would sum past that once extracted, catching the "many entries, each individually small" variant a per-file cap alone wouldn't.

Both are package-level `var`s rather than `const`s specifically so tests can temporarily shrink them and exercise the limits with small, fast fixtures instead of needing to actually construct real multi-megabyte archives.

## Linked Issue

Closes #157

## Package Impact

- [x] Package format or manifest behavior

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- TestImportRejectsArchiveEntryOverPerFileSizeCap
- TestImportRejectsArchiveOverTotalSizeCap

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- N/A, tests included above.

## Notes For Reviewers

Verified both are real regression tests the strong way: with `git stash`ing just `import.go`, the test file doesn't even compile against the pre-fix code (`undefined: maxExtractedFileSize`) - the tests are structurally impossible to pass without the fix, not just observed to fail once.

Default values (50MB/200MB) are a judgment call, not derived from anything in the codebase - happy to adjust if the maintainer wants different numbers.