### PR TITLE
docs: reposition README around workflow packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,43 @@
 # Lineage
 
-Lineage is an open-source local distribution layer for packaging and sharing AI
-agent workflows across Claude Code, Codex, and other coding agents.
+Package and share Claude Code and Codex workflow environments.
 
-It lets a prepared agent package travel as one environment: skills, workflows,
-agents, policies, references, setup material, and provider entrypoints can be
-bundled together, inspected, enabled, and launched from a receiver's machine.
-The package stays local and readable; the receiver keeps using their own agent
-tools.
+A reusable agent workflow usually depends on more than one prompt or skill:
+skills, workflow steps, agents, policies, references, setup files, declared
+capabilities, and provider entrypoints all shape how it behaves. Lineage keeps
+those pieces together as a local, inspectable package that another developer can
+add to their own project and run with their own agent tools.
 
-The goal is simple:
+```bash
+# author
+lineage package validate ./resume-workflow
+lineage login
+lineage package publish ./resume-workflow
 
-```text
-prepare once -> package safely -> share -> enable locally -> run with the user's own agent tools
+# receiver
+lineage add resume-workflow
+lineage run claude --dry-run
 ```
 
-Lineage does not try to replace the agent provider. It sits around local agent
-commands and makes the surrounding environment easier to package, review, and
-reproduce.
+`lineage add` fetches the package, shows what it contains, asks before enabling
+unless `--yes` is passed, and records it in the current project. `lineage run`
+can preview the provider-specific files it would stage before anything is
+written.
 
-## What Lineage Is For
+Use Lineage when you want to:
 
-Use Lineage when a workflow is more than a prompt and you want to share the
-working environment around it:
-
-- Package Claude Code workflows, Codex workflows, agent skills, policies,
-  references, and setup material together.
-- Publish a reusable agent workflow to the Lineage registry or share it as a
+- Package Claude Code workflows, Codex workflows, skills, agents, policies,
+  references, setup material, and adapter entrypoints together.
+- Publish a workflow package to the Lineage registry or share it as a
   deterministic `.tgz` archive.
-- Let receivers inspect the package contents and declared capabilities before
-  enabling anything locally.
-- Run the same packaged behavior through provider adapters instead of rebuilding
-  it by hand for each project.
+- Let receivers inspect package contents and declared capabilities before
+  enabling the workflow locally.
+- Run the packaged workflow through Claude Code or Codex without rebuilding the
+  environment by hand in each project.
 
-If you are looking for "how to share Claude workflows", "how to package AI
-agent skills", or "how to distribute reusable agent workflows", Lineage is the
-small local runtime and package format for that job.
+Lineage is provider-adjacent, not provider-owned. It prepares local files for
+the agent provider the receiver already uses; it does not replace Claude Code,
+Codex, or the user's agent account.
 
 ## Install
 
@@ -43,12 +45,97 @@ small local runtime and package format for that job.
 curl -fsSL https://agenticlineage.vercel.app/install.sh | sh
 ```
 
