### PR TITLE
cli: normalize the ref in disable the way enable does

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -558,6 +558,28 @@ func runEnable(args []string, home string, stdin *bufio.Reader, stdout, stderr i
 // left the workspace unchanged), but it is also not success - callers like
 // runAdd need to tell the two apart instead of treating "no error" as
 // "enabled" and reporting readiness for a package that was never turned on.
+// projectRelativeRef re-expresses a "./" or "../" style ref - typed
+// relative to cwd - against projectRoot, which is where the config lives
+// and what `lineage run` later resolves enabled_packages entries against.
+// Anything else, including a ref typed at the project root itself, is
+// already stored verbatim and comes back unchanged. Both enable (which
+// writes the entry) and disable (which has to match it) go through this,
+// so the two agree on what string a given ref means.
+func projectRelativeRef(ref, projectRoot, resolveRoot, resolvedPath string) string {
+	if !strings.HasPrefix(ref, ".") || resolveRoot == projectRoot {
+		return ref
+	}
+	rel, err := filepath.Rel(projectRoot, resolvedPath)
+	if err != nil {
+		return ref
+	}
+	rel = filepath.ToSlash(rel)
+	if !strings.HasPrefix(rel, ".") {
+		rel = "./" + rel
+	}
+	return rel
+}
+
 func enableRef(ref, home string, autoApprove bool, stdin *bufio.Reader, stdout, stderr io.Writer) (bool, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -605,16 +627,7 @@ func enableRef(ref, home string, autoApprove bool, stdin *bufio.Reader, stdout, 
 	// that same root. Store relative refs re-expressed against projectRoot
 	// so they still resolve correctly, instead of the literal string the
 	// user typed relative to cwd.
-	storedRef := ref
-	if strings.HasPrefix(ref, ".") && resolveRoot != projectRoot {
-		if rel, relErr := filepath.Rel(projectRoot, resolvedPath); relErr == nil {
-			rel = filepath.ToSlash(rel)
-			if !strings.HasPrefix(rel, ".") {
-				rel = "./" + rel
-			}
-			storedRef = rel
-		}
-	}
+	storedRef := projectRelativeRef(ref, projectRoot, resolveRoot, resolvedPath)
 
 	newEnabled := cfg.EnabledPackages
 	if !contains(newEnabled, storedRef) {
@@ -923,7 +936,18 @@ func runDisable(args []string, home string, stdin *bufio.Reader, stdout, stderr 
 		return err
 	}
 
-	if !contains(found.Config.EnabledPackages, ref) {
+	// Match the entry the way enable wrote it: a relative ref typed from a
+	// subdirectory was stored re-expressed against the project root, so
+	// comparing the literal argument would miss it. If the ref no longer
+	// resolves (the package directory is gone, which is a common reason to
+	// be disabling it), fall back to the literal string, which is still an
+	// exact match for anything enable stored verbatim.
+	storedRef := ref
+	if resolvedPath, resolveErr := packages.ResolveReference(home, found.Config.Workspace, cwd, ref); resolveErr == nil {
+		storedRef = projectRelativeRef(ref, found.Root, cwd, resolvedPath)
+	}
+
+	if !contains(found.Config.EnabledPackages, storedRef) {
 		err := fmt.Errorf("package %q is not enabled in %s", ref, found.Path)
 		fmt.Fprintln(stderr, err)
 		return err
@@ -931,7 +955,7 @@ func runDisable(args []string, home string, stdin *bufio.Reader, stdout, stderr 
 
 	newEnabled := make([]string, 0, len(found.Config.EnabledPackages)-1)
 	for _, r := range found.Config.EnabledPackages {
-		if r != ref {
+		if r != storedRef {
 			newEnabled = append(newEnabled, r)
 		}
 	}

--- a/internal/cli/regression_test.go
+++ b/internal/cli/regression_test.go
@@ -296,3 +296,59 @@ func TestInitWorkspaceRejectsTraversingName(t *testing.T) {
 		t.Fatalf("stat workspace packages dir: %v", err)
 	}
 }
+
+// TestDisableFromSubdirectoryMatchesStoredRef covers #162: `lineage enable
+// ./local-pack` from a subdirectory stores the ref re-expressed against the
+// project root, so `lineage disable ./local-pack` from that same directory
+// has to normalize its argument the same way before matching. Comparing the
+// literal argument made disable reject the exact ref enable had just
+// accepted.
+func TestDisableFromSubdirectoryMatchesStoredRef(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	sub := filepath.Join(project, "packages", "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	rootConfigPath := config.ProjectConfigPath(project)
+	if err := config.SaveProjectConfig(rootConfigPath, config.DefaultProjectConfig()); err != nil {
+		t.Fatal(err)
+	}
+	pkgDir := filepath.Join(sub, "local-pack")
+	if err := packages.InitPackage(pkgDir, "local-pack"); err != nil {
+		t.Fatal(err)
+	}
+
+	oldHome := os.Getenv(config.HomeEnv)
+	t.Setenv(config.HomeEnv, home)
+	defer t.Setenv(config.HomeEnv, oldHome)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+	if err := os.Chdir(sub); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"enable", "./local-pack"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("enable error = %v stderr=%s", err, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if err := Execute(nil, []string{"disable", "./local-pack", "--yes"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("disable error = %v stderr=%s; disable must normalize the ref the same way enable did", err, stderr.String())
+	}
+
+	rootCfg, err := config.LoadProjectConfig(rootConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rootCfg.EnabledPackages) != 0 {
+		t.Fatalf("root config EnabledPackages = %#v, want empty after disable", rootCfg.EnabledPackages)
+	}
+}


### PR DESCRIPTION
## Summary

`enableRef` re-expresses a `./`-relative ref against the project root before storing it, so `lineage enable ./local-pack` from `project/packages/sub` writes `./packages/sub/local-pack`. `runDisable` compared the literal CLI argument against `enabled_packages`, so `lineage disable ./local-pack` from that same directory failed with `package "./local-pack" is not enabled` — rejecting the exact ref enable had accepted moments earlier.

This lifts the normalization enable was doing inline into `projectRelativeRef` and calls it from both sides, so the two commands agree on what string a given ref means.

If the ref no longer resolves — the package directory being gone is a common reason to be disabling it — disable falls back to the literal argument, which still exactly matches anything enable stored verbatim. The error message keeps quoting what the user typed, not the normalized form.

## Linked Issue

Closes #162

## Package Impact

- [x] Package discovery or enablement

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.

Resolution still goes through `packages.ResolveReference`; this only changes which string is compared against config, and only ever narrows to a ref that already resolves.

## Verification

Relevant test cases:

- `TestDisableFromSubdirectoryMatchesStoredRef` (new) — enable then disable `./local-pack` from a subdirectory; the round trip now succeeds and leaves `enabled_packages` empty. Confirmed it fails on `develop` with exactly the reported error before the fix.
- `TestEnableFromSubdirectoryUsesProjectRoot` — unchanged, still passes over the extracted helper.

```text
go test ./...
ok  	github.com/agentic-lineage/lineage/internal/cli	3.753s
(all packages ok)
```

## Notes For Reviewers

The extraction is behavior-preserving for enable: `projectRelativeRef` folds the old `strings.HasPrefix(ref, ".") && resolveRoot != projectRoot` guard and the `filepath.Rel` failure fallback in unchanged.

Disable resolves the ref once to normalize it, which enable already had in hand. I kept the resolve local rather than restructuring `runDisable`'s config lookup, to keep the diff to the matching bug.