### PR TITLE
test: align Windows provider binary fixtures with PATHEXT

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -57,6 +57,7 @@ func TestCandidateBinariesFindsMultipleAndSkipsShim(t *testing.T) {
 	claudeB := writeExecutable(t, filepath.Join(dirB, "claude"))
 	writeExecutable(t, filepath.Join(shimDir, "claude"))
 
+	t.Setenv("PATHEXT", ".EXE;.CMD")
 	t.Setenv("PATH", strings.Join([]string{dirA, shimDir, dirB}, string(os.PathListSeparator)))
 
 	candidates := CandidateBinaries("claude", home)
@@ -87,6 +88,7 @@ func TestCandidateBinariesSkipsShimContentOutsideShimsDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	t.Setenv("PATHEXT", ".EXE;.CMD")
 	t.Setenv("PATH", strings.Join([]string{strayDir, realDir}, string(os.PathListSeparator)))
 
 	candidates := CandidateBinaries("claude", home)
@@ -119,14 +121,11 @@ func writeExecutable(t *testing.T, base string) string {
 
 // executableSuffix returns the filename suffix a bare command name needs
 // to be discovered by CandidateBinaries on the current OS: none on POSIX,
-// where the executable bit gates it instead, and ".exe" on Windows, which
-// resolves bare commands through PATHEXT and has no executable-bit concept.
-// ".exe" is always present in PATHEXT, whether left at its OS default or
-// overridden, so it's a safe fixed choice for tests that don't set PATHEXT
-// themselves (contrast the PATHEXT-sensitive tests below, which do).
+// where the executable bit gates it instead, and ".EXE" on Windows, matching
+// the PATHEXT value set by the high-level CandidateBinaries tests above.
 func executableSuffix() string {
 	if runtime.GOOS == "windows" {
-		return ".exe"
+		return ".EXE"
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary

Fixes the remaining Windows provider test portability failure surfaced by PR #209 after PR #212 landed.

The high-level CandidateBinaries tests now set PATHEXT explicitly to .EXE;.CMD, and the shared test helper writes .EXE fixtures on Windows to match the extension casing CandidateBinaries probes and returns. Product code is unchanged; this only removes a case-sensitive string-expectation mismatch in the tests.

## Linked Issue

Maintainer housekeeping follow-up for PR #209 and PR #212. No standalone issue; this is the narrow blocker exposed by the Windows CI matrix.

- [x] The linked issue is assigned to me, or this PR is maintainer follow-up housekeeping.
- [x] This PR targets develop, or it is a release-tracked promotion into master.
- [x] This PR is ready for review after the linked context and test plan are complete.

## Package Impact

- [ ] Package format or manifest behavior
- [ ] Package discovery or enablement
- [x] Provider launch/shim behavior
- [ ] Setup or permission flow
- [ ] Documentation only
- [x] Tests only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- Provider CandidateBinaries tests now control PATHEXT and expect the same extension casing that the resolver probes on Windows.

```text
go test ./internal/provider
go test ./...
```

Both pass locally on macOS.

If this PR does not need automated tests, explain why:

- N/A; this PR changes tests and was verified with the affected package plus full suite.

## Notes For Reviewers

This is intentionally test-only. The failing Windows CI output showed CandidateBinaries returning claude.EXE while the test expected claude.exe. On Windows that is the same file, but the Go test compares strings exactly, so the fixture should use the same PATHEXT casing the candidate search returns.
