### PR TITLE
Fix help flag parsing and add regression tests

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/agentic-lineage/lineage/internal/auth"
@@ -167,7 +168,14 @@ func isHelpFlag(s string) bool {
 	return s == "-h" || s == "--help"
 }
 
+// is there a help flag anywhere in this command's arguments?
+func hasHelpFlag(args []string) bool {
+	return slices.ContainsFunc(args, isHelpFlag)
+}
+
 func runPackage(args []string, home string, stdout, stderr io.Writer) error {
+	//   Can't call hasHelpFlag here, otherwise general lineage package help
+	// would be printed
 	if len(args) > 0 && isHelpFlag(args[0]) {
 		fmt.Fprintln(stdout, packageUsage)
 		return nil
@@ -180,7 +188,7 @@ func runPackage(args []string, home string, stdout, stderr io.Writer) error {
 
 	switch args[0] {
 	case "init":
-		if isHelpFlag(args[1]) {
+		if hasHelpFlag(args[1:]) {
 			fmt.Fprintln(stdout, "usage: lineage package init <name>\n\nScaffold a new package: lineage.yaml plus the standard skills/workflows/agents/policies/references/adapters folders.")
 			return nil
 		}
@@ -198,7 +206,7 @@ func runPackage(args []string, home string, stdout, stderr io.Writer) error {
 		fmt.Fprintf(stdout, "initialized package %s\n", dir)
 		return nil
 	case "validate":
-		if isHelpFlag(args[1]) {
+		if hasHelpFlag(args[1:]) {
 			fmt.Fprintln(stdout, "usage: lineage package validate <path> [--yaml]\n\nCheck manifest schema, export authority, entrypoint path safety, and scan for secrets - without enabling or writing anything. --yaml prints a stable, provider-independent structured report instead of the human-readable summary.")
 			return nil
 		}
@@ -238,7 +246,7 @@ func runPackage(args []string, home string, stdout, stderr io.Writer) error {
 }
 
 func runPackagePublish(args []string, home string, stdout, stderr io.Writer) error {
-	if len(args) > 0 && isHelpFlag(args[0]) {
+	if hasHelpFlag(args) {
 		fmt.Fprintln(stdout, "usage: lineage package publish <path>\n\nValidate and publish a package to the Lineage registry, identified by the GitHub login from `lineage login` (or LINEAGE_PUBLISH_TOKEN). The first publish of a name claims it; later publishes need the same identity.")
 		return nil
 	}
@@ -275,7 +283,7 @@ func runPackagePublish(args []string, home string, stdout, stderr io.Writer) err
 }
 
 func runPackagePull(args []string, home string, stdout, stderr io.Writer) error {
-	if len(args) > 0 && isHelpFlag(args[0]) {
+	if hasHelpFlag(args) {
 		fmt.Fprintln(stdout, "usage: lineage package pull <package-ref> [--as name]\n\nFetch a published package (ref is \"name\" for the latest version, or an exact \"name@version\") and verify its content digest. An unauthenticated read - no login needed.")
 		return nil
 	}
@@ -318,7 +326,7 @@ func runPackagePull(args []string, home string, stdout, stderr io.Writer) error 
 }
 
 func runPackageImport(args []string, home string, stdout, stderr io.Writer) error {
-	if len(args) > 0 && isHelpFlag(args[0]) {
+	if hasHelpFlag(args) {
 		fmt.Fprintln(stdout, "usage: lineage package import <file.tgz> [--as name]\n\nExtract an exported archive into the user packages directory, re-validating it as untrusted input. Never overwrites an existing package; use --as to import under a different name.")
 		return nil
 	}
@@ -365,7 +373,7 @@ func runPackageImport(args []string, home string, stdout, stderr io.Writer) erro
 }
 
 func runPackageExport(args []string, stdout, stderr io.Writer) error {
-	if len(args) > 0 && isHelpFlag(args[0]) {
+	if hasHelpFlag(args) {
 		fmt.Fprintln(stdout, "usage: lineage package export <path> [-o file.tgz]\n\nWrite a deterministic .tgz archive of the package after running the same checks as validate. Refuses to export a package that fails validation.")
 		return nil
 	}
@@ -510,7 +518,7 @@ func describeSuffix(description string) string {
 }
 
 func runEnable(args []string, home string, stdin *bufio.Reader, stdout, stderr io.Writer) error {
-	if len(args) > 0 && isHelpFlag(args[0]) {
+	if hasHelpFlag(args) {
 		fmt.Fprintln(stdout, "usage: lineage enable <package-path-or-id> [--yes]\n\nEnable a package in the current project. If the package declares setup - tracker files or directories its workflow expects - shows the plan and asks permission before creating anything; --yes skips that prompt.")
 		return nil
 	}
@@ -755,7 +763,7 @@ func importAddSource(ref, destParent string) (name, action string, err error) {
 }
 
 func runAdd(args []string, home string, stdin *bufio.Reader, stdout, stderr io.Writer) error {
-	if len(args) > 0 && isHelpFlag(args[0]) {
+	if hasHelpFlag(args) {
 		fmt.Fprintln(stdout, "usage: lineage add <package-ref> [--yes]\n\nFetch a published package, show what it contains, ask permission, then enable it in the current project - the one-command receiver path. <package-ref> is a registry ref (name or name@version), or the path to a local .tgz archive from `lineage package export`.")
 		return nil
 	}
@@ -922,7 +930,7 @@ func runDisable(args []string, home string, stdout, stderr io.Writer) error {
 }
 
 func runInspect(args []string, home string, stdout, stderr io.Writer) error {
-	if len(args) > 0 && isHelpFlag(args[0]) {
+	if hasHelpFlag(args) {
 		fmt.Fprintln(stdout, "usage: lineage inspect <package-path-or-id> [--yaml]\n\nShow a package's contents. --yaml prints a stable, provider-independent structured report instead of the human-readable summary.")
 		return nil
 	}

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -70,3 +70,47 @@ func TestPackageSubcommandHelpDoesNotTreatFlagAsArgument(t *testing.T) {
 		}
 	}
 }
+
+func TestHelpFlagRecognizedAfterOtherArguments(t *testing.T) {
+	cases := []struct {
+		args []string
+		wantUsage string
+	}{
+		{[]string{"enable", "--yes", "--help"}, "usage: lineage enable"},
+		{[]string{"add", "--yes", "-h"}, "usage: lineage add"},
+		{[]string{"inspect", "--yaml", "--help"}, "usage: lineage inspect"},
+		{
+			[]string{"package", "export", ".", "-o", "out.tgz", "--help"},
+			"usage: lineage package export",
+		},
+		{
+			[]string{"package", "pull", "example", "--as", "renamed", "-h"},
+			"usage: lineage package pull",
+		},
+	}
+
+	for _, tc := range cases {
+		var stdout, stderr bytes.Buffer
+
+		err := Execute(nil, tc.args, nil, &stdout, &stderr)
+		if err != nil {
+			t.Fatalf("%v: error = %v; stderr = %q",
+				tc.args, err, stderr.String())
+		}
+
+		if !strings.HasPrefix(stdout.String(), tc.wantUsage) {
+			t.Fatalf("%v: stdout = %q, want prefix %q",
+				tc.args, stdout.String(), tc.wantUsage)
+		}
+
+		if stderr.Len() != 0 {
+			t.Fatalf("%v: stderr = %q, want empty", tc.args, stderr.String())
+		}
+	}
+}
+
+func TestHasHelpFlagRequiresExactToken(t *testing.T) {
+	if hasHelpFlag([]string{"--helpful", "docs/--help-example"}) {
+		t.Fatal("similar strings must not be interpreted as help flags")
+	}
+}


### PR DESCRIPTION
## Summary

Changed files `internal/cli/cli.go` and `internal/cli/help_test.go`
I introduced function `hasHelpFlag` in the former and a couple of tests in the latter.
`hasHelpFlag(args)` checks if any string in `args` is a help flag.

## Linked Issue

Closes #172

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`, or it is a release-tracked promotion into `master`.
- [ ] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [ ] Package format or manifest behavior
- [x] Package discovery or enablement
- [ ] Provider launch/shim behavior
- [ ] Setup or permission flow
- [ ] Documentation only
- [ ] Tests only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- `TestHelpFlagRecognizedAfterOtherArguments`
- `TestHasHelpFlagRequiresExactToken`

```text
go test ./internal/cli -run Help
go test ./...
go run ./cmd/lineage enable --yes --help
```
