### PR TITLE
fix: recognize a shim by content, not only by which directory it's in

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -95,6 +95,14 @@ func candidateBinariesFor(name, lineageHome, goos string) []string {
 			if !isWindows && info.Mode()&0o111 == 0 {
 				continue
 			}
+			// Directory-based exclusion above only catches a shim installed
+			// under this call's own lineageHome. A shim installed under a
+			// different LINEAGE_HOME earlier, or a stray copy anywhere else
+			// on PATH, would otherwise pass through as a "real" binary here
+			// - see looksLikeShim's doc comment for why that matters.
+			if looksLikeShim(candidate, name) {
+				continue
+			}
 			candidates = append(candidates, candidate)
 		}
 	}
@@ -115,6 +123,52 @@ func candidateExtensions(goos string) []string {
 		pathext = ".COM;.EXE;.BAT;.CMD"
 	}
 	return strings.Split(pathext, ";")
+}
+
+// shimHeaderPrefixes are the literal opening lines of every shim template
+// internal/shim generates. Duplicated here rather than imported, since
+// internal/shim already imports this package (provider.Known()) and this
+// package importing shim back would be a cycle.
+var shimHeaderPrefixes = []string{"#!/bin/sh", "@echo off"}
+
+// looksLikeShim reports whether the file at path is a lineage-generated
+// shim script for a provider named providerName, by content rather than
+// only by which directory it's in. Directory-based exclusion in
+// candidateBinariesFor only catches a shim installed under the current
+// call's own lineageHome; a shim installed under a *different*
+// LINEAGE_HOME (env var changed between when shims were installed and
+// when a later `lineage run` resolves the real binary), or a stray copy
+// of the shim script anywhere else on PATH, would otherwise pass through
+// as a legitimate "real" binary. Launching that would exec straight back
+// into `lineage run`, which resolves the same wrong candidate again: an
+// unbounded fork loop, with no self-detection anywhere else in this path.
+//
+// Requires both a matching header (the exact first line every shim
+// template starts with) and the literal "run <providerName>" marker the
+// shim body always contains, so an unrelated real script that merely
+// starts with "#!/bin/sh" - an extremely common shebang - doesn't false-
+// positive; it would also have to coincidentally contain that specific
+// marker text.
+func looksLikeShim(path, providerName string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	buf := make([]byte, 512)
+	n, _ := f.Read(buf)
+	head := string(buf[:n])
+
+	if !strings.Contains(head, "run "+providerName) {
+		return false
+	}
+	for _, prefix := range shimHeaderPrefixes {
+		if strings.HasPrefix(head, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func IsShimPath(path, lineageHome string) bool {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -68,6 +68,33 @@ func TestCandidateBinariesFindsMultipleAndSkipsShim(t *testing.T) {
 	}
 }
 
+// TestCandidateBinariesSkipsShimContentOutsideShimsDir covers a regression
+// where only a shim's *directory* was excluded (config.ShimsDir(home)),
+// not its content. A shim installed under a different LINEAGE_HOME earlier
+// - or a stray copy of the shim script anywhere else on PATH - would
+// otherwise pass directory-based exclusion and be treated as a real
+// binary; launching it would exec straight back into `lineage run`,
+// resolving the same wrong candidate again with no self-detection: an
+// unbounded fork loop.
+func TestCandidateBinariesSkipsShimContentOutsideShimsDir(t *testing.T) {
+	home := t.TempDir()
+	realDir := t.TempDir()
+	strayDir := t.TempDir() // NOT config.ShimsDir(home) - simulates a shim installed under a different LINEAGE_HOME, or copied elsewhere
+
+	writeExecutable(t, filepath.Join(realDir, "claude"))
+	strayShim := filepath.Join(strayDir, "claude")
+	if err := os.WriteFile(strayShim, []byte("#!/bin/sh\nexec \"/some/other/lineage\" run claude \"$@\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", strings.Join([]string{strayDir, realDir}, string(os.PathListSeparator)))
+
+	candidates := CandidateBinaries("claude", home)
+	if len(candidates) != 1 || candidates[0] != filepath.Join(realDir, "claude") {
+		t.Fatalf("CandidateBinaries() = %#v, want only the real binary in %s (the shim-content stray copy in %s excluded)", candidates, realDir, strayDir)
+	}
+}
+
 func TestCandidateBinariesEmptyWhenNoneFound(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("PATH", t.TempDir())


### PR DESCRIPTION
## Summary

What changed, and why?

`candidateBinariesFor` (`internal/provider/provider.go`) only excluded a shim candidate by comparing its directory against `config.ShimsDir(lineageHome)` for the `lineageHome` passed in at call time. If `LINEAGE_HOME` differs between when shims were installed and when a later `lineage run` resolves the real binary - or a stray copy of the shim script sits anywhere else on `PATH` under the bare provider name - that directory check misses it, and `findRealBinary` can return the shim itself. `provider.Launch` then execs it, the shim runs `lineage run <provider> ...` again, which re-resolves and can pick the same wrong candidate: an unbounded fork loop. `LINEAGE_ACTIVE=1` is set in the launched child's environment but is never read anywhere in the codebase, so despite looking like a recursion guard, it provided no actual protection.

`candidateBinariesFor` now also sniffs each candidate's content, independent of which directory it's in: a match against the shim templates' distinctive header (the literal `#!/bin/sh` or `@echo off` every `internal/shim`-generated script starts with) combined with the `run <providerName>` marker every shim body contains is excluded. Both conditions are required together, so an unrelated real script that happens to start with the extremely common `#!/bin/sh` shebang doesn't false-positive - it would also have to coincidentally contain that specific marker text.

## Linked Issue

Closes #161

## Package Impact

- [x] Provider launch/shim behavior

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- TestCandidateBinariesSkipsShimContentOutsideShimsDir

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- N/A, test included above.

## Notes For Reviewers

Verified the new test is a real regression test: ran it against the pre-fix directory-only exclusion with `git stash`, confirmed the stray shim-content copy (deliberately placed outside `config.ShimsDir(home)`) was included as a candidate, then restored the fix and confirmed it's excluded.

`looksLikeShim` duplicates the shim templates' header strings locally rather than importing `internal/shim`, since `internal/shim` already imports `internal/provider` (for `provider.Known()`) - importing it back here would be a cycle.