-Downloads the right prebuilt binary for your OS/architecture (macOS/Linux, amd64/arm64), verifies it against the release's published checksum, and installs it to `~/.lineage/bin`. No Go toolchain required. Windows: download `lineage-windows-amd64.exe` directly from the [latest release](https://github.com/agentic-lineage/lineage/releases/latest).
+Downloads the right prebuilt binary for your OS/architecture (macOS/Linux,
+amd64/arm64), verifies it against the release's published checksum, and installs
+it to `~/.lineage/bin`. No Go toolchain required. Windows: download
+`lineage-windows-amd64.exe` directly from the
+[latest release](https://github.com/agentic-lineage/lineage/releases/latest).
 
 Go developers can also build from source:
 
 ```bash
 go install github.com/agentic-lineage/lineage/cmd/lineage@latest
+```
+
+## Quick Start
+
+Create a package:
+
+```bash
+lineage package init resume-workflow
+```
+
+Add the workflow's skills, workflow steps, agents, policies, references, and
+setup material to the generated folders. Keep secrets, provider login state,
+private machine paths, and local credentials out of the package.
+
+Validate and preview it locally:
+
+```bash
+lineage package validate ./resume-workflow
+lineage enable ./resume-workflow
+lineage run claude --dry-run
+lineage run codex --dry-run
+```
+
+Publish it to the Lineage registry:
+
+```bash
+lineage login
+lineage package publish ./resume-workflow
+```
+
+The first publish of a package name claims it for your verified GitHub login.
+To ship an update, bump `version` in `lineage.yaml` and run
+`lineage package publish` again. Run `lineage whoami` to check the active
+identity, or `lineage logout` to clear it. For non-interactive use, set
+`LINEAGE_PUBLISH_TOKEN` to a GitHub-issued token with `read:user` access instead
+of running `lineage login`.
+
+On the receiving end:
+
+```bash
+lineage add resume-workflow
+lineage inspect resume-workflow
+lineage run claude --dry-run
+```
+
+For scripts or bootstrap prompts where the caller has already decided to install
+the package:
+
+```bash
+lineage add resume-workflow --yes
+```
+
+`lineage add` and `lineage package pull` accept `resume-workflow` for the latest
+version or `resume-workflow@0.2.0` for an exact version. Both verify the
+registry-reported digest against the package contents before keeping anything.
+See
+[docs/decisions/0012-v1-distribution-contract-and-receiver-activation.md](docs/decisions/0012-v1-distribution-contract-and-receiver-activation.md)
+for the registry structure.
+
+Published packages are browsable at
+[agenticlineage.vercel.app/packages](https://agenticlineage.vercel.app/packages).
+A package detail page includes the package version, digest, publisher, raw
+archive download, and a copy-paste bootstrap prompt for someone who has never
+installed Lineage before. The canonical bootstrap prompt lives in
+[docs/bootstrap-prompt.md](docs/bootstrap-prompt.md).
+
+## Sharing A `.tgz` Archive
+
+You can share a package without the registry:
+
+```bash
+lineage package validate ./resume-workflow
+lineage package export ./resume-workflow -o resume-workflow.tgz
+```
+
+On the receiving end:
+
+```bash
+lineage package import resume-workflow.tgz
+lineage enable resume-workflow
+lineage run codex --dry-run
 ```
 
 ## What Is In A Package?
@@ -66,22 +153,40 @@ package/
 └── adapters/
 ```
 
-These folders are intentionally plain. A receiver should be able to open the package and see what it contains before enabling it.
+These folders are intentionally plain. A receiver should be able to open the
+package and see what it contains before enabling it.
 
-## How Lineage Fits Claude, Codex, and Other Agents
+## How Lineage Fits Claude, Codex, And Other Agents
 
-Lineage is provider-adjacent, not provider-owned. It prepares the local files a
-provider already knows how to read, keeps provider-specific behavior behind
-adapter boundaries, and can preview what it would materialize before writing.
+Lineage keeps provider-specific behavior behind adapter boundaries and previews
+what it would materialize before writing.
 
 - `lineage run claude --dry-run` previews Claude materialization.
 - `lineage run codex --dry-run` previews Codex materialization.
 - `lineage workflow run <workflow-name> <claude|codex> --dry-run` narrows the
   launch plan to one exported workflow.
 
-The current adapters focus on Claude and Codex. The package shape is deliberately
-plain so future adapters can use the same manifest, skills, workflows, agents,
-policies, references, and setup material.
+The current adapters focus on Claude and Codex. The package shape stays plain so
+future adapters can use the same manifest, skills, workflows, agents, policies,
+references, and setup material.
+
+Project configuration lives at `.lineage/config.yaml`.
+
+```yaml
+workspace: ""
+enabled_packages:
+  - ./my-agent-package
+provider_preferences: {}
+providers:
+  claude:
+    binary: /path/to/real/claude
+  codex:
+    binary: /path/to/real/codex
+```
+
+The first time `lineage run` would stage files for a provider, it shows what it
+is about to create or change and asks for confirmation. Pass `--yes`/`-y` to
+skip the prompt in scripts. `--dry-run` never writes anything.
 
 ## Current Commands
 
@@ -114,94 +219,6 @@ lineage doctor
 lineage version
 ```
 
-The first time `lineage run` would actually stage files for a provider, it shows what it's about to create or change and asks for confirmation; pass `--yes`/`-y` to skip the prompt in scripts. `--dry-run` never writes anything.
-
-Project configuration lives at `.lineage/config.yaml`.
-
-```yaml
-workspace: ""
-enabled_packages:
-  - ./my-agent-package
-provider_preferences: {}
-providers:
-  claude:
-    binary: /path/to/real/claude
-  codex:
-    binary: /path/to/real/codex
-```
-
-## Quick Start
-
-Create a package:
-
-```bash
-lineage package init resume-workflow
-```
-
-Enable it inside a project:
-
-```bash
-lineage enable ./resume-workflow
-```
-
-Preview the launch plan:
-
-```bash
-lineage run claude --dry-run
-```
-
-Install local shims when you want commands such as `claude` or `codex` to enter Lineage first:
-
-```bash
-lineage install-shims
-```
-
-Share a package as a file:
-
-```bash
-lineage package validate ./resume-workflow
-lineage package export ./resume-workflow -o resume-workflow.tgz
-```
-
-On the receiving end:
-
-```bash
-lineage package import resume-workflow.tgz
-lineage enable resume-workflow
-```
-
-Or publish it to the Lineage registry instead of passing a file around. No token to request first - `lineage login` authenticates you with your own GitHub account (the same device-flow approval `gh auth login` uses):
-
-```bash
-lineage login   # opens a code + a github.com link to approve once
-lineage package publish ./resume-workflow
-```
-
-On the receiving end, the shortest path is `lineage add`. It fetches the package, shows what it contains, asks before enabling unless `--yes` is passed, and records it in the current project:
-
-```bash
-lineage add resume-workflow
-```
-
-For scripts or bootstrap prompts where the caller has already decided to install the package:
-
-```bash
-lineage add resume-workflow --yes
-```
-
-You can still pull and enable in two explicit steps if you want to inspect the imported copy yourself first. Pulling is an open read and does not require login:
-
-```bash
-lineage package pull resume-workflow
-lineage enable resume-workflow
-```
-
-`lineage add` and `lineage package pull` accept `resume-workflow` for the latest version or `resume-workflow@0.2.0` for an exact version. Both verify the registry-reported digest against the package contents before keeping anything - see [docs/decisions/0012-v1-distribution-contract-and-receiver-activation.md](docs/decisions/0012-v1-distribution-contract-and-receiver-activation.md) for how the registry is structured.
-
-The first publish of a package name claims it for your verified GitHub login. To ship an update, bump `version` in `lineage.yaml` and run `lineage package publish` again - the registry accepts it because you're still the recorded owner of that name; a different GitHub account would be rejected. Run `lineage whoami` any time to check which identity is currently active, or `lineage logout` to clear it. For non-interactive use (CI), set `LINEAGE_PUBLISH_TOKEN` to any GitHub-issued token with `read:user` access instead of running `lineage login`.
-
-Published packages are browsable at [agenticlineage.vercel.app/packages](https://agenticlineage.vercel.app/packages). A package detail page includes the package version, digest, publisher, raw archive download, and a copy-paste bootstrap prompt for someone who has never installed Lineage before. The canonical bootstrap prompt lives in [docs/bootstrap-prompt.md](docs/bootstrap-prompt.md).
-
 Useful day-to-day checks:
 
 ```bash
@@ -209,6 +226,22 @@ lineage list
 lineage inspect resume-workflow
 lineage doctor
 lineage workflow run resume-review claude --dry-run
+```
+
+Install local shims when you want commands such as `claude` or `codex` to enter
+Lineage first:
+
+```bash
+lineage install-shims
+```
+
+You can also pull and enable in two explicit steps if you want to inspect the
+imported copy yourself first. Pulling is an open read and does not require
+login:
+
+```bash
+lineage package pull resume-workflow
+lineage enable resume-workflow
 ```
 
 ## Guides
@@ -221,11 +254,13 @@ lineage workflow run resume-review claude --dry-run
 ## Safety Principles
 
 - Packages should be inspectable before they are enabled.
-- Secrets, credentials, provider login state, and private machine-local files should not be packaged.
+- Secrets, credentials, provider login state, and private machine-local files
+  should not be packaged.
 - Setup actions should be explicit and permission-gated.
 - Package behavior should be idempotent where possible.
 - Provider-specific behavior should stay behind clear adapter boundaries.
-- Declared capabilities are visible to receivers but are not a sandbox in this build.
+- Declared capabilities are visible to receivers but are not a sandbox in this
+  build.
 
 ## Development
 
@@ -238,16 +273,17 @@ The source follows the standard Go layout:
 
 - `cmd/lineage` contains the CLI entrypoint.
 - `internal/` contains runtime, package, config, provider, and shim code.
-- `.agents/skills` contains repository-native guardrail skills for consistent agent-assisted development.
+- `.agents/skills` contains repository-native guardrail skills for consistent
+  agent-assisted development.
 
-Important project decisions are recorded in [docs/decisions](docs/decisions/README.md).
-Release and stable-branch rules are documented in
-[docs/release-versioning.md](docs/release-versioning.md).
-GitHub and website discoverability checks live in
-[docs/discoverability.md](docs/discoverability.md).
-When behavior affects install, publishing, receiver activation, setup prompts,
-or safety wording, also check [docs/public-docs-sync.md](docs/public-docs-sync.md)
-so the website, Wiki, package pages, and Discussions do not drift.
+Important project decisions are recorded in
+[docs/decisions](docs/decisions/README.md). Release and stable-branch rules are
+documented in [docs/release-versioning.md](docs/release-versioning.md). GitHub
+and website discoverability checks live in
+[docs/discoverability.md](docs/discoverability.md). When behavior affects
+install, publishing, receiver activation, setup prompts, or safety wording, also
+check [docs/public-docs-sync.md](docs/public-docs-sync.md) so the website, Wiki,
+package pages, and Discussions do not drift.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ To ship an update, bump `version` in `lineage.yaml` and run
 `lineage package publish` again. Run `lineage whoami` to check the active
 identity, or `lineage logout` to clear it. For non-interactive use, set
 `LINEAGE_PUBLISH_TOKEN` to a GitHub-issued token with `read:user` access instead
-of running `lineage login`.
+of running `lineage login`; publishing uses GitHub only to identify the
+publisher, so repository write scopes are not required.
 
 On the receiving end:
 
@@ -251,16 +252,12 @@ lineage enable resume-workflow
 - [Architecture and trust model](docs/architecture.md)
 - [Public docs and discoverability checklist](docs/discoverability.md)
 
-## Safety Principles
+## Safety
 
-- Packages should be inspectable before they are enabled.
-- Secrets, credentials, provider login state, and private machine-local files
-  should not be packaged.
-- Setup actions should be explicit and permission-gated.
-- Package behavior should be idempotent where possible.
-- Provider-specific behavior should stay behind clear adapter boundaries.
-- Declared capabilities are visible to receivers but are not a sandbox in this
-  build.
+Packages are meant to be inspected before they are enabled, and generated
+provider files can be previewed with `--dry-run` before they are written. The
+canonical safety model, including current checks, warnings, and non-goals, lives
+in [docs/safety.md](docs/safety.md).
 
 ## Development
 


### PR DESCRIPTION
## Summary

- Rework the README opening around a compact Claude Code/Codex workflow-environment positioning statement.
- Move the author-to-receiver registry flow above architecture details so the first screen shows immediate proof.
- Preserve the package shape, command reference, safety principles, and existing guide/decision links while reducing repetitive framing.

## Linked Issue

Maintainer housekeeping

## Package Impact

- [ ] Package format or manifest behavior
- [ ] Package discovery or enablement
- [ ] Provider launch/shim behavior
- [ ] Setup or permission flow
- [x] Documentation only
- [ ] Tests only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.

## Verification

Relevant test cases:

- README-only positioning change; no product behavior or CLI behavior is introduced.
- Full Go test suite run as a regression check.
- CLI help smoke check run to confirm README command surface still resolves.

```text
go test ./...
go run ./cmd/lineage --help
```

## Notes For Reviewers

This is a maintainer-authored documentation positioning change. The PR body was adjusted by the maintainer to satisfy the repository PR Policy parser; the content diff is unchanged.
