### PR TITLE
test: encode legacy materialize state fixtures

### DIFF
--- a/internal/materialize/materialize_test.go
+++ b/internal/materialize/materialize_test.go
@@ -1,6 +1,7 @@
 package materialize
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -410,8 +411,13 @@ func TestNeedsApprovalDefaultsMissingSchemaToCurrent(t *testing.T) {
 		t.Fatal(err)
 	}
 	rel := filepath.Join(adapter.SkillsDir, pkg.Manifest.Name+"-"+pkg.Skills[0])
-	legacy := `{"skill_dirs":["` + filepath.ToSlash(rel) + `"]}`
-	if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
+	legacy, err := json.Marshal(struct {
+		SkillDirs []string `json:"skill_dirs"`
+	}{SkillDirs: []string{rel}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, legacy, 0o644); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## Summary

Maintainer housekeeping follow-up for the Windows CI rollout in PR #209.

The `TestNeedsApprovalDefaultsMissingSchemaToCurrent` fixture was manually building schema-less JSON with `filepath.ToSlash(rel)`. That made the test fail on Windows because `NeedsApproval` computes platform-native relative skill directories with `filepath.Join`, so the loaded legacy state and desired state differed only by separator style.

This changes the fixture to use `json.Marshal` with the platform-native `rel` value. The state remains schema-less, so the test still verifies the intended backwards-compatibility path; it just writes valid JSON without changing path semantics.

## Linked Issue

Maintainer housekeeping follow-up for PR #209 and PR #212. No standalone issue; this is the narrow Windows test blocker exposed by the Windows CI matrix.

- [x] The linked issue is assigned to me, or this PR is maintainer follow-up housekeeping.
- [x] This PR targets develop, or it is a release-tracked promotion into master.
- [x] This PR is ready for review after the linked context and test plan are complete.

## Package Impact

- [ ] Package format or manifest behavior
- [ ] Package discovery or enablement
- [ ] Provider launch/shim behavior
- [x] Setup or permission flow
- [ ] Documentation only
- [x] Tests only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- `TestNeedsApprovalDefaultsMissingSchemaToCurrent` now writes schema-less state through JSON encoding while preserving platform-native path separators.

```text
go test ./internal/materialize
go test ./...
```

Both pass locally on macOS.

If this PR does not need automated tests, explain why:

- N/A; this PR changes a test fixture and was verified with the affected package plus full suite.

## Notes For Reviewers

This is intentionally test-only. It does not change `NeedsApproval` or materialized state behavior; it only fixes the legacy-state fixture so Windows does not compare `.claude/skills/...` from the hand-built JSON against `.claude\skills\...` from `filepath.Join`.
