### PR TITLE
chore: update master references to main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ What changed, and why?
 Closes #
 
 - [ ] The linked issue is assigned to me.
-- [ ] This PR targets `develop`, or it is a release-tracked promotion into `master`.
+- [ ] This PR targets `develop`, or it is a release-tracked promotion into `main`.
 - [ ] This PR is not ready for review until the linked issue and test plan are complete.
 
 ## Package Impact
@@ -44,9 +44,9 @@ If this PR does not need automated tests, explain why:
 
 ## Release Tracking
 
-Complete this section only for PRs targeting `master`.
+Complete this section only for PRs targeting `main`.
 
-- [ ] Release-worthy master promotion
+- [ ] Release-worthy main promotion
 - [ ] Non-release housekeeping
 
 Planned version:
@@ -77,7 +77,7 @@ Safety and compatibility notes:
 
 Post-merge tag plan:
 
-- [ ] Create and push an annotated SemVer tag after merge to `master`.
+- [ ] Create and push an annotated SemVer tag after merge to `main`.
 
 Non-release housekeeping reason:
 

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -2,7 +2,7 @@ name: PR Policy
 
 on:
   pull_request:
-    branches: [develop, master]
+    branches: [develop, main]
     types: [opened, edited, reopened, synchronize, ready_for_review]
 
 permissions:
@@ -32,8 +32,8 @@ jobs:
           repo = os.environ.get("GITHUB_REPOSITORY") or ""
           errors = []
 
-          if base not in {"develop", "master"}:
-              errors.append("PR must target develop, except release-tracked promotions may target master.")
+          if base not in {"develop", "main"}:
+              errors.append("PR must target develop, except release-tracked promotions may target main.")
 
           linked_issue = re.search(r"(?im)\b(closes|fixes|resolves)\s+#\d+\b", body)
           maintainer_housekeeping = re.search(r"(?im)\bmaintainer housekeeping\b", body)
@@ -80,27 +80,27 @@ jobs:
           def has_bullet_text(text):
               return bool(re.search(r"(?m)^-\s+\S+", text))
 
-          if base == "master":
+          if base == "main":
               release = section_text("Release Tracking")
               if not release:
-                  errors.append("PRs targeting master must include a Release Tracking section.")
+                  errors.append("PRs targeting main must include a Release Tracking section.")
               else:
-                  is_release = has_checked_item(release, "Release-worthy master promotion")
+                  is_release = has_checked_item(release, "Release-worthy main promotion")
                   is_housekeeping = has_checked_item(release, "Non-release housekeeping")
 
                   if is_release == is_housekeeping:
-                      errors.append("Master PRs must check exactly one release-tracking mode: release-worthy promotion or non-release housekeeping.")
+                      errors.append("Main PRs must check exactly one release-tracking mode: release-worthy promotion or non-release housekeeping.")
 
                   if is_housekeeping:
                       reason = subsection_text(release, "Non-release housekeeping reason")
                       if not has_bullet_text(reason):
-                          errors.append("Non-release housekeeping master PRs must explain why no release tag is needed.")
+                          errors.append("Non-release housekeeping main PRs must explain why no release tag is needed.")
 
                   if is_release:
                       planned_version = subsection_text(release, "Planned version")
                       version_match = re.search(r"\bv\d+\.\d+\.\d+\b", planned_version)
                       if not version_match:
-                          errors.append("Release-worthy master PRs must declare a planned SemVer tag like `v0.4.0`.")
+                          errors.append("Release-worthy main PRs must declare a planned SemVer tag like `v0.4.0`.")
                       else:
                           version = version_match.group(0)
                           tag_url = f"https://api.github.com/repos/{repo}/git/ref/tags/{version}"
@@ -115,7 +115,7 @@ jobs:
 
                       release_classification = subsection_text(release, "Release classification")
                       if not re.search(r"\b(patch|minor|major)\b", release_classification):
