### PR TITLE
secrets: flag ASIA-prefixed temporary AWS key IDs

### DIFF
--- a/internal/packages/secrets.go
+++ b/internal/packages/secrets.go
@@ -49,7 +49,9 @@ var deniedExtensions = []string{".pem", ".key", ".pfx", ".p12"}
 // are essentially never present in legitimate package source material.
 var secretContentPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`-----BEGIN [A-Z ]*PRIVATE KEY-----`),
-	regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`),         // AWS access key ID
+	// AWS access key ID: AKIA is a long-lived user key, ASIA a temporary
+	// STS/assumed-role session key.
+	regexp.MustCompile(`\b(AKIA|ASIA)[0-9A-Z]{16}\b`),
 	regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9]{20,}`), // GitHub token prefixes (ghp_, gho_, ghu_, ghs_, ghr_)
 }
 

--- a/internal/packages/secrets_test.go
+++ b/internal/packages/secrets_test.go
@@ -62,6 +62,24 @@ func TestScanForSecretsFlagsAWSKeyID(t *testing.T) {
 	}
 }
 
+func TestScanForSecretsFlagsAWSSessionKeyID(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "sts-pack")
+	if err := InitPackage(root, "sts-pack"); err != nil {
+		t.Fatal(err)
+	}
+	// Split for the same reason as the AKIA fixture above.
+	fakeSessionKeyID := "ASIA" + "ABCDEFGHIJKLMNOP"
+	mustWrite(t, filepath.Join(root, "references", "session.txt"), "aws_access_key_id = "+fakeSessionKeyID+"\n")
+
+	findings, err := ScanForSecrets(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasFindingForPath(findings, filepath.ToSlash(filepath.Join("references", "session.txt"))) {
+		t.Fatalf("findings = %#v, want a finding for the temporary STS key ID", findings)
+	}
+}
+
 func TestScanForSecretsCatchesContentInFilesOverSizeCap(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "big-pack")
 	if err := InitPackage(root, "big-pack"); err != nil {


### PR DESCRIPTION
## Summary

The AWS access key ID pattern in `internal/packages/secrets.go` matched only `AKIA` (long-lived user keys), so `ASIA`-prefixed temporary STS/assumed-role session credentials passed the scan unflagged. Both share the same 16-character suffix shape, so this widens the existing pattern to `\b(AKIA|ASIA)[0-9A-Z]{16}\b`.

## Linked Issue

Closes #167

## Package Impact

- [x] Package discovery or enablement

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.

Findings still carry only the path and reason, never the matched value — `TestScanForSecretsNeverIncludesMatchedValue` continues to cover that.

## Verification

Relevant test cases:

- `TestScanForSecretsFlagsAWSSessionKeyID` (new) — an `ASIA`-prefixed key in `references/session.txt` produces a finding.
- `TestScanForSecretsFlagsAWSKeyID` — unchanged, `AKIA` still matches.
- `TestScanForSecretsIgnoresSafeContent` — unchanged, no new false positives.

```text
go build ./...
go test ./internal/packages/
go test ./...
ok  	github.com/agentic-lineage/lineage/internal/packages	0.645s
```

## Notes For Reviewers

The new test fixture splits the literal string (`"ASIA" + "ABCDEF..."`) the same way the existing `AKIA` fixtures do, to keep push protection from flagging the test file itself.
