### PR TITLE
Add Auggie support with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,13 @@ adapter boundaries, and can preview what it would materialize before writing.
 
 - `lineage run claude --dry-run` previews Claude materialization.
 - `lineage run codex --dry-run` previews Codex materialization.
-- `lineage workflow run <workflow-name> <claude|codex> --dry-run` narrows the
+- `lineage run auggie --dry-run` previews Auggie materialization.
+- `lineage workflow run <workflow-name> <claude|codex|auggie> --dry-run` narrows the
   launch plan to one exported workflow.
 
-The current adapters focus on Claude and Codex. The package shape is deliberately
-plain so future adapters can use the same manifest, skills, workflows, agents,
-policies, references, and setup material.
+The current adapters support Claude, Codex, and Auggie. The package shape is
+deliberately plain so future adapters can use the same manifest, skills,
+workflows, agents, policies, references, and setup material.
 
 ## Current Commands
 
@@ -107,7 +108,8 @@ lineage list
 lineage inspect <package-path-or-id>
 lineage run claude --dry-run
 lineage run codex --dry-run
-lineage workflow run <workflow-name> <claude|codex> [--dry-run] [--yes]
+lineage run auggie --dry-run
+lineage workflow run <workflow-name> <claude|codex|auggie> [--dry-run] [--yes]
 
 lineage install-shims
 lineage doctor
@@ -128,7 +130,30 @@ providers:
     binary: /path/to/real/claude
   codex:
     binary: /path/to/real/codex
+  auggie:
+    binary: /path/to/real/auggie
 ```
+
+### Auggie setup and limitations
+
+Auggie is installed and authenticated separately on the receiving machine. It
+currently requires Node.js 22 or later:
+
+```bash
+npm install -g @augmentcode/auggie
+auggie login
+lineage run auggie --dry-run
+```
+
+The adapter finds `auggie` on `PATH`, or uses `providers.auggie.binary` when
+configured. When approved, Lineage stages package skills in
+`.augment/skills/`, updates its generated section in the project's `AGENTS.md`,
+and launches Auggie with the supplied provider arguments.
+
+Lineage does not read, package, or materialize Augment credentials, login or
+session state, settings, user rules, MCP configuration, or other machine-local
+files under `~/.augment`. Configure those features locally with Auggie. Auggie
+is currently beta, so its own platform and terminal limitations still apply.
 
 ## Quick Start
 
@@ -150,7 +175,8 @@ Preview the launch plan:
 lineage run claude --dry-run
 ```
 
