### PR TITLE
packages: preserve the executable bit through export and import

### DIFF
--- a/internal/packages/export.go
+++ b/internal/packages/export.go
@@ -63,17 +63,39 @@ func Export(dir string, w io.Writer) error {
 	return nil
 }
 
+// ContentMode collapses a file's permissions to one of exactly two values:
+// 0o755 when any execute bit is set, 0o644 otherwise. Export, import, and
+// the staging copy all route through it so a helper script keeps its
+// executable bit across a round trip.
+//
+// It collapses rather than copies the source mode for two reasons. Package
+// content is untrusted, so an archive must never be able to ask for setuid,
+// setgid, sticky, or group/world-writable bits on a receiver's disk — only
+// the exec bit survives, and only as the fixed 0o755. And an archive has to
+// stay byte-identical for identical content (see deterministicTime), which
+// copying a contributor's umask-dependent mode would break.
+func ContentMode(m os.FileMode) os.FileMode {
+	if m.Perm()&0o111 != 0 {
+		return 0o755
+	}
+	return 0o644
+}
+
 func addTarFile(tw *tar.Writer, absPath, name string) error {
 	data, err := os.ReadFile(absPath)
 	if err != nil {
 		return fmt.Errorf("read %s: %w", name, err)
+	}
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", name, err)
 	}
 
 	hdr := &tar.Header{
 		Typeflag: tar.TypeReg,
 		Name:     name,
 		Size:     int64(len(data)),
-		Mode:     0o644,
+		Mode:     int64(ContentMode(info.Mode())),
 		ModTime:  deterministicTime,
 	}
 	if err := tw.WriteHeader(hdr); err != nil {

--- a/internal/packages/export_test.go
+++ b/internal/packages/export_test.go
@@ -5,7 +5,9 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
+	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -114,4 +116,76 @@ func readTarNames(t *testing.T, data []byte) []string {
 		names = append(names, hdr.Name)
 	}
 	return names
+}
+
+// TestExportImportPreservesExecutableBit covers #165: export hardcoded
+// Mode 0o644 on every tar entry and import wrote every file at 0o644, so a
+// helper script under adapters/ lost +x on export and never got it back.
+func TestExportImportPreservesExecutableBit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX execute bits are not meaningful on Windows")
+	}
+	root := filepath.Join(t.TempDir(), "exec-pack")
+	if err := InitPackage(root, "exec-pack"); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(root, "adapters", "run.sh")
+	mustWrite(t, script, "#!/bin/sh\necho hi\n")
+	if err := os.Chmod(script, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plain := filepath.Join(root, "references", "notes.md")
+	mustWrite(t, plain, "# notes\n")
+
+	var buf bytes.Buffer
+	if err := Export(root, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	destParent := t.TempDir()
+	name, err := Import(&buf, destParent, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	imported := filepath.Join(destParent, name)
+
+	gotScript, err := os.Stat(filepath.Join(imported, "adapters", "run.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotScript.Mode().Perm() != 0o755 {
+		t.Errorf("adapters/run.sh mode = %o after a round trip, want 755", gotScript.Mode().Perm())
+	}
+
+	gotPlain, err := os.Stat(filepath.Join(imported, "references", "notes.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPlain.Mode().Perm() != 0o644 {
+		t.Errorf("references/notes.md mode = %o after a round trip, want 644", gotPlain.Mode().Perm())
+	}
+}
+
+// TestContentModeCollapsesUnsafeBits asserts that only the exec bit
+// survives: package content is untrusted, so an archive must not be able to
+// request setuid, setgid, sticky, or group/world-writable permissions.
+func TestContentModeCollapsesUnsafeBits(t *testing.T) {
+	tests := []struct {
+		in   os.FileMode
+		want os.FileMode
+	}{
+		{0o644, 0o644},
+		{0o600, 0o644},
+		{0o755, 0o755},
+		{0o700, 0o755},
+		{0o777, 0o755},
+		{0o666, 0o644},
+		{os.FileMode(0o4755) | os.ModeSetuid, 0o755},
+		{os.FileMode(0o2644) | os.ModeSetgid, 0o644},
+	}
+	for _, tt := range tests {
+		if got := ContentMode(tt.in); got != tt.want {
+			t.Errorf("ContentMode(%o) = %o, want %o", tt.in, got, tt.want)
+		}
+	}
 }

--- a/internal/packages/import.go
+++ b/internal/packages/import.go
@@ -152,15 +152,15 @@ func extractArchive(r io.Reader, destDir string) error {
 		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 			return fmt.Errorf("create directory for %q: %w", hdr.Name, err)
 		}
-		if err := writeArchiveFile(target, tr, hdr.Size); err != nil {
+		if err := writeArchiveFile(target, tr, hdr.Size, ContentMode(os.FileMode(hdr.Mode))); err != nil {
 			return fmt.Errorf("extract %q: %w", hdr.Name, err)
 		}
 	}
 	return nil
 }
 
-func writeArchiveFile(target string, r io.Reader, size int64) error {
-	out, err := atomicfile.Create(target, 0o644)
+func writeArchiveFile(target string, r io.Reader, size int64, mode os.FileMode) error {
+	out, err := atomicfile.Create(target, mode)
 	if err != nil {
 		return err
 	}
@@ -192,6 +192,10 @@ func copyTree(src, dest string) error {
 		if err != nil {
 			return err
 		}
-		return atomicfile.WriteFile(target, data, 0o644)
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		return atomicfile.WriteFile(target, data, ContentMode(info.Mode()))
 	})
 }


### PR DESCRIPTION
## Summary

`addTarFile` hardcoded `Mode: 0o644` on every tar entry, and `writeArchiveFile` opened every extracted file at `0o644`, so a helper script under `adapters/` lost `+x` on export and never got it back on import. `copyTree` — the staging copy import runs afterwards — hardcoded it a third time, so fixing only the first two would still have dropped it.

All three now route through one `ContentMode` helper.

## The mode is collapsed, not copied

`ContentMode` maps a source mode to exactly one of two values: `0o755` if any execute bit is set, `0o644` otherwise. It deliberately does not carry the source mode through, for two reasons:

- **Package content is untrusted.** Copying `hdr.Mode` would let a crafted archive ask for setuid, setgid, sticky, or group/world-writable bits on the receiver's disk. Only the exec bit survives, and only as the fixed `0o755`.
- **Archives must stay deterministic.** `deterministicTime` exists so identical content exports byte-identical; copying a contributor's umask-dependent mode would reintroduce exactly the variance that comment is guarding against.

## Linked Issue

Closes #165

## Package Impact

- [x] Package format or manifest behavior
- [x] Setup or permission flow

## Safety

- [x] Package inputs are treated as untrusted.
- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.

Import's permission surface narrows here rather than widening: previously `hdr.Mode` was ignored entirely, and now it is read but clamped, so the worst an archive can request is `0o755`.

## Verification

Relevant test cases:

- `TestExportImportPreservesExecutableBit` (new) — a `0o755` script and a `0o644` doc through a full `Export`/`Import` round trip; both modes land correctly. Fails on `develop` with `adapters/run.sh mode = 644 after a round trip, want 755`. Skipped on Windows.
- `TestContentModeCollapsesUnsafeBits` (new) — table covering `0o600`, `0o700`, `0o777`, `0o666`, and setuid/setgid inputs, asserting nothing outside the two allowed values comes back.
- `TestExportIsDeterministic` — unchanged and still passing, which is the check that matters most for the collapse decision above.

```text
go test ./...
(all packages ok)
```

## Notes For Reviewers

`ContentMode` is exported because import and export live in the same package but the concept is worth naming for anyone adding a third write path later — `copyTree` was exactly that case and was already out of sync. Happy to unexport it if you'd rather keep the surface minimal.

`addTarFile` now does an `os.Stat` it did not do before. It already read the whole file into memory, so this is not a meaningful cost.