### PR TITLE
packages: reject an explicit schema: 0 instead of coercing it

### DIFF
--- a/internal/packages/manifest.go
+++ b/internal/packages/manifest.go
@@ -163,9 +163,20 @@ func LoadManifest(dir string) (Manifest, error) {
 	if err := validateIdentifier("version", path, manifest.Version); err != nil {
 		return Manifest{}, err
 	}
-	// schema 0 means the manifest predates the schema field; treat that as
-	// schema 1, the only schema that ever existed before it was added.
-	if manifest.Schema == 0 {
+	// An absent schema field and an explicit `schema: 0` both leave
+	// manifest.Schema at 0, so the int alone cannot tell them apart. Decode
+	// the field again as a pointer to distinguish them: an absent field
+	// means the manifest predates the schema field and is treated as schema
+	// 1, the only schema that ever existed before it was added, while an
+	// explicit 0 is a value that never existed and is rejected rather than
+	// silently coerced.
+	var probe struct {
+		Schema *int `yaml:"schema"`
+	}
+	if err := yaml.Unmarshal(data, &probe); err != nil {
+		return Manifest{}, fmt.Errorf("parse manifest %s: %w", path, err)
+	}
+	if probe.Schema == nil {
 		manifest.Schema = CurrentSchema
 	}
 	if manifest.Schema != CurrentSchema {

--- a/internal/packages/manifest_test.go
+++ b/internal/packages/manifest_test.go
@@ -89,3 +89,55 @@ func TestDefaultManifestRoundTripsCapabilities(t *testing.T) {
 		t.Fatalf("Capabilities.Network = %#v", loaded.Capabilities.Network)
 	}
 }
+
+// TestLoadManifestDistinguishesAbsentAndExplicitZeroSchema covers #166: an
+// absent schema field and an explicit `schema: 0` both unmarshal to 0, so
+// the explicit zero — a value that never existed as a real schema — was
+// silently coerced to the current schema instead of rejected.
+func TestLoadManifestDistinguishesAbsentAndExplicitZeroSchema(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+	}{
+		{
+			name: "absent is treated as the pre-schema manifest",
+			yaml: "name: legacy-pack\nversion: 1.0.0\n",
+		},
+		{
+			name: "explicit current schema is accepted",
+			yaml: "schema: 1\nname: current-pack\nversion: 1.0.0\n",
+		},
+		{
+			name:    "explicit zero is rejected",
+			yaml:    "schema: 0\nname: zero-pack\nversion: 1.0.0\n",
+			wantErr: true,
+		},
+		{
+			name:    "a future schema is still rejected",
+			yaml:    "schema: 2\nname: future-pack\nversion: 1.0.0\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			mustWrite(t, filepath.Join(dir, ManifestFileName), tt.yaml)
+
+			manifest, err := LoadManifest(dir)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("LoadManifest() error = nil, want a rejection for %q", tt.yaml)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadManifest() error = %v", err)
+			}
+			if manifest.Schema != CurrentSchema {
+				t.Errorf("Schema = %d, want %d", manifest.Schema, CurrentSchema)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

YAML-unmarshaling an absent `schema` field and an explicit `schema: 0` both leave `manifest.Schema == 0`, so the int alone could not tell them apart. A manifest declaring `schema: 0` — a value that never existed as a real schema — was silently coerced to the current schema and accepted, while every other invalid value (`schema: 2`) was rejected.

`LoadManifest` now decodes the field a second time as `*int` purely to answer "was this key present?". Absent still means the manifest predates the schema field and is treated as schema 1; an explicit `0` now falls through to the existing "declares schema %d, but this build only understands schema %d" error.

## Linked Issue

Closes #166

## Package Impact

- [x] Package format or manifest behavior

## Safety

- [x] Package inputs are treated as untrusted.
- [x] This change does not export secrets, credentials, private prompts, or machine-local state.

A manifest is untrusted input, and this makes one previously-accepted malformed value fail closed. Nothing that was valid before becomes invalid.

## Verification

Relevant test cases:

- absent schema -> accepted, normalized to `CurrentSchema` (the pre-schema-manifest path, unchanged)
- `schema: 1` -> accepted
- `schema: 0` -> rejected; fails on `develop` with `error = nil, want a rejection`
- `schema: 2` -> still rejected, confirming the existing path did not regress

```text
go test ./...
(all packages ok)
```

## Notes For Reviewers

The issue offered a pointer field or a sentinel. I used a pointer, but in a local probe struct rather than on `Manifest` itself — changing `Manifest.Schema` to `*int` would ripple into `SaveManifest`, `DefaultManifest`, and every reader of the field, for a question only `LoadManifest` ever asks. This keeps the public type and the on-disk output identical.

Cost is a second `yaml.Unmarshal` over an already-in-memory manifest, which is negligible at manifest size. If you would rather have the pointer on the struct as a deliberate API statement, say so and I will switch it.

The error message for the zero case is the existing schema-mismatch one, which reads correctly ("declares schema 0, but this build only understands schema 1"). I did not add a special-cased message for `0`, but it is a one-liner if you want the reserved-value meaning spelled out.
