### PR TITLE
docs: document lack of file locking on concurrent invocations

### DIFF
--- a/docs/safety.md
+++ b/docs/safety.md
@@ -56,6 +56,12 @@ None of this proves *who* published a package — v1 has no signing and no publi
 - **Enable**: if a package declares setup (tracker files or directories its workflow expects to exist), `lineage enable` shows exactly what would be created — file by file, directory by directory — and asks for confirmation before creating anything, unless `--yes` was passed. Declining setup leaves the workspace completely unchanged, same as declining to enable at all.
 - **Materialize**: the first time a given package set would actually change what's staged for a provider, `lineage run`/`lineage workflow run` shows the plan and asks for confirmation (`y`/`yes`, or `--yes` to skip the prompt for scripts). Re-running with an unchanged package set doesn't re-prompt. This is tracked per-provider in `.lineage/materialized-<provider>.json` so cleanup on disable is exact, not guessed from disk contents (ADR 0008).
 
+## Concurrent Invocations Are Not Locked
+
+`.lineage/config.yaml` and `.lineage/materialized-<provider>.json` take no advisory or file lock. Running two `lineage` invocations against the same project at the same time — two terminals, or a script that shells out twice — can race: both read the same starting content, both write, and the second write wins. The first process's change is silently lost, with no error to either caller.
+
+This is a lost update, not corruption — every write to these files goes through `internal/atomicfile` (temp file + atomic rename), so a reader never sees a torn or partially-written file, only the previous version or the complete new one. For a single-user local CLI this is an accepted tradeoff: don't run concurrent `lineage enable`/`lineage run` invocations against the same project, and if you do, expect the second one to win.
+
 ## Capabilities: Declared, Not Enforced
 
 A package's manifest can carry an optional `capabilities` block (`filesystem.read`, `network`). `lineage package validate` and `--dry-run` print what a package declares wanting. **Nothing in this build enforces, blocks, or warns based on those values beyond printing them** (ADR 0006) — a `capabilities` block that looks unenforced is expected, not a bug. Treat a declared capability as a receiver-visible statement of intent, not a permission you're granting or a boundary Lineage is holding.


### PR DESCRIPTION
## Summary

- Closes #170. Maintainer decision on the issue was to accept this as a documented limitation, not a bug: `.lineage/config.yaml` and `.lineage/materialized-<provider>.json` writes go through `internal/atomicfile` (temp+rename), so concurrent invocations race to a clean lost update, never file corruption.
- Adds a "Concurrent Invocations Are Not Locked" section to `docs/safety.md` explaining the scenario, the actual failure mode, and the accepted tradeoff.

Note: `docs/safety.md` itself is from #201, already merged into `102-source-workspace-discovery-inventory` but not yet into `develop`. This PR's diff carries the whole file for that reason -- only the new "Concurrent Invocations Are Not Locked" section is this issue's actual change.

## Linked Issue

Closes #170

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`, or it is a release-tracked promotion into `master`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [ ] Package format or manifest behavior
- [ ] Package discovery or enablement
- [ ] Provider launch/shim behavior
- [ ] Setup or permission flow
- [x] Documentation only
- [ ] Tests only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

N/A - docs-only PR.

If this PR does not need automated tests, explain why:

- Documentation-only change; manually reviewed the rendered section for tone, heading consistency, and accuracy against the accepted maintainer decision in #170.

## Notes For Reviewers

- This documents an accepted limitation rather than adding cross-platform file locking.
- `internal/atomicfile` still prevents torn or partially-written files; the documented risk is last-writer-wins lost updates during concurrent read-modify-write flows.