-Install local shims when you want commands such as `claude` or `codex` to enter Lineage first:
+Install local shims when you want commands such as `claude`, `codex`, or
+`auggie` to enter Lineage first:
 
 ```bash
 lineage install-shims

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,7 @@ Lineage is a local runtime for distributing agent environment packages.
 - `lineage add <ref>` is the receiver shortcut for the registry path: resolve, download/import, inspect, confirm, and enable in one command. `lineage package pull` remains available when the receiver wants to fetch first and enable separately.
 - The runtime resolves enabled packages, builds a launch plan, and starts the selected provider through an explicit adapter boundary.
 - `lineage workflow run <workflow> <provider>` narrows materialization to the ordered steps declared by one workflow, while plain `lineage run <provider>` materializes the full enabled package set.
-- Provider shims let a normal command such as `claude` or `codex` enter the Lineage runtime first, then hand off to the real provider binary.
+- Provider shims let a normal command such as `claude`, `codex`, or `auggie` enter the Lineage runtime first, then hand off to the real provider binary.
 
 ## Package Shape
 

--- a/docs/bootstrap-prompt.md
+++ b/docs/bootstrap-prompt.md
@@ -2,7 +2,7 @@
 
 This is the copy-paste prompt for ADR 0012 decision 5: the primary receiver
 path for someone who has never touched Lineage and doesn't want to. They
-paste this into a fresh Claude or Codex chat, with `{{PACKAGE_REF}}`
+paste this into a fresh Claude, Codex, or Auggie chat, with `{{PACKAGE_REF}}`
 replaced by one real package reference, and the agent does the rest.
 
 This file is the canonical source. The website embeds a copy of this exact
@@ -42,7 +42,7 @@ diff check is tracked as follow-up in the ADR.
 
 ````text
 You're going to install and enable a Lineage package for me. Lineage
-packages one or more Claude/Codex skills, workflows, agents, or policies
+packages one or more Claude/Codex/Auggie skills, workflows, agents, or policies
 together; you'll fetch one, and I'll be able to use it right after.
 
 Do exactly these steps, in order:
@@ -97,7 +97,7 @@ Verified 2026-08-22 against Lineage v0.3.0, the first release containing
 session with no other context. It ran the curl installer, ran
 `lineage add commit-message-helper@0.1.0 --yes`, correctly summarized the
 package's skill and capabilities back in its own words, and named the correct
-next command (`lineage run <claude|codex>`). A separate
+next command (`lineage run <claude|codex|auggie>`). A separate
 `lineage run claude --dry-run` confirmed the expected package and skill
 resolved.
 
@@ -111,8 +111,8 @@ manifest text back as content rather than acting on it.
 
 **Caveats.**
 - "Fresh agent session" here means a subagent spawned with the prompt as its
-  entire task and no other context, not a brand-new top-level Claude Code or
-  Codex chat window.
+  entire task and no other context, not a brand-new top-level Claude Code,
+  Codex, or Auggie chat window.
 - Two adversarial phrasings were tried. That is useful evidence, not a formal
   proof that no prompt-injection phrasing could ever work.
 - Re-check this section whenever the prompt wording or `lineage add` output

--- a/docs/guides/lineage-package.md
+++ b/docs/guides/lineage-package.md
@@ -64,6 +64,7 @@ Preview provider materialization before anything is written:
 ```bash
 lineage run claude --dry-run
 lineage run codex --dry-run
+lineage run auggie --dry-run
 lineage workflow run resume-review claude --dry-run
 ```
 

--- a/docs/guides/share-agent-workflows.md
+++ b/docs/guides/share-agent-workflows.md
@@ -1,9 +1,9 @@
-# How To Share Claude Code And Codex Workflows
+# How To Share Claude Code, Codex, And Auggie Workflows
 
-Lineage shares Claude Code and Codex workflows by packaging the local files
-around the workflow, publishing or exporting that package, and letting the
-receiver inspect and enable it in their own project. The receiver keeps using
-their own agent tools; Lineage supplies the portable workflow environment.
+Lineage shares Claude Code, Codex, and Auggie workflows by packaging the local
+files around the workflow, publishing or exporting that package, and letting
+the receiver inspect and enable it in their own project. The receiver keeps
+using their own agent tools; Lineage supplies the portable workflow environment.
 
 ## Author Flow
 
@@ -24,6 +24,7 @@ lineage package validate ./resume-workflow
 lineage enable ./resume-workflow
 lineage run claude --dry-run
 lineage run codex --dry-run
+lineage run auggie --dry-run
 ```
 
 Publish through the Lineage registry:
@@ -59,6 +60,7 @@ Preview the provider-specific plan before writing files:
 ```bash
 lineage run claude --dry-run
 lineage run codex --dry-run
+lineage run auggie --dry-run
 ```
 
 Run one exported workflow when the package contains several:
@@ -66,6 +68,7 @@ Run one exported workflow when the package contains several:
 ```bash
 lineage workflow run resume-review claude --dry-run
 lineage workflow run resume-review codex --dry-run
+lineage workflow run resume-review auggie --dry-run
 ```
 
 ## What Receivers Can Inspect
@@ -75,7 +78,13 @@ Before enabling, receivers can review:
 - `lineage.yaml` manifest metadata, exports, entrypoints, and capabilities.
 - `skills/`, `workflows/`, `agents/`, `policies/`, and `references/` content.
 - Validation output, including portability and safety findings.
