### PR TITLE
fix: detect GitHub fine-grained PAT format in secret scanner

### DIFF
--- a/internal/packages/secrets.go
+++ b/internal/packages/secrets.go
@@ -53,6 +53,7 @@ var secretContentPatterns = []*regexp.Regexp{
 	// STS/assumed-role session key.
 	regexp.MustCompile(`\b(AKIA|ASIA)[0-9A-Z]{16}\b`),
 	regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9]{20,}`), // GitHub token prefixes (ghp_, gho_, ghu_, ghs_, ghr_)
+	regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{20,}`), // GitHub fine-grained PATs
 }
 
 // ScanForSecrets walks a package directory and flags files that look like


### PR DESCRIPTION
## Summary

fix: detect GitHub fine-grained PAT format in secret scanner

## Changes

- Add github_pat_ pattern alongside classic gh[pousr]_ tokens.

Fixes #152
