### PR TITLE
fix: detect colliding skill directory names instead of silently dropping one

### DIFF
--- a/internal/materialize/materialize.go
+++ b/internal/materialize/materialize.go
@@ -92,7 +92,10 @@ func apply(projectRoot string, adapter provider.Provider, pkgs []packages.Packag
 		return err
 	}
 
-	desired := desiredSkillDirs(adapter, pkgs)
+	desired, err := desiredSkillDirs(adapter, pkgs)
+	if err != nil {
+		return err
+	}
 
 	for _, rel := range prev.SkillDirs {
 		if _, ok := desired[rel]; ok {
@@ -135,7 +138,10 @@ func NeedsApproval(projectRoot string, adapter provider.Provider, pkgs []package
 		return false, err
 	}
 
-	desired := desiredSkillDirs(adapter, pkgs)
+	desired, err := desiredSkillDirs(adapter, pkgs)
+	if err != nil {
+		return false, err
+	}
 	desiredDirs := make([]string, 0, len(desired))
 	for rel := range desired {
 		desiredDirs = append(desiredDirs, rel)
@@ -156,15 +162,28 @@ func NeedsApprovalForWorkflow(projectRoot string, adapter provider.Provider, pkg
 	return NeedsApproval(projectRoot, adapter, []packages.Package{scoped})
 }
 
-func desiredSkillDirs(adapter provider.Provider, pkgs []packages.Package) map[string]string {
+// desiredSkillDirs computes each enabled skill's staged directory name by
+// joining package name and skill name with "-". Neither is restricted
+// enough to make that join unambiguous on its own (manifest names can
+// contain "-", and hyphenated skill names like "commit-messages" are
+// normal): package "foo-bar" skill "x" and package "foo" skill "bar-x"
+// both produce "foo-bar-x". Rather than change the naming scheme (which
+// would make every staged directory harder to read, for a collision that
+// almost never happens), a genuine collision is detected and reported as
+// an error instead of one entry silently overwriting the other in the map.
+func desiredSkillDirs(adapter provider.Provider, pkgs []packages.Package) (map[string]string, error) {
 	desired := map[string]string{} // relative skill dir -> absolute source dir
 	for _, pkg := range pkgs {
 		for _, skill := range pkg.Skills {
 			rel := filepath.Join(adapter.SkillsDir, pkg.Manifest.Name+"-"+skill)
-			desired[rel] = filepath.Join(pkg.Path, "skills", skill)
+			src := filepath.Join(pkg.Path, "skills", skill)
+			if existing, ok := desired[rel]; ok && existing != src {
+				return nil, fmt.Errorf("skill directory name %q is claimed by both %s and %s - rename one of these skills or packages to disambiguate", rel, existing, src)
+			}
+			desired[rel] = src
 		}
 	}
-	return desired
+	return desired, nil
 }
 
 func equalStrings(a, b []string) bool {

--- a/internal/materialize/materialize_test.go
+++ b/internal/materialize/materialize_test.go
@@ -61,6 +61,27 @@ func TestNeedsApprovalTrueWhenPackageSetChanges(t *testing.T) {
 	}
 }
 
+// TestApplyRejectsCollidingSkillDirNames covers a regression where two
+// different (package, skill) pairs whose "-"-joined staged directory names
+// collide (package "foo-bar" skill "x" and package "foo" skill "bar-x"
+// both produce "foo-bar-x") would silently overwrite one another in a map,
+// permanently dropping one package's skill from what actually gets staged.
+// Apply/NeedsApproval must now fail loudly with a clear error instead.
+func TestApplyRejectsCollidingSkillDirNames(t *testing.T) {
+	root := t.TempDir()
+	first := buildTestPackage(t, "foo-bar", "x")
+	second := buildTestPackage(t, "foo", "bar-x")
+	adapter := provider.Provider{Name: "claude", SkillsDir: filepath.Join(".claude", "skills"), ContextFile: "CLAUDE.md"}
+
+	if err := Apply(root, adapter, []packages.Package{first, second}); err == nil {
+		t.Fatal("Apply() error = nil, want an error for colliding skill directory names")
+	}
+
+	if _, err := NeedsApproval(root, adapter, []packages.Package{first, second}); err == nil {
+		t.Fatal("NeedsApproval() error = nil, want an error for colliding skill directory names")
+	}
+}
+
 func TestApplyStagesSkillsAndWritesContextFile(t *testing.T) {
 	root := t.TempDir()
 	pkg := buildTestPackage(t, "review-pack", "review")


### PR DESCRIPTION
## Summary

What changed, and why?

`desiredSkillDirs` (`internal/materialize/materialize.go`) joins package name and skill name with a bare `"-"` and no escaping: `pkg.Manifest.Name+"-"+skill`. Two different `(package, skill)` pairs can collide on the same string - package `foo-bar` skill `x` and package `foo` skill `bar-x` both produce `foo-bar-x`. Since the result is used as a map key, one pair silently overwrote the other during iteration - one package's skill was just never staged, with no error or warning surfaced anywhere.

Considered changing the naming scheme itself (e.g. length-prefixing, so the join is unambiguous by construction) but went with detecting the collision instead: both package names and skill names commonly contain hyphens (`commit-messages` is an existing test fixture skill name), so an unambiguous encoding would make every staged directory name harder to read in the overwhelming majority of cases that never collide, to guard against a coincidence that's rare in practice. `desiredSkillDirs` now tracks each claimed name's source directory and returns a clear error naming both conflicting sources the moment a second, different source claims a name already taken - `Apply`/`NeedsApproval` propagate that error instead of quietly materializing an incomplete package set.

## Linked Issue

Closes #158

## Package Impact

- [x] Provider launch/shim behavior

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- TestApplyRejectsCollidingSkillDirNames

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- N/A, test included above.

## Notes For Reviewers

Verified the new test is a real regression test: ran it against the pre-fix `desiredSkillDirs` (which returned only a `map[string]string`, no error) with `git stash`, confirmed it fails (`Apply() error = nil, want an error for colliding skill directory names`), then restored the fix and confirmed it passes.

`desiredSkillDirs`'s signature changed from `map[string]string` to `(map[string]string, error)` - checked both call sites (`apply`, `NeedsApproval`) and all test files for direct callers (none found outside this package), so this doesn't leak out as a breaking change to anything else.