### PR TITLE
registry: give pull the same request timeout publish uses

### DIFF
--- a/internal/packages/registry.go
+++ b/internal/packages/registry.go
@@ -39,6 +39,19 @@ func (c RegistryConfig) baseURL() string {
 	return DefaultRegistryURL
 }
 
+// registryRequestTimeout bounds a single registry request end to end,
+// including reading the response body. Without it a hung or slow-drip
+// registry response stalls the command indefinitely with no way out but
+// Ctrl-C.
+const registryRequestTimeout = 60 * time.Second
+
+// registryClient returns the HTTP client every registry call uses, so
+// publish, metadata resolution, and archive download share one timeout
+// policy rather than some of them falling back to http.DefaultClient.
+func registryClient() *http.Client {
+	return &http.Client{Timeout: registryRequestTimeout}
+}
+
 type PublishResult struct {
 	Name             string
 	Version          string
@@ -94,8 +107,7 @@ func Publish(dir string, cfg RegistryConfig) (PublishResult, error) {
 	req.Header.Set("Content-Type", "application/gzip")
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	client := &http.Client{Timeout: 60 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := registryClient().Do(req)
 	if err != nil {
 		return PublishResult{}, fmt.Errorf("publish %s@%s: %w", report.Manifest.Name, report.Manifest.Version, err)
 	}
@@ -142,7 +154,7 @@ func Pull(ref string, cfg RegistryConfig, destParent, asName string) (string, er
 		return "", err
 	}
 
-	resp, err := http.Get(cfg.baseURL() + meta.DownloadPath)
+	resp, err := registryClient().Get(cfg.baseURL() + meta.DownloadPath)
 	if err != nil {
 		return "", fmt.Errorf("download %s: %w", ref, err)
 	}
@@ -176,7 +188,7 @@ func Pull(ref string, cfg RegistryConfig, destParent, asName string) (string, er
 }
 
 func fetchPackageMetadata(ref string, cfg RegistryConfig) (packageMetadata, error) {
-	resp, err := http.Get(cfg.baseURL() + "/api/packages/" + url.PathEscape(ref))
+	resp, err := registryClient().Get(cfg.baseURL() + "/api/packages/" + url.PathEscape(ref))
 	if err != nil {
 		return packageMetadata{}, fmt.Errorf("resolve %s: %w", ref, err)
 	}

--- a/internal/packages/registry_test.go
+++ b/internal/packages/registry_test.go
@@ -276,3 +276,12 @@ func TestPullReportsMissingRef(t *testing.T) {
 		t.Fatal("Pull() error = nil, want error for an unknown ref")
 	}
 }
+
+// TestRegistryClientHasTimeout covers #164: the metadata fetch and archive
+// download in Pull used http.DefaultClient, which has no timeout, so a hung
+// registry stalled `lineage package pull` indefinitely.
+func TestRegistryClientHasTimeout(t *testing.T) {
+	if got := registryClient().Timeout; got != registryRequestTimeout {
+		t.Fatalf("registryClient().Timeout = %v, want %v", got, registryRequestTimeout)
+	}
+}


### PR DESCRIPTION
## Summary

`fetchPackageMetadata` and the archive download inside `Pull` used bare `http.Get`, i.e. `http.DefaultClient`, which has no timeout — a hung or slow-drip registry response stalled `lineage package pull`/`lineage add` indefinitely. `Publish` already built a 60s client inline.

Rather than copy that literal to two more call sites, this lifts it into `registryClient()` behind a named `registryRequestTimeout` constant, and routes all three registry calls through it, so there is one timeout policy instead of three chances to forget one.

## Linked Issue

Closes #164

## Package Impact

- [x] Package discovery or enablement

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.

A registry that never finishes responding is itself part of the untrusted surface; this bounds it. Digest verification after import is unchanged, so `Pull` still fails closed on mismatch.

## Verification

Relevant test cases:

- `TestRegistryClientHasTimeout` (new) — guards that the shared client stays timeout-configured.
- `TestPullImportsAndVerifiesDigest`, `TestPullFailsClosedOnDigestMismatch`, `TestPullFailsClosedOnMissingDigest`, `TestPullReportsMissingRef`, and the `Publish*` tests — unchanged, all still pass against their httptest servers.

```text
go build ./...
go test ./internal/packages/
go test ./...
ok  	github.com/agentic-lineage/lineage/internal/packages	1.076s
```

## Notes For Reviewers

One tradeoff worth a decision: `http.Client.Timeout` covers reading the response body, so the 60s ceiling now also bounds how long an archive download may take, not just how long the server may take to start replying. That is fine for the text-bundle-sized packages Lineage distributes today, and it matches what the issue asked for. If you would rather not couple those two, the alternative is a longer timeout (or a header-only `ResponseHeaderTimeout` via a custom transport) on the download path specifically — happy to switch.

The new test asserts the client's configuration rather than driving a real hang, since a genuine timeout test would have to wait out the full 60s.
