### PR TITLE
fix: disable gates re-materialization behind confirmation, like enable/run

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -75,7 +75,7 @@ func Execute(ctx context.Context, args []string, stdin io.Reader, stdout, stderr
 	case "list":
 		return runList(home, stdout, stderr)
 	case "disable":
-		return runDisable(args[1:], home, stdout, stderr)
+		return runDisable(args[1:], home, in, stdout, stderr)
 	case "inspect":
 		return runInspect(args[1:], home, stdout, stderr)
 	case "graph":
@@ -853,13 +853,30 @@ func runList(home string, stdout, stderr io.Writer) error {
 	return nil
 }
 
-func runDisable(args []string, home string, stdout, stderr io.Writer) error {
-	if len(args) != 1 {
-		err := fmt.Errorf("usage: lineage disable <package-path-or-id>")
+func runDisable(args []string, home string, stdin *bufio.Reader, stdout, stderr io.Writer) error {
+	if len(args) > 0 && isHelpFlag(args[0]) {
+		fmt.Fprintln(stdout, "usage: lineage disable <package-path-or-id> [--yes]\n\nDisable a package and re-materialize every provider that has ever run in this project, so the packages it staged are actually removed. Asks for confirmation before re-materializing unless --yes is passed.")
+		return nil
+	}
+	ref := ""
+	autoApprove := false
+	for _, a := range args {
+		if a == "--yes" || a == "-y" {
+			autoApprove = true
+			continue
+		}
+		if ref != "" {
+			err := fmt.Errorf("usage: lineage disable <package-path-or-id> [--yes]")
+			fmt.Fprintln(stderr, err)
+			return err
+		}
+		ref = a
+	}
+	if ref == "" {
+		err := fmt.Errorf("usage: lineage disable <package-path-or-id> [--yes]")
 		fmt.Fprintln(stderr, err)
 		return err
 	}
-	ref := args[0]
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -897,6 +914,8 @@ func runDisable(args []string, home string, stdout, stderr io.Writer) error {
 	// anything no longer desired. A provider that was never materialized
 	// here doesn't get a state file created just because something else
 	// was disabled.
+	var pending []provider.Provider
+	needsApproval := false
 	for _, p := range provider.Known() {
 		hasState, err := materialize.HasState(found.Root, p.Name)
 		if err != nil {
@@ -906,6 +925,36 @@ func runDisable(args []string, home string, stdout, stderr io.Writer) error {
 		if !hasState {
 			continue
 		}
+		pending = append(pending, p)
+		na, err := materialize.NeedsApproval(found.Root, p, resolved)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return err
+		}
+		if na {
+			needsApproval = true
+		}
+	}
+
+	// Re-materializing rewrites every provider's staged content, not just
+	// the package being disabled - the same "explicit confirmation before
+	// anything is written" gate `run`/`workflow run` already use, since
+	// this can otherwise silently rewrite other, still-enabled packages'
+	// staged content as a side effect of disabling one.
+	if needsApproval && !autoApprove {
+		names := make([]string, len(pending))
+		for i, p := range pending {
+			names[i] = p.Name
+		}
+		fmt.Fprintf(stdout, "Disabling %s will re-materialize the remaining enabled packages for: %s\n", ref, strings.Join(names, ", "))
+		fmt.Fprint(stdout, "Proceed? [y/N] ")
+		if !confirm(stdin) {
+			fmt.Fprintln(stdout, "aborted: disable was not approved. Nothing was changed.")
+			return nil
+		}
+	}
+
+	for _, p := range pending {
 		if err := materialize.Apply(found.Root, p, resolved); err != nil {
 			fmt.Fprintln(stderr, err)
 			return err

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -508,7 +508,10 @@ func TestDisableCleansUpMaterializedContent(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	if err := Execute(nil, []string{"disable", "./agent-pack"}, nil, &stdout, &stderr); err != nil {
+	// --yes: disabling the only enabled package changes what's
+	// materialized, so it now goes through the same confirmation gate
+	// enable/run/workflow run already use (#160).
+	if err := Execute(nil, []string{"disable", "./agent-pack", "--yes"}, nil, &stdout, &stderr); err != nil {
 		t.Fatalf("disable error = %v stderr=%s", err, stderr.String())
 	}
 	if _, err := os.Stat(filepath.Join(project, ".claude", "skills", "agent-pack-hello")); !os.IsNotExist(err) {
@@ -521,6 +524,62 @@ func TestDisableCleansUpMaterializedContent(t *testing.T) {
 	}
 	if contains(cfg.EnabledPackages, "./agent-pack") {
 		t.Fatalf("EnabledPackages = %#v, want ./agent-pack removed", cfg.EnabledPackages)
+	}
+}
+
+// TestDisableRequiresConfirmationBeforeRematerializing covers a regression
+// where disable was the one mutating command with no confirmation gate at
+// all - every other command that writes staged files (enable, run,
+// workflow run) asks first. Declining must leave both the config and the
+// already-staged content completely untouched, the same as declining any
+// other prompt in this codebase.
+func TestDisableRequiresConfirmationBeforeRematerializing(t *testing.T) {
+	project, _ := setUpEnabledProject(t)
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"run", "claude", "--yes"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("run error = %v stderr=%s", err, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	stdin := strings.NewReader("n\n")
+	if err := Execute(nil, []string{"disable", "./agent-pack"}, stdin, &stdout, &stderr); err != nil {
+		t.Fatalf("disable error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "aborted") {
+		t.Errorf("stdout = %q, want it to explain the disable was aborted", stdout.String())
+	}
+
+	if _, err := os.Stat(filepath.Join(project, ".claude", "skills", "agent-pack-hello")); err != nil {
+		t.Errorf("expected the staged skill to survive a declined disable: %v", err)
+	}
+	cfg, err := config.LoadProjectConfig(config.ProjectConfigPath(project))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(cfg.EnabledPackages, "./agent-pack") {
+		t.Errorf("EnabledPackages = %#v, want ./agent-pack still enabled after declining", cfg.EnabledPackages)
+	}
+}
+
+func TestDisableAcceptsInteractiveConfirmation(t *testing.T) {
+	project, _ := setUpEnabledProject(t)
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"run", "claude", "--yes"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("run error = %v stderr=%s", err, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	stdin := strings.NewReader("y\n")
+	if err := Execute(nil, []string{"disable", "./agent-pack"}, stdin, &stdout, &stderr); err != nil {
+		t.Fatalf("disable error = %v stderr=%s", err, stderr.String())
+	}
+
+	if _, err := os.Stat(filepath.Join(project, ".claude", "skills", "agent-pack-hello")); !os.IsNotExist(err) {
+		t.Errorf("expected staged skill removed after an approved disable, stat err = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

What changed, and why?

`runDisable` (`internal/cli/cli.go`) called `materialize.Apply` for every provider with existing state unconditionally - no `NeedsApproval` check, no prompt of any kind. Every other command that writes staged files (`enable`, `run`, `workflow run`) gates that write behind an explicit `[y/N]` confirmation, per the README's "explicit confirmation before anything is written" principle - `disable` was the one exception. Because `materialize.Apply` re-syncs staged content for every package that's still enabled (not just the one being removed), `lineage disable <pkg>` could silently rewrite *other*, still-enabled packages' staged content as an unannounced side effect of disabling one.

`runDisable` now checks `materialize.NeedsApproval` for each provider that has state before touching anything, and - if any of them would actually change something - prompts once, naming which providers would be re-materialized, unless `--yes`/`-y` is passed. Declining leaves both `.lineage/config.yaml` and every already-staged file completely untouched, matching how declining any other prompt in this codebase behaves.

## Linked Issue

Closes #160

## Package Impact

- [x] Provider launch/shim behavior
- [x] Setup or permission flow

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- TestDisableRequiresConfirmationBeforeRematerializing
- TestDisableAcceptsInteractiveConfirmation

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- N/A, tests included above.

## Notes For Reviewers

Verified the new test is a real regression test: ran it against the pre-fix unconditional `disable` with `git stash`, confirmed it fails (the package ends up disabled and the skill removed even though stdin declined), then restored the fix and confirmed it passes.

This is an intentional behavior change, not just a bug fix in isolation: `disable` now requires `--yes` (or an interactive "y") in the same situations `run`/`workflow run` already do. Updated the one existing test that relied on the old no-confirmation behavior (`TestDisableCleansUpMaterializedContent`) to pass `--yes`, since that's exactly the gap this issue asked to close.