### PR TITLE
config: nil-guard EnabledPackages after unmarshal

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,9 @@ func LoadProjectConfig(path string) (ProjectConfig, error) {
 	if cfg.Providers == nil {
 		cfg.Providers = map[string]Provider{}
 	}
+	if cfg.EnabledPackages == nil {
+		cfg.EnabledPackages = []string{}
+	}
 	return cfg, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -61,3 +61,28 @@ func TestFindProjectConfigMissing(t *testing.T) {
 		t.Fatal("FindProjectConfig() error = nil, want error")
 	}
 }
+
+// TestLoadProjectConfigNormalizesExplicitEmptyCollections covers #168: an
+// explicit `enabled_packages:` with no value unmarshals to nil, overwriting
+// the empty slice DefaultProjectConfig seeded. The two sibling map fields
+// were already guarded; this one was not.
+func TestLoadProjectConfigNormalizesExplicitEmptyCollections(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("enabled_packages:\nprovider_preferences:\nproviders:\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadProjectConfig(path)
+	if err != nil {
+		t.Fatalf("LoadProjectConfig() error = %v", err)
+	}
+	if cfg.EnabledPackages == nil {
+		t.Error("EnabledPackages = nil, want an empty slice like the sibling map fields get")
+	}
+	if cfg.ProviderPreferences == nil {
+		t.Error("ProviderPreferences = nil, want an empty map")
+	}
+	if cfg.Providers == nil {
+		t.Error("Providers = nil, want an empty map")
+	}
+}


### PR DESCRIPTION
## Summary

`LoadProjectConfig` re-initializes `ProviderPreferences` and `Providers` to empty collections when `yaml.Unmarshal` leaves them nil, but `EnabledPackages` got no equivalent treatment. A config with an explicit but valueless `enabled_packages:` key unmarshals to nil, overwriting the empty slice `DefaultProjectConfig` seeded, so the field came back nil instead of the documented `[]string{}`.

## Linked Issue

Closes #168

## Package Impact

- [x] Package discovery or enablement

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.

## Verification

Relevant test cases:

- `TestLoadProjectConfigNormalizesExplicitEmptyCollections` (new) — loads a config with all three keys present and valueless, asserts none of them come back nil. Fails on `develop` on the `EnabledPackages` assertion and passes the two sibling assertions, which is exactly the inconsistency this closes.

```text
go test ./...
(all packages ok)
```

## Notes For Reviewers

As the issue notes, practical impact is low — a nil slice ranges, lens, and appends like an empty one, so nothing was misbehaving. This is about the loaded config matching its documented shape, and about the next reader of `LoadProjectConfig` not having to work out why two of three collections are normalized. I kept the test covering all three fields so the guard can't be dropped from one of them again without a failure.