-- Dry-run materialization output for Claude Code or Codex.
+- Dry-run materialization output for Claude Code, Codex, or Auggie.
+
+To receive an Auggie workflow, install `@augmentcode/auggie` with Node.js 22 or
+later and run `auggie login` locally before launching. Lineage stages native
+skills in `.augment/skills/` and its generated package summary in `AGENTS.md`.
+Augment credentials, sessions, settings, user rules, and MCP configuration stay
+receiver-local and are outside the adapter's current scope.
 
 Lineage's goal is to make reusable agent workflows portable without hiding what
 will be staged locally.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1383,7 +1383,7 @@ func pathIndexOf(pathEntries []string, dir string) int {
 func printUsage(w io.Writer) {
 	fmt.Fprintln(w, strings.TrimSpace(fmt.Sprintf(`
 Lineage - package a working agent setup, share it, and run it through your
-own Claude or Codex.
+own Claude, Codex, or Auggie.
 
 Usage:
   lineage <command> [arguments]
@@ -1414,7 +1414,7 @@ Using a package:
 Setup:
   init user                               create the user package directory
   init workspace <name>                   create a shared workspace
-  install-shims                           put lineage in front of claude/codex on PATH
+  install-shims                           put lineage in front of claude/codex/auggie on PATH
   doctor                                  check config, PATH, and provider setup
 
   -h, --help                              show this help

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/agentic-lineage/lineage/internal/auth"
@@ -167,7 +168,14 @@ func isHelpFlag(s string) bool {
 	return s == "-h" || s == "--help"
 }
 
+// is there a help flag anywhere in this command's arguments?
+func hasHelpFlag(args []string) bool {
+	return slices.ContainsFunc(args, isHelpFlag)
+}
+
 func runPackage(args []string, home string, stdout, stderr io.Writer) error {
+	//   Can't call hasHelpFlag here, otherwise general lineage package help
+	// would be printed
 	if len(args) > 0 && isHelpFlag(args[0]) {
 		fmt.Fprintln(stdout, packageUsage)
 		return nil
@@ -180,7 +188,7 @@ func runPackage(args []string, home string, stdout, stderr io.Writer) error {
 
 	switch args[0] {
 	case "init":
-		if isHelpFlag(args[1]) {
+		if hasHelpFlag(args[1:]) {
 			fmt.Fprintln(stdout, "usage: lineage package init <name>\n\nScaffold a new package: lineage.yaml plus the standard skills/workflows/agents/policies/references/adapters folders.")
 			return nil
 		}
@@ -198,7 +206,7 @@ func runPackage(args []string, home string, stdout, stderr io.Writer) error {
 		fmt.Fprintf(stdout, "initialized package %s\n", dir)
 		return nil
 	case "validate":
-		if isHelpFlag(args[1]) {
+		if hasHelpFlag(args[1:]) {
 			fmt.Fprintln(stdout, "usage: lineage package validate <path> [--yaml]\n\nCheck manifest schema, export authority, entrypoint path safety, and scan for secrets - without enabling or writing anything. --yaml prints a stable, provider-independent structured report instead of the human-readable summary.")
 			return nil
 		}
@@ -238,7 +246,7 @@ func runPackage(args []string, home string, stdout, stderr io.Writer) error {
 }
 
 func runPackagePublish(args []string, home string, stdout, stderr io.Writer) error {
-	if len(args) > 0 && isHelpFlag(args[0]) {
+	if hasHelpFlag(args) {
 		fmt.Fprintln(stdout, "usage: lineage package publish <path>\n\nValidate and publish a package to the Lineage registry, identified by the GitHub login from `lineage login` (or LINEAGE_PUBLISH_TOKEN). The first publish of a name claims it; later publishes need the same identity.")
 		return nil
 	}
@@ -275,7 +283,7 @@ func runPackagePublish(args []string, home string, stdout, stderr io.Writer) err
 }
 
 func runPackagePull(args []string, home string, stdout, stderr io.Writer) error {
-	if len(args) > 0 && isHelpFlag(args[0]) {
+	if hasHelpFlag(args) {
 		fmt.Fprintln(stdout, "usage: lineage package pull <package-ref> [--as name]\n\nFetch a published package (ref is \"name\" for the latest version, or an exact \"name@version\") and verify its content digest. An unauthenticated read - no login needed.")
 		return nil
 	}
@@ -318,7 +326,7 @@ func runPackagePull(args []string, home string, stdout, stderr io.Writer) error 
 }
 
 func runPackageImport(args []string, home string, stdout, stderr io.Writer) error {
-	if len(args) > 0 && isHelpFlag(args[0]) {
+	if hasHelpFlag(args) {
 		fmt.Fprintln(stdout, "usage: lineage package import <file.tgz> [--as name]\n\nExtract an exported archive into the user packages directory, re-validating it as untrusted input. Never overwrites an existing package; use --as to import under a different name.")
 		return nil
 	}
@@ -365,7 +373,7 @@ func runPackageImport(args []string, home string, stdout, stderr io.Writer) erro
 }
 
 func runPackageExport(args []string, stdout, stderr io.Writer) error {
-	if len(args) > 0 && isHelpFlag(args[0]) {
+	if hasHelpFlag(args) {
 		fmt.Fprintln(stdout, "usage: lineage package export <path> [-o file.tgz]\n\nWrite a deterministic .tgz archive of the package after running the same checks as validate. Refuses to export a package that fails validation.")
 		return nil
 	}
@@ -510,7 +518,7 @@ func describeSuffix(description string) string {
 }
 
 func runEnable(args []string, home string, stdin *bufio.Reader, stdout, stderr io.Writer) error {
-	if len(args) > 0 && isHelpFlag(args[0]) {
+	if hasHelpFlag(args) {
 		fmt.Fprintln(stdout, "usage: lineage enable <package-path-or-id> [--yes]\n\nEnable a package in the current project. If the package declares setup - tracker files or directories its workflow expects - shows the plan and asks permission before creating anything; --yes skips that prompt.")
 		return nil
 	}
@@ -755,7 +763,7 @@ func importAddSource(ref, destParent string) (name, action string, err error) {
 }
 
 func runAdd(args []string, home string, stdin *bufio.Reader, stdout, stderr io.Writer) error {
-	if len(args) > 0 && isHelpFlag(args[0]) {
+	if hasHelpFlag(args) {
 		fmt.Fprintln(stdout, "usage: lineage add <package-ref> [--yes]\n\nFetch a published package, show what it contains, ask permission, then enable it in the current project - the one-command receiver path. <package-ref> is a registry ref (name or name@version), or the path to a local .tgz archive from `lineage package export`.")
 		return nil
 	}
@@ -922,7 +930,7 @@ func runDisable(args []string, home string, stdout, stderr io.Writer) error {
 }
 
 func runInspect(args []string, home string, stdout, stderr io.Writer) error {
-	if len(args) > 0 && isHelpFlag(args[0]) {
+	if hasHelpFlag(args) {
 		fmt.Fprintln(stdout, "usage: lineage inspect <package-path-or-id> [--yaml]\n\nShow a package's contents. --yaml prints a stable, provider-independent structured report instead of the human-readable summary.")
 		return nil
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/agentic-lineage/lineage/internal/config"
 	"github.com/agentic-lineage/lineage/internal/packages"
+	"github.com/agentic-lineage/lineage/internal/provider"
 )
 
-func TestEnableAndDryRun(t *testing.T) {
+func TestEnableAndDryRunForEveryProvider(t *testing.T) {
 	tmp := t.TempDir()
 	home := filepath.Join(tmp, "home")
 	project := filepath.Join(tmp, "project")
@@ -45,21 +46,41 @@ func TestEnableAndDryRun(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cfg.Providers = map[string]config.Provider{"codex": {Binary: "/bin/echo"}}
+
+	cfg.Providers = map[string]config.Provider{}
+
+	for _, adapter := range provider.Known() {
+		cfg.Providers[ adapter.Name ] = config.Provider{
+			Binary: "/bin/echo",
+		}
+	}
+
 	if err := config.SaveProjectConfig(config.ProjectConfigPath(project), cfg); err != nil {
 		t.Fatal(err)
 	}
 
-	stdout.Reset()
-	stderr.Reset()
-	if err := Execute(nil, []string{"run", "codex", "--dry-run"}, nil, &stdout, &stderr); err != nil {
-		t.Fatalf("dry-run error = %v stderr=%s", err, stderr.String())
-	}
-	if !strings.Contains(stdout.String(), "provider: codex") {
-		t.Fatalf("dry-run output = %s", stdout.String())
-	}
-	if !strings.Contains(stdout.String(), "agent-pack@0.1.0") {
-		t.Fatalf("dry-run output = %s", stdout.String())
+	for _, adapter := range provider.Known() {
+		t.Run(adapter.Name, func(t *testing.T) {
+			stdout.Reset()
+			stderr.Reset()
+
+			err := Execute(
+				nil, []string{"run", adapter.Name, "--dry-run"}, nil, &stdout, &stderr,
+			)
+
+			if err != nil {
+				t.Fatalf("dry-run error = %v stderr = %s", err, stderr.String())
+			}
+
+			output := stdout.String()
+			if !strings.Contains(output, "real_binary: /bin/echo") {
+				t.Errorf("dry-run output does not name configured binary:\n%s", output)
+			}
+
+			if !strings.Contains(output, "agent-pack@0.1.0") {
+				t.Errorf("dry-run output does not name enabled package:\n%s", output)
+			}
+		})
 	}
 }
 
@@ -229,8 +250,11 @@ func TestRunUnknownProviderListsKnownProviders(t *testing.T) {
 	if err == nil {
 		t.Fatal("Execute(run does-not-exist) error = nil, want error")
 	}
-	if !strings.Contains(stderr.String(), "claude") || !strings.Contains(stderr.String(), "codex") {
-		t.Fatalf("stderr = %q, want it to list known providers", stderr.String())
+
+	for _, adapter := range provider.Known() {
+		if !strings.Contains(stderr.String(), adapter.Name) {
+			t.Fatalf("stderr = %q, want it to list known providers", stderr.String())
+		}
 	}
 }
 
@@ -238,8 +262,11 @@ func TestUsageListsKnownProvidersNotHardcoded(t *testing.T) {
 	var stdout bytes.Buffer
 	printUsage(&stdout)
 	out := stdout.String()
-	if !strings.Contains(out, "claude") || !strings.Contains(out, "codex") {
-		t.Fatalf("usage = %q, want it to mention every registered provider", out)
+
+	for _, adapter := range provider.Known() {
+		if !strings.Contains(out, adapter.Name) {
+			t.Fatalf("usage = %q, want it to mention every registered provider", out)
+		}
 	}
 }
 

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -70,3 +70,47 @@ func TestPackageSubcommandHelpDoesNotTreatFlagAsArgument(t *testing.T) {
 		}
 	}
 }
+
+func TestHelpFlagRecognizedAfterOtherArguments(t *testing.T) {
+	cases := []struct {
+		args []string
+		wantUsage string
+	}{
+		{[]string{"enable", "--yes", "--help"}, "usage: lineage enable"},
+		{[]string{"add", "--yes", "-h"}, "usage: lineage add"},
+		{[]string{"inspect", "--yaml", "--help"}, "usage: lineage inspect"},
+		{
+			[]string{"package", "export", ".", "-o", "out.tgz", "--help"},
+			"usage: lineage package export",
+		},
+		{
+			[]string{"package", "pull", "example", "--as", "renamed", "-h"},
+			"usage: lineage package pull",
+		},
+	}
+
+	for _, tc := range cases {
+		var stdout, stderr bytes.Buffer
+
+		err := Execute(nil, tc.args, nil, &stdout, &stderr)
+		if err != nil {
+			t.Fatalf("%v: error = %v; stderr = %q",
+				tc.args, err, stderr.String())
+		}
+
+		if !strings.HasPrefix(stdout.String(), tc.wantUsage) {
+			t.Fatalf("%v: stdout = %q, want prefix %q",
+				tc.args, stdout.String(), tc.wantUsage)
+		}
+
+		if stderr.Len() != 0 {
+			t.Fatalf("%v: stderr = %q, want empty", tc.args, stderr.String())
+		}
+	}
+}
+
+func TestHasHelpFlagRequiresExactToken(t *testing.T) {
+	if hasHelpFlag([]string{"--helpful", "docs/--help-example"}) {
+		t.Fatal("similar strings must not be interpreted as help flags")
+	}
+}

--- a/internal/materialize/materialize_test.go
+++ b/internal/materialize/materialize_test.go
@@ -82,30 +82,69 @@ func TestApplyRejectsCollidingSkillDirNames(t *testing.T) {
 	}
 }
 
-func TestApplyStagesSkillsAndWritesContextFile(t *testing.T) {
-	root := t.TempDir()
+func TestApplyStagesSkillsAndWritesContextForEveryProvider(t *testing.T) {
 	pkg := buildTestPackage(t, "review-pack", "review")
 
-	claude, err := provider.Get("claude")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := Apply(root, claude, []packages.Package{pkg}); err != nil {
-		t.Fatalf("Apply() error = %v", err)
-	}
+	for _, adapter := range provider.Known() {
+		t.Run(adapter.Name, func(t *testing.T) {
+			root := t.TempDir()
 
-	skillFile := filepath.Join(root, ".claude", "skills", "review-pack-review", "SKILL.md")
-	if _, err := os.Stat(skillFile); err != nil {
-		t.Fatalf("expected staged skill at %s: %v", skillFile, err)
-	}
+			if err := Apply(root, adapter, []packages.Package{pkg}); err != nil {
+				t.Fatalf("Apply() error = %v", err)
+			}
 
-	contextData, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
-	if err != nil {
-		t.Fatalf("read CLAUDE.md: %v", err)
-	}
-	content := string(contextData)
-	if !containsAll(content, beginMarker, endMarker, "review-pack@0.1.0") {
-		t.Fatalf("CLAUDE.md missing expected content:\n%s", content)
+			skillFile := filepath.Join(
+				root,
+				adapter.SkillsDir,
+				"review-pack-review",
+				"SKILL.md",
+			)
+
+			if _, err := os.Stat(skillFile); err != nil {
+				t.Fatalf(
+					"expected %s skill at %s: %v",
+					adapter.Name,
+					skillFile,
+					err,
+				)
+			}
+
+			contextPath := filepath.Join(root, adapter.ContextFile)
+			contextData, err := os.ReadFile(contextPath)
+			if err != nil {
+				t.Fatalf("read %s: %v", adapter.ContextFile, err)
+			}
+
+			if !containsAll(
+				string(contextData), beginMarker, endMarker, "review-pack@0.1.0",
+			) {
+				t.Fatalf(
+					"%s missing expected content:\n%s", adapter.ContextFile, contextData,
+				)
+			}
+
+			statePath := filepath.Join(
+				root, ".lineage", "materialized-" + adapter.Name + ".json",
+			)
+
+			stateData, err := os.ReadFile(statePath)
+			if err != nil {
+				t.Fatalf(
+					"read %s materialization state: %v", adapter.Name, err,
+				)
+			}
+
+			expectedSkillDir := filepath.Join(
+				adapter.SkillsDir, "review-pack-review",
+			)
+
+			if !strings.Contains(string(stateData), expectedSkillDir) {
+				t.Fatalf(
+					"%s state missing skill path %q:\n%s", adapter.Name,
+					expectedSkillDir, stateData,
+				)
+			}
+		})
 	}
 }
 
@@ -140,33 +179,6 @@ func TestApplyCapsStagedFilePermissions(t *testing.T) {
 			t.Errorf("staged file mode = %v, want no group/other write bit (source was 0o777, umask forced to 0 so the OS can't mask this for us)", info.Mode().Perm())
 		}
 	})
-}
-
-func TestApplyStagesSkillsForCodexAdapter(t *testing.T) {
-	root := t.TempDir()
-	pkg := buildTestPackage(t, "review-pack", "review")
-	codex, err := provider.Get("codex")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := Apply(root, codex, []packages.Package{pkg}); err != nil {
-		t.Fatalf("Apply() error = %v", err)
-	}
-
-	skillFile := filepath.Join(root, ".agents", "skills", "review-pack-review", "SKILL.md")
-	if _, err := os.Stat(skillFile); err != nil {
-		t.Fatalf("expected staged skill at %s: %v", skillFile, err)
-	}
-
-	contextData, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))
-	if err != nil {
-		t.Fatalf("read AGENTS.md: %v", err)
-	}
-	content := string(contextData)
-	if !containsAll(content, beginMarker, endMarker, "review-pack@0.1.0") {
-		t.Fatalf("AGENTS.md missing expected content:\n%s", content)
-	}
 }
 
 func TestApplyKeepsProvidersIsolated(t *testing.T) {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -26,22 +27,59 @@ func TestIsShimPath(t *testing.T) {
 	}
 }
 
-func TestResolveWithConfiguredBinary(t *testing.T) {
-	project := config.ProjectConfig{
-		Providers: map[string]config.Provider{
-			"codex": {Binary: "/bin/echo"},
-		},
+func TestResolveWithConfiguredBinaryForEveryProvider(t *testing.T) {
+	for _, adapter := range Known() {
+		t.Run(adapter.Name, func(t *testing.T) {
+			binary := filepath.Join(t.TempDir(), adapter.Name)
+			project := config.ProjectConfig{
+				Providers: map[string]config.Provider{
+					adapter.Name: {
+						Binary: binary,
+						Args: []string{"configured-arg"},
+					},
+				},
+			}
+
+			plan, err := Resolve(
+				adapter.Name, t.TempDir(), project, []string{"launch-arg"},
+			)
+
+			if err != nil {
+				t.Fatalf("Resolve() error = %v", err)
+			}
+
+			if plan.Name != adapter.Name {
+				t.Errorf("Name = %q, want %q", plan.Name, adapter.Name)
+			}
+
+			if plan.Binary != binary {
+				t.Errorf("Binary = %q, want %q", plan.Binary, binary)
+			}
+
+			wantArgs := []string{"configured-arg", "launch-arg"}
+			if !reflect.DeepEqual(plan.Args, wantArgs) {
+				t.Errorf("Args = %#v, want %#v", plan.Args, wantArgs)
+			}
+
+			if !containsString(plan.Env,"LINEAGE_PROVIDER="+adapter.Name) {
+				t.Errorf("Env does not contain LINEAGE_PROVIDER=%s", adapter.Name)
+			}
+
+			if !containsString(plan.Env, "LINEAGE_ACTIVE=1") {
+				t.Error("Env does not contain LINEAGE_ACTIVE=1")
+			}
+		})
 	}
-	plan, err := Resolve("codex", t.TempDir(), project, []string{"hello"})
-	if err != nil {
-		t.Fatalf("Resolve() error = %v", err)
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
 	}
-	if plan.Binary != "/bin/echo" {
-		t.Fatalf("Binary = %q", plan.Binary)
-	}
-	if len(plan.Args) != 1 || plan.Args[0] != "hello" {
-		t.Fatalf("Args = %#v", plan.Args)
-	}
+
+	return false
 }
 
 func TestCandidateBinariesFindsMultipleAndSkipsShim(t *testing.T) {

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -22,6 +22,7 @@ type Provider struct {
 var registry = []Provider{
 	{Name: "claude", SkillsDir: filepath.Join(".claude", "skills"), ContextFile: "CLAUDE.md"},
 	{Name: "codex", SkillsDir: filepath.Join(".agents", "skills"), ContextFile: "AGENTS.md"},
+	{Name: "auggie", SkillsDir: filepath.Join(".augment", "skills"), ContextFile: "AGENTS.md"},
 }
 
 // Known returns every registered provider, in registration order.

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -1,17 +1,40 @@
 package provider
 
 import (
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
 
-func TestKnownIncludesClaudeAndCodex(t *testing.T) {
-	names := map[string]bool{}
-	for _, p := range Known() {
-		names[p.Name] = true
+//	 This gives each future provider one obvious test addition and verifies all
+// three parts of its adapter.
+//
+//	 The test duplicates the registry data: this way, if someone accidentally
+// changes Auggie's path to .augment/rules, the test should fail and force them
+// to explain the contract change.
+func TestKnownProviders(t *testing.T) {
+	want := []Provider{
+		{
+			Name:        "claude",
+			SkillsDir:   filepath.Join(".claude", "skills"),
+			ContextFile: "CLAUDE.md",
+		},
+		{
+			Name:        "codex",
+			SkillsDir:   filepath.Join(".agents", "skills"),
+			ContextFile: "AGENTS.md",
+		},
+		{
+			Name:        "auggie",
+			SkillsDir:   filepath.Join(".augment", "skills"),
+			ContextFile: "AGENTS.md",
+		},
 	}
-	if !names["claude"] || !names["codex"] {
-		t.Fatalf("Known() = %v, want claude and codex present", names)
+
+	got := Known()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Known() = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/agentic-lineage/lineage/internal/provider"
 )
 
 func TestFileNamePOSIXHasNoExtension(t *testing.T) {
@@ -29,10 +31,10 @@ func TestInstallWritesShimForEveryKnownProvider(t *testing.T) {
 		t.Fatalf("Install() error = %v", err)
 	}
 
-	for _, name := range []string{"claude", "codex"} {
-		path := filepath.Join(home, "bin", FileName(name, runtime.GOOS))
+	for _, adapter := range provider.Known() {
+		path := filepath.Join(home, "bin", FileName(adapter.Name, runtime.GOOS))
 		if _, err := os.Stat(path); err != nil {
-			t.Fatalf("expected shim for %s at %s: %v", name, path, err)
+			t.Fatalf("expected shim for %s at %s: %v", adapter.Name, path, err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Add Auggie / Augment Code as a supported Lineage provider.

The adapter:
- resolves the `auggie` executable from `PATH` or `providers.auggie.binary`;
- stages packaged Agent Skills under `.augment/skills/`;
- writes Lineage-managed context to the project’s `AGENTS.md`;
- inherits generic launch planning, argument forwarding, shims, doctor diagnostics, approval gating, and idempotent materialization.

The implementation uses `.augment/skills/` instead of `.augment/rules/` because current Auggie releases support native `SKILL.md` Agent Skills there. Rules are a separate Augment concept.

Provider tests were generalized to cover every registered provider, making future adapters easier to add without duplicating test cases.

## Linked Issue
Closes #35 

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`, or it is a release-tracked promotion into `master`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact
- [ ] Package format or manifest behavior
- [ ] Package discovery or enablement
- [x] Provider launch/shim behavior
- [ ] Setup or permission flow
- [x] Documentation only
- [x] Tests only

## Safety
- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification
Relevant test cases:
- Provider registry contracts for Claude, Codex, and Auggie.
- Configured binary resolution and launch arguments for every provider.
- Materialization of skills, context, and provider-specific state for every provider.
- Shim installation for every registered provider.
- CLI help and unknown-provider output derived from the provider registry.
- Dry-run launch planning for every provider.

```text
git diff --check
go test ./...
```
All tests pass.

## Notes For Reviewers
Please review the Auggie filesystem mapping in particular:
- Skills: .augment/skills/
- Context: AGENTS.md

Auggie requires Node.js 22 or later, and local authentication through `auggie login`. Also, we should keep in mind that Auggie is beta.
Please take a look at the tests to determine if I've generalized them correctly. While I've only added Auggie as provider, the way tests are written now should allow to easily add other providers.
Finally, I've edited the docs to include Auggie: it works for now, but depending on the number of providers it could require some reformat.
