### PR TITLE
Add canonical safety docs; document rollback and yank terminology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@ lineage workflow run resume-review codex --dry-run
 - Repository: https://github.com/agentic-lineage/lineage
 - Website and registry: https://agenticlineage.vercel.app/
 - Package directory: https://agenticlineage.vercel.app/packages
+- Safety model: https://github.com/agentic-lineage/lineage/blob/develop/docs/safety.md
 - Architecture: https://github.com/agentic-lineage/lineage/blob/develop/docs/architecture.md
 - What is a Lineage package: https://github.com/agentic-lineage/lineage/blob/develop/docs/guides/lineage-package.md
 - How to share Claude Code and Codex workflows: https://github.com/agentic-lineage/lineage/blob/develop/docs/guides/share-agent-workflows.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,3 +182,12 @@ All notable changes to Lineage will be documented here.
   also takes a durable snapshot of exactly what was enabled, and links
   it to the graph entry above via `snapshot_id`. Identical file content
   is stored once regardless of how many packages/versions reference it.
+- Added `docs/safety.md` as the canonical safety model (#143, #137):
+  maps every safety check to its pipeline stage, spells out secret-scan
+  and capability-declaration limits, and says plainly that PII/personal-
+  context detection and instruction-risk scanning are not implemented
+  yet. README, `docs/architecture.md`, `docs/guides/lineage-package.md`,
+  `AGENTS.md`, `SECURITY.md`, and `llms.txt` now link to it.
+- Documented the exact-version pinning flow as the current rollback path
+  (#144) and the planned yank/tombstone semantics for `lineage package
+  unpublish` (#145) in the README, ahead of either command landing.

--- a/README.md
+++ b/README.md
@@ -198,7 +198,24 @@ lineage enable resume-workflow
 
 `lineage add` and `lineage package pull` accept `resume-workflow` for the latest version or `resume-workflow@0.2.0` for an exact version. Both verify the registry-reported digest against the package contents before keeping anything - see [docs/decisions/0012-v1-distribution-contract-and-receiver-activation.md](docs/decisions/0012-v1-distribution-contract-and-receiver-activation.md) for how the registry is structured.
 
+That same exact-ref form is also how you move a project back to a previous version - there's no separate `rollback` command yet ([#122](https://github.com/agentic-lineage/lineage/issues/122)), because pinning already covers it. The first time you pull that version, it's one command:
+
+```bash
+lineage add resume-workflow@0.1.0 --yes
+```
+
+If a different version of the same package is already pulled locally (a package directory is keyed by name, not version), pulling another version under the same name is refused rather than silently overwritten - `lineage add`/`lineage package pull` report the local/requested digest mismatch and tell you to remove the existing copy first. Pull the exact version you want under a different local name instead, then enable that:
+
+```bash
+lineage package pull resume-workflow@0.1.0 --as resume-workflow-0.1.0
+lineage enable resume-workflow-0.1.0
+```
+
+Either way, an exact version isn't a lower-trust path: the same manifest schema check, export-authority check, secret scan, and digest verification run as for any other pull. `lineage enable` stores whichever ref you gave it and doesn't drift to a newer version on its own - a project stays pinned until you explicitly `enable` a different ref.
+
 The first publish of a package name claims it for your verified GitHub login. To ship an update, bump `version` in `lineage.yaml` and run `lineage package publish` again - the registry accepts it because you're still the recorded owner of that name; a different GitHub account would be rejected. Run `lineage whoami` any time to check which identity is currently active, or `lineage logout` to clear it. For non-interactive use (CI), set `LINEAGE_PUBLISH_TOKEN` to any GitHub-issued token with `read:user` access instead of running `lineage login`.
+
+There's no way to remove a published version yet. The planned V1 behavior ([#123](https://github.com/agentic-lineage/lineage/issues/123)) is to **yank** a version - hide it from the package directory and from bare-name "latest" resolution behind a tombstone, while leaving it addressable by exact version for anyone who already depends on it - not to delete it. Until `lineage package unpublish` ships, treat every publish as effectively permanent and get the version right before running it.
 
 Published packages are browsable at [agenticlineage.vercel.app/packages](https://agenticlineage.vercel.app/packages). A package detail page includes the package version, digest, publisher, raw archive download, and a copy-paste bootstrap prompt for someone who has never installed Lineage before. The canonical bootstrap prompt lives in [docs/bootstrap-prompt.md](docs/bootstrap-prompt.md).
 
@@ -226,6 +243,8 @@ lineage workflow run resume-review claude --dry-run
 - Package behavior should be idempotent where possible.
 - Provider-specific behavior should stay behind clear adapter boundaries.
 - Declared capabilities are visible to receivers but are not a sandbox in this build.
+
+See [docs/safety.md](docs/safety.md) for the full safety model: what each command checks, what's only a warning, and what remains out of scope in this build.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -198,13 +198,19 @@ lineage enable resume-workflow
 
 `lineage add` and `lineage package pull` accept `resume-workflow` for the latest version or `resume-workflow@0.2.0` for an exact version. Both verify the registry-reported digest against the package contents before keeping anything - see [docs/decisions/0012-v1-distribution-contract-and-receiver-activation.md](docs/decisions/0012-v1-distribution-contract-and-receiver-activation.md) for how the registry is structured.
 
-That same exact-ref form is also how you move a project back to a previous version - there's no separate `rollback` command yet ([#122](https://github.com/agentic-lineage/lineage/issues/122)), because pinning already covers it. The first time you pull that version, it's one command:
+That same exact-ref form is also how you move a project back to a previous version - there's no separate `rollback` command yet ([#122](https://github.com/agentic-lineage/lineage/issues/122)), because pinning already covers it. If that version is not already present locally, `lineage add` pulls it and then enables it for the current project:
 
 ```bash
 lineage add resume-workflow@0.1.0 --yes
 ```
 
-If a different version of the same package is already pulled locally (a package directory is keyed by name, not version), pulling another version under the same name is refused rather than silently overwritten - `lineage add`/`lineage package pull` report the local/requested digest mismatch and tell you to remove the existing copy first. Pull the exact version you want under a different local name instead, then enable that:
+The `enable` step is what changes the active version recorded in the project. If
+a different version of the same package is already pulled locally (a package
+directory is keyed by name, not version), pulling another version under the same
+name is refused rather than silently overwritten - `lineage add`/`lineage
+package pull` report the local/requested digest mismatch and tell you to remove
+the existing copy first. Pull the exact version you want under a different local
+name instead, then enable that local name:
 
 ```bash
 lineage package pull resume-workflow@0.1.0 --as resume-workflow-0.1.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,3 +18,5 @@ Lineage should not package or export:
 - Private machine-local cache files
 
 If a workflow needs configuration, prefer setup prompts, templates, or explicit user-provided values on the receiver's machine.
+
+For what Lineage actually checks, blocks, or only warns about across the package lifecycle - not a vulnerability-reporting concern, but a product-safety one - see [docs/safety.md](docs/safety.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,6 +47,8 @@ Packages are local files, but they are still untrusted input. Manifests are vali
 
 Capabilities declared in `lineage.yaml` are safety metadata, not enforcement. They are printed during validation, inspection, dry runs, and registry/package-page flows so receivers can see what a package says it wants before enabling it. They are not a sandbox in this build.
 
+See [docs/safety.md](safety.md) for the canonical, receiver-facing version of this model: every check mapped to its pipeline stage, secret-scanning and capability limits spelled out, and what's explicitly not implemented yet (PII detection, instruction-risk scanning).
+
 ## Decision Records
 
 Architecture decisions are tracked in the [decision log](decisions/README.md).

--- a/docs/guides/lineage-package.md
+++ b/docs/guides/lineage-package.md
@@ -77,8 +77,12 @@ materialization writes provider files.
 Declared capabilities are visible metadata, not a sandbox. They help receivers
 understand what a package says it needs before enabling it.
 
+See [docs/safety.md](../safety.md) for the full model, including secret-scanning
+limits and what's not implemented yet.
+
 Related docs:
 
+- [Safety model](../safety.md)
 - [Architecture](../architecture.md)
 - [Bootstrap prompt](../bootstrap-prompt.md)
 - [Distribution contract](../decisions/0012-v1-distribution-contract-and-receiver-activation.md)

--- a/docs/public-docs-sync.md
+++ b/docs/public-docs-sync.md
@@ -12,6 +12,8 @@ check these surfaces before calling the docs fresh.
   flow.
 - `CHANGELOG.md`: release history and complete behavior notes.
 - `docs/architecture.md`: system boundaries and trust model.
+- `docs/safety.md`: canonical safety model - what each command checks, what's
+  a warning vs. a block, and what's explicitly not implemented yet.
 - `docs/bootstrap-prompt.md`: canonical copy-paste prompt embedded by package
   pages.
 - `docs/guides/`: search-targeted explanations for package concepts and

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -1,0 +1,103 @@
+# Safety Model
+
+This is the canonical explanation of what Lineage checks, what it blocks, what it only warns about, and what remains the package author's, receiver's, or provider's own responsibility. It reflects current behavior only — it does not promise anything Lineage doesn't actually do yet. See [docs/architecture.md](architecture.md) for the shorter, system-level version this page expands on, and [docs/decisions/](decisions/README.md) for the reasoning behind each decision referenced below.
+
+## Why This Page Exists
+
+A Lineage package is a normal folder: skills, workflows, agents, policies, references, and setup material that travel together and get materialized into a provider's own directories. Nothing about that format is executable on its own, but its *content* can still instruct an agent to do something a receiver wouldn't have chosen — read files outside the workspace, reach an unexpected network endpoint, or embed a credential that gets redistributed by accident. Lineage's job is to make a package inspectable and its risks visible before any of that content reaches a running agent, not to promise a sandbox it doesn't have.
+
+## The Package Lifecycle
+
+A package passes through the same checks whether it was authored locally, imported from an archive, or pulled from the registry — later stages never trust an earlier stage's judgment call, they redo the check themselves:
+
+```
+author → validate → export/publish → import/pull → inspect → enable → materialize → run
+```
+
+- **Author**: `lineage package init` scaffolds the standard layout. Nothing is checked yet.
+- **Validate**: `lineage package validate <path>` runs every check below against the package as it sits on disk, without enabling or writing anything.
+- **Export/Publish**: `lineage package export`/`lineage package publish` refuse to run at all if `Validate` finds a blocking problem — a package that fails validation cannot leave the machine that authored it.
+- **Import/Pull**: `lineage package import <archive>`/`lineage package pull <ref>` treat the incoming content as fully untrusted regardless of source (ADR 0011) — a previously-valid export that was edited, corrupted, or substituted in transit gets caught here, not assumed safe because it parsed.
+- **Inspect**: `lineage inspect <ref>` shows a package's declared and discovered contents (manifest, skills/workflows/agents/policies, digest, declared capabilities) so a receiver can look before enabling.
+- **Enable**: `lineage enable <ref>` adds a package to the current project's `.lineage/config.yaml`. If the package declares setup (files/directories its workflow expects), the receiver sees exactly what would be created and must approve it first.
+- **Materialize**: `lineage run <provider>`/`lineage workflow run` stage the package's skills into the provider's own directory and write its generated context file — gated behind an explicit confirmation the first time a given package set would actually change anything on disk, and idempotent/reversible on every re-run (ADR 0008).
+
+## What `lineage package validate` Checks
+
+`internal/packages.Validate` (also run implicitly by `export`, `import`, and `publish`) checks, and reports every problem it finds rather than stopping at the first one:
+
+- **Manifest schema**: `lineage.yaml` must declare a `schema` this build understands (ADR 0005) and load cleanly.
+- **Export authority**: if `exports.agents`/`exports.workflows` names something, it must exist on disk — a declared-but-missing export is a blocking error, not a warning.
+- **Entrypoint path safety**: `entrypoints.claude`/`entrypoints.codex` are checked with `SafeJoin`, a traversal guard scoped specifically to package-controlled input (ADR 0010) — this never applies to a path you type yourself at the CLI.
+- **Secret scan**: see [Secret Scanning](#secret-scanning-what-it-catches-and-what-it-doesnt) below.
+- **Content digest**: a `sha256` digest over the manifest and every content directory, computed in deterministic order, so `name@version` pairs with "and this is exactly what that resolved to" (ADR 0005).
+
+A package with any blocking error fails validation and refuses to export/publish. Informational notes (e.g. a required skill this package doesn't itself provide, which may come from another package at enable time) don't block.
+
+## What `lineage inspect` Shows
+
+`lineage inspect <ref>` resolves a package (project path, user id, or workspace id) and shows its manifest, discovered skills/workflows/agents/policies/references, content digest, and declared capabilities — without enabling it or writing anything. This is the point in the lifecycle meant for a receiver to actually read what they're about to enable, before they type `lineage enable`.
+
+## What `publish`, `pull`, And `import` Protect
+
+- **Publish**: requires a logged-in identity (`lineage login`, or `LINEAGE_PUBLISH_TOKEN` for non-interactive use). The first publish of a name claims it; a later publish of the same name needs the same identity, so one publisher can't overwrite another's package.
+- **Pull**: an unauthenticated read. The registry's reported digest is treated as untrusted the same way archive bytes are — Pull recomputes the digest from the actually-downloaded content and refuses to keep it if the registry didn't report a digest at all, or if the recomputed digest doesn't match what was reported.
+- **Import**: every archive entry path is checked with `SafeJoin` before anything is written, and the fully extracted content is re-run through the complete `Validate` pass before it's kept — a full re-check, not a trust-the-archive-because-it-parsed shortcut (ADR 0011). Import never overwrites an existing local package; use `--as` to bring in a second copy under a different name.
+
+None of this proves *who* published a package — v1 has no signing and no publisher-identity verification beyond the registry's own claim-on-first-publish rule. The digest proves content integrity, not authorship (ADR 0011's Follow-Up).
+
+## What `enable`, Setup Prompts, And Materialization Ask Before Writing
+
+- **Enable**: if a package declares setup (tracker files or directories its workflow expects to exist), `lineage enable` shows exactly what would be created — file by file, directory by directory — and asks for confirmation before creating anything, unless `--yes` was passed. Declining setup leaves the workspace completely unchanged, same as declining to enable at all.
+- **Materialize**: the first time a given package set would actually change what's staged for a provider, `lineage run`/`lineage workflow run` shows the plan and asks for confirmation (`y`/`yes`, or `--yes` to skip the prompt for scripts). Re-running with an unchanged package set doesn't re-prompt. This is tracked per-provider in `.lineage/materialized-<provider>.json` so cleanup on disable is exact, not guessed from disk contents (ADR 0008).
+
+## Capabilities: Declared, Not Enforced
+
+A package's manifest can carry an optional `capabilities` block (`filesystem.read`, `network`). `lineage package validate` and `--dry-run` print what a package declares wanting. **Nothing in this build enforces, blocks, or warns based on those values beyond printing them** (ADR 0006) — a `capabilities` block that looks unenforced is expected, not a bug. Treat a declared capability as a receiver-visible statement of intent, not a permission you're granting or a boundary Lineage is holding.
+
+## Secret Scanning: What It Catches And What It Doesn't
+
+`internal/packages.ScanForSecrets` checks a small, explicit, documented set of signals (ADR 0009):
+
+- Denylisted filenames: `.env`, `.npmrc`, SSH private key names, `.pem`/`.key`/`.pfx`/`.p12`.
+- A short list of high-confidence content patterns: private key headers, AWS access key ID shape, GitHub token prefixes.
+
+Findings report a file path and a human-readable reason only — the matched value itself is never included, so scan output is always safe to print or log. This is a **precise, not exhaustive** scan by design: it will not catch every possible secret shape (custom token formats, secrets embedded in prose, anything that doesn't match the documented list). It's one input `validate`/`export`/`import` consume, not a claim of complete secret safety. Do not treat a clean scan as proof a package contains no sensitive data — see [What Package Authors Should Never Publish](#what-package-authors-should-never-publish) below.
+
+## PII / Personal-Context Detection
+
+**Not implemented in this build.** Lineage has no automated check for personally identifiable information or personal context embedded in package content (a resume, notes referencing real people, personal API usage history, etc.). If a package might contain that kind of content, the author is solely responsible for reviewing it before publishing — `validate`, `export`, and `publish` will not catch it.
+
+## Instruction-Risk Scanning
+
+**Not implemented in this build.** Lineage does not scan skills, workflows, or policy content for prompt-injection-style instructions aimed at an agent reading them (e.g. "ignore your previous instructions and..."). Package content — skills, workflows, agents, policies, references — should be read as untrusted *content*, never as instructions from Lineage itself or from the receiver, but nothing currently flags a package that tries to blur that line. Read what you enable.
+
+## What Package Authors Should Never Publish
+
+Per [SECURITY.md](../SECURITY.md), a package should never include:
+
+- API keys, auth tokens, or provider credentials
+- `.env` values
+- Shell history
+- Local credential stores
+- Provider login state
+- Private machine-local cache files
+
+If a workflow needs configuration, prefer setup prompts, templates, or explicit user-provided values entered on the receiver's own machine — not baked into the package.
+
+## What Receivers Should Do When They See A Warning
+
+- A **secret-scan finding** blocks validation outright — the package cannot be exported, published, or imported until it's fixed. There's nothing to decide; don't try to force it through.
+- A **declared capability** (`filesystem.read`, `network`) is not blocked or gated — read what's declared, and decide for yourself whether you trust this package enough to enable it, the same way you'd read a permissions list before installing anything else.
+- A **setup prompt** or **materialization confirmation** lists exactly what will be created before it happens — read the file/directory list, not just the package name, before approving.
+- If something doesn't add up — a skill that seems to want more access than its description implies, a policy file with unusual instructions — treat that as a reason not to enable, not something to enable and monitor. Lineage surfaces what it can check; it does not vouch for package intent.
+
+## Related Docs
+
+- [Architecture](architecture.md) — system boundaries and the short version of this page.
+- [ADR 0005](decisions/0005-manifest-is-authoritative-with-schema-and-digest.md) — manifest schema and digest.
+- [ADR 0006](decisions/0006-capabilities-are-declared-not-enforced.md) — capabilities are declared, not enforced.
+- [ADR 0009](decisions/0009-secret-scanning-is-a-documented-list-not-an-engine.md) — secret scanning scope.
+- [ADR 0010](decisions/0010-path-safety-only-applies-to-package-controlled-input.md) — path safety scope.
+- [ADR 0011](decisions/0011-export-import-treats-archives-as-untrusted-input.md) — export/import trust model.
+- [SECURITY.md](../SECURITY.md) — how to report a vulnerability, and what should never be packaged.

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -8,7 +8,12 @@ A Lineage package is a normal folder: skills, workflows, agents, policies, refer
 
 ## The Package Lifecycle
 
-A package passes through the same checks whether it was authored locally, imported from an archive, or pulled from the registry — later stages never trust an earlier stage's judgment call, they redo the check themselves:
+A package passes through stage-specific checks whether it was authored locally,
+imported from an archive, or pulled from the registry. Later stages do not trust
+an earlier stage's judgment call blindly: import re-runs full package
+validation after extraction, pull re-checks the registry-reported digest against
+downloaded content, and enable/materialize keep their own write prompts instead
+of treating validation as permission to write everywhere:
 
 ```
 author → validate → export/publish → import/pull → inspect → enable → materialize → run
@@ -17,7 +22,7 @@ author → validate → export/publish → import/pull → inspect → enable �
 - **Author**: `lineage package init` scaffolds the standard layout. Nothing is checked yet.
 - **Validate**: `lineage package validate <path>` runs every check below against the package as it sits on disk, without enabling or writing anything.
 - **Export/Publish**: `lineage package export`/`lineage package publish` refuse to run at all if `Validate` finds a blocking problem — a package that fails validation cannot leave the machine that authored it.
-- **Import/Pull**: `lineage package import <archive>`/`lineage package pull <ref>` treat the incoming content as fully untrusted regardless of source (ADR 0011) — a previously-valid export that was edited, corrupted, or substituted in transit gets caught here, not assumed safe because it parsed.
+- **Import/Pull**: `lineage package import <archive>`/`lineage package pull <ref>` treat incoming content as untrusted regardless of source (ADR 0011). Import checks archive entry paths before writing and re-runs full `Validate` on the extracted package. Pull verifies the downloaded content against the registry-reported digest before keeping it; package validation then applies to the imported package contents.
 - **Inspect**: `lineage inspect <ref>` shows a package's declared and discovered contents (manifest, skills/workflows/agents/policies, digest, declared capabilities) so a receiver can look before enabling.
 - **Enable**: `lineage enable <ref>` adds a package to the current project's `.lineage/config.yaml`. If the package declares setup (files/directories its workflow expects), the receiver sees exactly what would be created and must approve it first.
 - **Materialize**: `lineage run <provider>`/`lineage workflow run` stage the package's skills into the provider's own directory and write its generated context file — gated behind an explicit confirmation the first time a given package set would actually change anything on disk, and idempotent/reversible on every re-run (ADR 0008).

--- a/llms.txt
+++ b/llms.txt
@@ -11,6 +11,7 @@ Canonical links:
 - Website and registry: https://agenticlineage.vercel.app/
 - Package directory: https://agenticlineage.vercel.app/packages
 - Install: https://agenticlineage.vercel.app/install.sh
+- Safety model: https://github.com/agentic-lineage/lineage/blob/develop/docs/safety.md
 - Architecture: https://github.com/agentic-lineage/lineage/blob/develop/docs/architecture.md
 - What is a Lineage package: https://github.com/agentic-lineage/lineage/blob/develop/docs/guides/lineage-package.md
 - How to share Claude Code and Codex workflows: https://github.com/agentic-lineage/lineage/blob/develop/docs/guides/share-agent-workflows.md


### PR DESCRIPTION
## Summary

Documentation-only PR covering four open `documentation`-labeled issues (all unlikely to be picked up otherwise - filed as `good first issue`/`help wanted` with no assignee):

- **#143 / #137**: Adds `docs/safety.md` as the canonical, receiver-facing safety model - every check mapped to its pipeline stage (validate, inspect, publish/pull/import, enable/setup, materialize), secret-scanning and capability-declaration limits spelled out, and an explicit, honest statement that PII/personal-context detection and instruction-risk scanning are **not implemented** in this build. README, `docs/architecture.md`, `docs/guides/lineage-package.md`, `AGENTS.md`, `SECURITY.md`, and `llms.txt` (all of which already carried short safety summaries) now link to it as the canonical source, per #137's decision. Wiki and the website are outside this repo and not touched here.
- **#144**: Documents the exact-version pinning flow in the README as the current rollback path - including the real "a different version is already pulled locally under the same name" collision and its `--as` workaround, verified against actual `Import`/`Pull` behavior rather than assumed. Makes clear no `rollback` command exists yet (#122).
- **#145**: Documents the planned yank/tombstone semantics for `lineage package unpublish` (already decided in #123's own issue body) ahead of the command shipping, using consistent terminology and explicitly not promising deletion.

I checked each issue against current `develop` before writing anything - none of this existed yet (no `docs/safety.md`, no rollback/pinning guidance, no yank terminology anywhere in the repo).

## Linked Issue

Closes #143
Closes #137
Closes #144
Closes #145

- [x] The linked issues are assigned to me.
- [x] This PR targets `develop`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [x] Documentation only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- 

```text
go build ./... && go vet ./... && go test ./...
```

If this PR does not need automated tests, explain why:

- Documentation-only change (README, docs/safety.md, docs/architecture.md, docs/guides/lineage-package.md, AGENTS.md, SECURITY.md, llms.txt, CHANGELOG.md) - no code behavior changed, so the build/test commands above are run only to confirm the docs change didn't accidentally touch anything compiled.

## Notes For Reviewers

- `docs/safety.md` deliberately does not reference ADR 0015 (from #59/PR #199) even though it's directly relevant to the materialize-state discussion - #199 hadn't merged yet when this was written, so referencing it would have been a dangling link depending on merge order. Happy to add that cross-reference in a follow-up once #199 is in.
- The rollback section in the README (#144) is intentionally more cautious than a first draft would suggest: I verified against `internal/packages/import.go` that pulling a second version of an already-locally-present package collides on the package-name-keyed directory and is refused, not silently handled - so the docs show the real `--as` workaround rather than an example that would fail for a reader who already has an older version pulled.