### PR TITLE
auth: re-enforce 0600 on an existing token file

### DIFF
--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -7,6 +7,10 @@ import (
 	"strings"
 )
 
+// tokenFileMode keeps the stored bearer credential readable only by its
+// owner.
+const tokenFileMode = 0o600
+
 // TokenPath is where `lineage login` stores the GitHub device-flow token.
 func TokenPath(home string) string {
 	return filepath.Join(home, "github_token")
@@ -20,8 +24,16 @@ func SaveToken(home, token string) error {
 	if err := os.MkdirAll(home, 0o755); err != nil {
 		return fmt.Errorf("create lineage home: %w", err)
 	}
-	if err := os.WriteFile(TokenPath(home), []byte(strings.TrimSpace(token)+"\n"), 0o600); err != nil {
+	path := TokenPath(home)
+	if err := os.WriteFile(path, []byte(strings.TrimSpace(token)+"\n"), tokenFileMode); err != nil {
 		return fmt.Errorf("save GitHub token: %w", err)
+	}
+	// The mode passed to WriteFile only applies when the file is created,
+	// so an existing github_token - from an older Lineage, a manual edit, a
+	// restored backup - would keep whatever loose permissions it already
+	// had. Re-enforce them on every save instead.
+	if err := os.Chmod(path, tokenFileMode); err != nil {
+		return fmt.Errorf("restrict GitHub token permissions: %w", err)
 	}
 	return nil
 }

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -63,3 +63,30 @@ func TestTokenPathIsUnderHome(t *testing.T) {
 		t.Errorf("TokenPath(%q) = %q, want %q", home, got, want)
 	}
 }
+
+// TestSaveTokenTightensExistingLoosePermissions covers #159: the mode
+// passed to os.WriteFile only applies when the file is created, so a
+// github_token that already existed with loose permissions - from an older
+// Lineage, a manual edit, a restored backup - kept them across every
+// subsequent save.
+func TestSaveTokenTightensExistingLoosePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not meaningful on Windows")
+	}
+	home := t.TempDir()
+	if err := os.WriteFile(TokenPath(home), []byte("gho_stale\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SaveToken(home, "gho_fresh"); err != nil {
+		t.Fatalf("SaveToken() error = %v", err)
+	}
+
+	info, err := os.Stat(TokenPath(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := info.Mode().Perm(); mode&0o077 != 0 {
+		t.Errorf("token file mode = %o after overwriting a pre-existing world-readable file, want no group/other permission bits", mode)
+	}
+}


### PR DESCRIPTION
## Summary

`SaveToken` relied on the mode argument to `os.WriteFile`, which POSIX `open()` applies only when the file is created. A `github_token` that already existed — written by an older Lineage, edited by hand, restored from a backup — kept whatever permissions it already had, so a world-readable bearer credential stayed world-readable across every subsequent `lineage login`.

This adds an explicit `os.Chmod` after the write, and names the mode so the create path and the re-enforce path cannot drift apart.

## Linked Issue

Closes #159

## Package Impact

- [x] Setup or permission flow

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.

This narrows who can read a stored credential; nothing new is written or exported. A `chmod` failure is surfaced as an error rather than swallowed, so login cannot quietly report success while leaving the token loose.

## Verification

Relevant test cases:

- `TestSaveTokenTightensExistingLoosePermissions` (new) — pre-creates `github_token` at `0644`, saves over it, asserts no group/other bits survive. Fails on `develop` with `token file mode = 644`. Skipped on Windows, matching the existing permission assertion.
- `TestSaveLoadDeleteTokenRoundTrip` — unchanged; it only covered the freshly-created case, which is why this slipped through.

```text
go test ./internal/auth/
go test ./...
ok  	github.com/agentic-lineage/lineage/internal/auth	5.598s
```

## Notes For Reviewers

`os.Chmod` is a no-op cost on the common path (file just created at the right mode), so I did not gate it behind a stat-and-compare.

Worth noting the scope limit: this fixes permissions going forward from the next `lineage login`. It does not repair a loose token file that exists right now and is never saved over again. If you want that covered, `LoadToken` could tighten on read too — happy to file or fold that in, but it changes a read path into a write path, so I left it out of this fix.
