### PR TITLE
fix: cap materialized file permissions instead of copying source mode

### DIFF
--- a/internal/materialize/materialize.go
+++ b/internal/materialize/materialize.go
@@ -315,11 +315,27 @@ func copyFile(src, dest string) error {
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 		return err
 	}
-	out, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	// Cap at 0o755 rather than copying the source file's mode verbatim: a
+	// package could otherwise ship a skill file with 0o666/0o777
+	// permissions and have that exact mode replicated into the receiver's
+	// project, potentially leaving world-writable files behind on a
+	// multi-user machine. Masking with 0o755 keeps any owner/group/other
+	// read or execute bits the source had, but can never grant group or
+	// other write access regardless of what the source declared. Chmod'd
+	// explicitly after creation rather than only passed to OpenFile,
+	// since OpenFile's mode argument is itself subject to the process's
+	// umask - relying on that alone would make the cap only as strong as
+	// whatever umask happens to be in effect on the receiver's machine,
+	// rather than a guarantee this codebase actually makes.
+	perm := info.Mode().Perm() & 0o755
+	out, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
 	if err != nil {
 		return err
 	}
 	defer out.Close()
+	if err := out.Chmod(perm); err != nil {
+		return err
+	}
 
 	_, err = io.Copy(out, in)
 	return err

--- a/internal/materialize/materialize_test.go
+++ b/internal/materialize/materialize_test.go
@@ -88,6 +88,39 @@ func TestApplyStagesSkillsAndWritesContextFile(t *testing.T) {
 	}
 }
 
+// TestApplyCapsStagedFilePermissions covers a regression where copyFile
+// copied a source file's permission bits verbatim. A package could ship a
+// skill file with 0o666/0o777 permissions and have that exact mode
+// replicated into the receiver's project, potentially leaving
+// world-writable files behind on a multi-user machine.
+func TestApplyCapsStagedFilePermissions(t *testing.T) {
+	withUmask0(func() {
+		root := t.TempDir()
+		pkg := buildTestPackage(t, "loose-perms-pack", "loose")
+		skillSrc := filepath.Join(pkg.Path, "skills", "loose", "SKILL.md")
+		if err := os.Chmod(skillSrc, 0o777); err != nil {
+			t.Fatal(err)
+		}
+
+		claude, err := provider.Get("claude")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := Apply(root, claude, []packages.Package{pkg}); err != nil {
+			t.Fatalf("Apply() error = %v", err)
+		}
+
+		staged := filepath.Join(root, ".claude", "skills", "loose-perms-pack-loose", "SKILL.md")
+		info, err := os.Stat(staged)
+		if err != nil {
+			t.Fatalf("expected staged skill at %s: %v", staged, err)
+		}
+		if info.Mode().Perm()&0o022 != 0 {
+			t.Errorf("staged file mode = %v, want no group/other write bit (source was 0o777, umask forced to 0 so the OS can't mask this for us)", info.Mode().Perm())
+		}
+	})
+}
+
 func TestApplyStagesSkillsForCodexAdapter(t *testing.T) {
 	root := t.TempDir()
 	pkg := buildTestPackage(t, "review-pack", "review")

--- a/internal/materialize/umask_unix_test.go
+++ b/internal/materialize/umask_unix_test.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package materialize
+
+import "syscall"
+
+// withUmask0 runs fn with the process umask temporarily set to 0, so a
+// permission-related test isn't at the mercy of whatever umask the test
+// happens to run under (a standard 0o022 umask would strip the same bits
+// os.OpenFile's mode argument would ask for anyway, hiding the difference
+// between "the code asked for a safe mode" and "the umask saved us").
+// Windows has no umask concept in this sense, so its variant is a no-op.
+func withUmask0(fn func()) {
+	old := syscall.Umask(0)
+	defer syscall.Umask(old)
+	fn()
+}

--- a/internal/materialize/umask_windows_test.go
+++ b/internal/materialize/umask_windows_test.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package materialize
+
+// withUmask0 is a no-op on Windows, which has no POSIX umask concept -
+// os.OpenFile's mode argument isn't masked the same way there.
+func withUmask0(fn func()) {
+	fn()
+}


### PR DESCRIPTION
## Summary

What changed, and why?

`copyFile` (`internal/materialize/materialize.go`) opened the staged destination file with `info.Mode().Perm()` taken directly from the source file inside the package. A malicious or careless package could ship a skill file with `0o666`/`0o777` permissions, and that exact mode would be replicated verbatim into the receiver's project directory (`.claude/skills/...`) - potentially leaving world-writable files behind on a multi-user machine.

The source mode is now masked with `0o755` before use (keeps any owner/group/other read or execute bits the source had, never grants group/other write access regardless of what the source declared), and explicitly `Chmod`'d after creation rather than relying solely on `OpenFile`'s mode argument - that argument is itself subject to the process's umask, so a receiver running with umask 0 would otherwise get no actual protection from the cap despite the code looking like it enforces one.

## Linked Issue

Closes #169

## Package Impact

- [x] Provider launch/shim behavior

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- TestApplyCapsStagedFilePermissions

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- N/A, test included above.

## Notes For Reviewers

Worth flagging how this test was actually validated, since it caught a subtlety in my own first attempt: writing the test without controlling the process umask, it passed against *both* the fixed and the unfixed code - a standard `0o022` umask already strips the same group/other write bits `OpenFile`'s mode argument would ask for, so the test wasn't distinguishing "the code enforces a safe mode" from "the umask happened to save us." Added `withUmask0` (`internal/materialize/umask_unix_test.go` / `umask_windows_test.go`, split since `syscall.Umask` doesn't exist on Windows) to force umask to 0 for the duration of the assertion, confirmed the test now genuinely fails against the pre-fix code (`staged file mode = -rwxrwxrwx`) via `git stash`, then restored the fix and confirmed it passes.