-                          errors.append("Release-worthy master PRs must classify the version bump as patch, minor, or major.")
+                          errors.append("Release-worthy main PRs must classify the version bump as patch, minor, or major.")
 
                       for heading in [
                           "What changed",
@@ -127,8 +127,8 @@ jobs:
                           if not has_bullet_text(content):
                               errors.append(f"Release notes must include at least one bullet for '{heading}'.")
 
-                      if not has_checked_item(release, "Create and push an annotated SemVer tag after merge to `master`."):
-                          errors.append("Release-worthy master PRs must confirm the post-merge annotated tag plan.")
+                      if not has_checked_item(release, "Create and push an annotated SemVer tag after merge to `main`."):
+                          errors.append("Release-worthy main PRs must confirm the post-merge annotated tag plan.")
 
           if errors:
               print("PR policy failed:")

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   pull_request:
-    branches: [develop, master]
+    branches: [develop, main]
   push:
-    branches: [develop, master]
+    branches: [develop, main]
 
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,10 @@ Repository skills in `.agents/skills` are Lineage guardrails, not generic engine
 
 ## Branch Policy
 
-- `master` is the stable branch.
+- `main` is the stable branch.
 - `develop` is the active development branch.
 - Feature and fix branches should target `develop`.
-- Changes reach `master` only after they have been reviewed and are ready for a stable release point.
+- Changes reach `main` only after they have been reviewed and are ready for a stable release point.
 - Protected branches should require tests to pass and owner approval before merge.
 
 ## Lean Planning

--- a/docs/branch-policy.md
+++ b/docs/branch-policy.md
@@ -2,7 +2,7 @@
 
 Lineage uses two protected long-lived branches:
 
-- `master`: stable branch.
+- `main`: stable branch.
 - `develop`: active development branch and default PR target.
 
 ## Required Flow
@@ -18,7 +18,7 @@ PRs without a linked assigned issue should not be reviewed except for maintainer
 
 ## Recommended GitHub Protection
 
-Apply these protections to both `master` and `develop`:
+Apply these protections to both `main` and `develop`:
 
 - Require a pull request before merging.
 - Require at least one approving review.
@@ -31,9 +31,9 @@ Apply these protections to both `master` and `develop`:
 - Restrict deletions.
 - Require conversation resolution before merging.
 
-The test workflow runs for pull requests targeting `develop` and pushes to `develop` or `master`.
+The test workflow runs for pull requests targeting `develop` and pushes to `develop` or `main`.
 
-Release tags should point at commits that are already on `master`. See
+Release tags should point at commits that are already on `main`. See
 [Release And Versioning Policy](release-versioning.md) for the tagging,
 release-note, and stable-promotion rules.
 

--- a/docs/lean-development.md
+++ b/docs/lean-development.md
@@ -30,7 +30,7 @@ A milestone is done when its issues prove the goal works well enough to trust, n
 
 Stable releases are cut from completed or explicitly bounded goal milestones.
 See [Release And Versioning Policy](release-versioning.md) for how milestone
-completion maps to `master` promotions and SemVer tags.
+completion maps to `main` promotions and SemVer tags.
 
 ## Issue Shape
 

--- a/docs/release-versioning.md
+++ b/docs/release-versioning.md
@@ -6,11 +6,11 @@ Lineage's own release tags.
 
 ## Stable Branch
 
-`master` is the stable public baseline. A commit promoted to `master` should be
+`main` is the stable public baseline. A commit promoted to `main` should be
 something a user can install, run, and cite in a bug report.
 
 Development happens on `develop`. Feature and fix work should merge to
-`develop` first, then `develop` is promoted to `master` when the current stable
+`develop` first, then `develop` is promoted to `main` when the current stable
 goal is coherent enough to release.
 
 ## Version Scheme
@@ -38,7 +38,7 @@ package, inspect it, enable it, and run it through a local provider workflow.
 
 ## Tagging
 
-Every meaningful stable promotion to `master` should have an annotated tag:
+Every meaningful stable promotion to `main` should have an annotated tag:
 
 ```bash
 git tag -a v0.x.y -m "Lineage v0.x.y"
@@ -78,10 +78,10 @@ release scope.
 
 ## Required Checks
 
-Before promoting to `master` or tagging a release:
+Before promoting to `main` or tagging a release:
 
 - All release-scope issues are closed or explicitly deferred.
-- The PR from `develop` to `master` passes the `Go` test workflow and release
+- The PR from `develop` to `main` passes the `Go` test workflow and release
   tracking check.
 - The PR declares the planned SemVer tag, release classification, release notes,
   and post-merge annotated tag plan.
@@ -89,11 +89,11 @@ Before promoting to `master` or tagging a release:
   resolution, and no force pushes or branch deletion.
 - The release notes identify any skipped automated tests or manual validation.
 
-Release tags should point at commits that are already on `master`.
+Release tags should point at commits that are already on `main`.
 
 ## Non-Release Housekeeping
 
-A PR to `master` may skip release tagging only when it is explicitly marked as
+A PR to `main` may skip release tagging only when it is explicitly marked as
 non-release housekeeping and explains why no user-facing release is needed.
 Examples include release-doc typo fixes, workflow metadata cleanup, or
 administrative repository maintenance.


### PR DESCRIPTION
## Summary

Follow-up to renaming the default branch from `master` to `main`: updates every place that still hardcoded the literal string `master` so CI and the PR policy keep working against `main`.

- `.github/workflows/test.yml` and `.github/workflows/pr-policy.yml`: trigger branches `master` -> `main`.
- `.github/workflows/pr-policy.yml`: the release-tracking policy logic (`base == "master"`, error messages, the required "Create and push an annotated SemVer tag after merge to `master`." checkbox text) updated to `main`.
- `.github/PULL_REQUEST_TEMPLATE.md`: matching checkbox labels and prose updated to `main` so the template still satisfies the policy script's exact-text checks.
- `CONTRIBUTING.md`, `docs/branch-policy.md`, `docs/lean-development.md`, `docs/release-versioning.md`: branch-policy and release docs updated to refer to `main` as the stable branch.

Without this, the first PR opened against `main` would fail the PR Policy check, since it still requires a Release Tracking section keyed off the literal branch name `master`.

- [ ] The linked issue is assigned to me.
- [x] This PR targets `develop`, or it is a release-tracked promotion into `main`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Linked Issue

maintainer housekeeping

## Package Impact

- [ ] Package format or manifest behavior
- [ ] Package discovery or enablement
- [ ] Provider launch/shim behavior
- [ ] Setup or permission flow
- [x] Documentation only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- N/A: CI config and docs only, no Go code changed.

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- Only CI trigger config, the PR policy script's text, and Markdown docs changed; no runtime behavior to test. `go build ./...` and `go test ./...` were run locally beforehand to confirm the branch rename itself didn't break anything.

## Release Tracking

Complete this section only for PRs targeting `main`.

- [ ] Release-worthy main promotion
- [x] Non-release housekeeping

Planned version:

`v0.0.0`

Release classification:

`patch | minor | major`

Release notes:

What changed:

-

What is experimental:

-

What is outside scope:

-

Safety and compatibility notes:

-

Post-merge tag plan:

- [ ] Create and push an annotated SemVer tag after merge to `main`.

Non-release housekeeping reason:

- Pure repo/CI hygiene following the master->main default branch rename; no user-facing behavior changes, so no release tag is needed.

## Notes For Reviewers

This depends on the branch rename already being done (master->main, main set as default) which happened via the GitHub API, not a PR (branch rename/default-branch changes aren't expressible as a PR). This PR just catches up the text that referenced the old name.
