### PR TITLE
secrets: flag GitHub fine-grained personal access tokens

### DIFF
--- a/internal/packages/secrets.go
+++ b/internal/packages/secrets.go
@@ -52,7 +52,8 @@ var secretContentPatterns = []*regexp.Regexp{
 	// AWS access key ID: AKIA is a long-lived user key, ASIA a temporary
 	// STS/assumed-role session key.
 	regexp.MustCompile(`\b(AKIA|ASIA)[0-9A-Z]{16}\b`),
-	regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9]{20,}`), // GitHub token prefixes (ghp_, gho_, ghu_, ghs_, ghr_)
+	regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9]{20,}`),   // GitHub token prefixes (ghp_, gho_, ghu_, ghs_, ghr_)
+	regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{30,}`), // GitHub fine-grained personal access token
 }
 
 // ScanForSecrets walks a package directory and flags files that look like

--- a/internal/packages/secrets_test.go
+++ b/internal/packages/secrets_test.go
@@ -80,6 +80,24 @@ func TestScanForSecretsFlagsAWSSessionKeyID(t *testing.T) {
 	}
 }
 
+func TestScanForSecretsFlagsFineGrainedGitHubToken(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "gh-pack")
+	if err := InitPackage(root, "gh-pack"); err != nil {
+		t.Fatal(err)
+	}
+	// Split for the same reason as the AWS key ID fixture above.
+	fakeToken := "github" + "_pat_11AAAAAAA0aaaaaaaaaaaaa_" + strings.Repeat("b", 59)
+	mustWrite(t, filepath.Join(root, "references", "token.txt"), "GITHUB_TOKEN="+fakeToken+"\n")
+
+	findings, err := ScanForSecrets(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasFindingForPath(findings, filepath.ToSlash(filepath.Join("references", "token.txt"))) {
+		t.Fatalf("findings = %#v, want a finding for the fine-grained GitHub token", findings)
+	}
+}
+
 func TestScanForSecretsCatchesContentInFilesOverSizeCap(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "big-pack")
 	if err := InitPackage(root, "big-pack"); err != nil {


### PR DESCRIPTION
## Summary

The GitHub token pattern in `internal/packages/secrets.go` covered only the classic `ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_` prefixes, so a `github_pat_` fine-grained token — the format GitHub now steers users toward — scanned clean. This adds a sibling pattern for it rather than widening the existing one, since the two formats have different shapes.

## Linked Issue

Closes #152

## Package Impact

- [x] Package discovery or enablement

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.

Findings still carry only the path and reason, never the matched value.

## Verification

Relevant test cases:

- `TestScanForSecretsFlagsFineGrainedGitHubToken` (new) — a `github_pat_` token in `references/token.txt` produces a finding.
- `TestScanForSecretsIgnoresSafeContent` — unchanged, no new false positives.

```text
go test ./internal/packages/
go test ./...
ok  	github.com/agentic-lineage/lineage/internal/packages	0.742s
```

## Notes For Reviewers

The `{30,}` length floor is deliberately loose rather than pinned to GitHub's current 22+1+59 body length, so a future length change doesn't silently stop matching. It still stays well clear of ordinary prose, since the `github_pat_` prefix carries most of the confidence.

This touches the same var block as #167 (`ASIA` prefix, PR #191). Whichever merges second will need a one-line rebase; happy to fold both into a single PR if you'd prefer.
