### PR TITLE
cli: validate the workspace name before joining it into the home dir

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -130,6 +130,10 @@ func runInit(args []string, home string, stdout, stderr io.Writer) error {
 			fmt.Fprintln(stderr, err)
 			return err
 		}
+		if err := config.ValidateWorkspaceName(args[1]); err != nil {
+			fmt.Fprintln(stderr, err)
+			return err
+		}
 		dir := config.WorkspacePackagesDir(home, args[1])
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			fmt.Fprintln(stderr, err)

--- a/internal/cli/regression_test.go
+++ b/internal/cli/regression_test.go
@@ -263,3 +263,36 @@ func TestParseRunArgs(t *testing.T) {
 		})
 	}
 }
+
+// TestInitWorkspaceRejectsTraversingName covers #171: `lineage init
+// workspace ../../escaped` created `.../escaped/packages` outside the
+// intended workspaces/ directory, because the name went straight into
+// filepath.Join unvalidated.
+func TestInitWorkspaceRejectsTraversingName(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home", "lineage")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(config.HomeEnv, home)
+
+	var stdout, stderr bytes.Buffer
+	if err := Execute(nil, []string{"init", "workspace", filepath.Join("..", "..", "escaped")}, nil, &stdout, &stderr); err == nil {
+		t.Fatal("init workspace with a traversing name: error = nil, want a rejection")
+	}
+
+	escaped := filepath.Join(tmp, "escaped")
+	if _, err := os.Stat(escaped); err == nil {
+		t.Fatalf("a workspace directory was created at %s, outside %s", escaped, config.WorkspacesDir(home))
+	}
+
+	// A well-formed name still works.
+	stdout.Reset()
+	stderr.Reset()
+	if err := Execute(nil, []string{"init", "workspace", "team-a"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("init workspace team-a error = %v stderr=%s", err, stderr.String())
+	}
+	if _, err := os.Stat(config.WorkspacePackagesDir(home, "team-a")); err != nil {
+		t.Fatalf("stat workspace packages dir: %v", err)
+	}
+}

--- a/internal/config/home.go
+++ b/internal/config/home.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 )
 
 const HomeEnv = "LINEAGE_HOME"
@@ -30,6 +31,27 @@ func WorkspacesDir(home string) string {
 
 func WorkspacePackagesDir(home, name string) string {
 	return filepath.Join(WorkspacesDir(home), name, "packages")
+}
+
+// workspaceNamePattern is the safe charset for a workspace name: it has to
+// survive being used as a single directory name under WorkspacesDir on
+// every supported platform, so no separators, no drive letters, no
+// leading dot.
+var workspaceNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+
+// ValidateWorkspaceName rejects names that would not stay inside
+// WorkspacesDir once joined, or that are not usable as a directory name.
+// A workspace name is a plain identifier, not a path: callers pass it
+// straight to WorkspacePackagesDir, where "../.." would otherwise escape
+// the Lineage home entirely.
+func ValidateWorkspaceName(name string) error {
+	if name == "" {
+		return fmt.Errorf("workspace name must not be empty")
+	}
+	if !workspaceNamePattern.MatchString(name) {
+		return fmt.Errorf("invalid workspace name %q: use letters, digits, dot, dash, or underscore, starting with a letter or digit", name)
+	}
+	return nil
 }
 
 func ShimsDir(home string) string {

--- a/internal/config/home_test.go
+++ b/internal/config/home_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestValidateWorkspaceName covers #171: `lineage init workspace
+// ../../escaped` created a directory outside WorkspacesDir, because the
+// name went straight into filepath.Join with no validation.
+func TestValidateWorkspaceName(t *testing.T) {
+	valid := []string{"team", "team-a", "team_a", "team.a", "Team1", "a"}
+	for _, name := range valid {
+		if err := ValidateWorkspaceName(name); err != nil {
+			t.Errorf("ValidateWorkspaceName(%q) = %v, want nil", name, err)
+		}
+	}
+
+	invalid := []string{"", "..", ".", "../../escaped", "a/b", `a\b`, ".hidden", "a b", "-leading"}
+	for _, name := range invalid {
+		if err := ValidateWorkspaceName(name); err == nil {
+			t.Errorf("ValidateWorkspaceName(%q) = nil, want an error", name)
+		}
+	}
+}
+
+// TestValidateWorkspaceNameKeepsJoinInsideWorkspacesDir asserts the
+// property the charset exists to protect, rather than only the charset.
+func TestValidateWorkspaceNameKeepsJoinInsideWorkspacesDir(t *testing.T) {
+	home := t.TempDir()
+	root := WorkspacesDir(home)
+	for _, name := range []string{"team", "team-a", "Team1.2_3"} {
+		if err := ValidateWorkspaceName(name); err != nil {
+			t.Fatalf("ValidateWorkspaceName(%q) = %v, want nil", name, err)
+		}
+		dir := WorkspacePackagesDir(home, name)
+		if !strings.HasPrefix(filepath.Clean(dir), filepath.Clean(root)+string(filepath.Separator)) {
+			t.Errorf("WorkspacePackagesDir(%q) = %q, want it under %q", name, dir, root)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`lineage init workspace <name>` passed the name straight to `config.WorkspacePackagesDir`, i.e. into `filepath.Join`, with no validation. `lineage init workspace ../../escaped` therefore created `.../escaped/packages` outside the intended `workspaces/` directory — reproduced, and now covered by a test that fails on `develop`.

A workspace name is a plain identifier, not a path, so this validates it against a safe charset up front rather than trying to sanitize the joined result.

## Linked Issue

Closes #171

## Package Impact

- [x] Setup or permission flow

## Safety

- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] This change does not export secrets, credentials, private prompts, or machine-local state.

The rejected charset also covers the Windows separator and leading dots, so a name that validates is usable as a single directory component on every supported platform, not only one where `/` happens to be the separator.

## Verification

Relevant test cases:

- `TestInitWorkspaceRejectsTraversingName` (new, `internal/cli`) — the reported `../../escaped` reproduction is rejected, no directory appears outside `WorkspacesDir`, and a well-formed name still initializes. Fails on `develop` with `error = nil, want a rejection`.
- `TestValidateWorkspaceName` (new, `internal/config`) — accept/reject table including `..`, `.`, `a/b`, `a\\b`, `.hidden`, and empty.
- `TestValidateWorkspaceNameKeepsJoinInsideWorkspacesDir` (new) — asserts the property the charset exists to protect, so the test does not just restate the regex.

```text
go test ./...
(all packages ok)
```

## Notes For Reviewers

I put `ValidateWorkspaceName` in `config` next to `WorkspacePackagesDir` rather than inline in `runInit`, so the check lives beside the join it protects and is available if another caller ever takes a workspace name. `runInit` is the only caller of `WorkspacePackagesDir` today.

Related but deliberately out of scope: `ResolveReference` builds `home/workspaces/<workspace>/packages` from `cfg.Workspace` (`internal/packages/discovery.go:263`) without going through `WorkspacePackagesDir`, so a hand-edited `workspace:` value in a project config is a separate read-side path worth its own issue. Happy to file it if you agree it's a real gap.