### PR TITLE
chore: align release infrastructure with main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ What changed, and why?
 Closes #
 
 - [ ] The linked issue is assigned to me.
-- [ ] This PR targets `develop`, or it is a release-tracked promotion into `master`.
+- [ ] This PR targets `develop`, or it is a release-tracked promotion into `main`.
 - [ ] This PR is not ready for review until the linked issue and test plan are complete.
 
 ## Package Impact
@@ -44,9 +44,9 @@ If this PR does not need automated tests, explain why:
 
 ## Release Tracking
 
-Complete this section only for PRs targeting `master`.
+Complete this section only for PRs targeting `main`.
 
-- [ ] Release-worthy master promotion
+- [ ] Release-worthy main promotion
 - [ ] Non-release housekeeping
 
 Planned version:
@@ -77,7 +77,9 @@ Safety and compatibility notes:
 
 Post-merge tag plan:
 
-- [ ] Create and push an annotated SemVer tag after merge to `master`.
+- [ ] Create and push an annotated SemVer tag after merge to `main`.
+- [ ] Publish the matching GitHub Release and artifacts.
+- [ ] Sync the resulting `main` merge commit back into `develop`.
 
 Non-release housekeeping reason:
 

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -2,7 +2,7 @@ name: PR Policy
 
 on:
   pull_request:
-    branches: [develop, master]
+    branches: [develop, main]
     types: [opened, edited, reopened, synchronize, ready_for_review]
 
 permissions:
@@ -18,6 +18,7 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           python3 - <<'PY'
@@ -29,11 +30,12 @@ jobs:
 
           body = os.environ.get("PR_BODY") or ""
           base = os.environ.get("PR_BASE") or ""
+          head = os.environ.get("PR_HEAD") or ""
           repo = os.environ.get("GITHUB_REPOSITORY") or ""
           errors = []
 
-          if base not in {"develop", "master"}:
-              errors.append("PR must target develop, except release-tracked promotions may target master.")
+          if base not in {"develop", "main"}:
+              errors.append("PR must target develop, except release-tracked promotions may target main.")
 
           linked_issue = re.search(r"(?im)\b(closes|fixes|resolves)\s+#\d+\b", body)
           maintainer_housekeeping = re.search(r"(?im)\bmaintainer housekeeping\b", body)
@@ -80,27 +82,30 @@ jobs:
           def has_bullet_text(text):
               return bool(re.search(r"(?m)^-\s+\S+", text))
 
-          if base == "master":
+          if base == "main":
               release = section_text("Release Tracking")
               if not release:
-                  errors.append("PRs targeting master must include a Release Tracking section.")
+                  errors.append("PRs targeting main must include a Release Tracking section.")
               else:
-                  is_release = has_checked_item(release, "Release-worthy master promotion")
+                  is_release = has_checked_item(release, "Release-worthy main promotion")
                   is_housekeeping = has_checked_item(release, "Non-release housekeeping")
 
                   if is_release == is_housekeeping:
-                      errors.append("Master PRs must check exactly one release-tracking mode: release-worthy promotion or non-release housekeeping.")
+                      errors.append("Main PRs must check exactly one release-tracking mode: release-worthy promotion or non-release housekeeping.")
 
                   if is_housekeeping:
                       reason = subsection_text(release, "Non-release housekeeping reason")
                       if not has_bullet_text(reason):
-                          errors.append("Non-release housekeeping master PRs must explain why no release tag is needed.")
+                          errors.append("Non-release housekeeping main PRs must explain why no release tag is needed.")
 
                   if is_release:
+                      if head != "develop":
+                          errors.append("Release-worthy PRs targeting main must originate from develop.")
+
                       planned_version = subsection_text(release, "Planned version")
                       version_match = re.search(r"\bv\d+\.\d+\.\d+\b", planned_version)
                       if not version_match:
-                          errors.append("Release-worthy master PRs must declare a planned SemVer tag like `v0.4.0`.")
+                          errors.append("Release-worthy main PRs must declare a planned SemVer tag like `v0.4.0`.")
                       else:
                           version = version_match.group(0)
                           tag_url = f"https://api.github.com/repos/{repo}/git/ref/tags/{version}"
@@ -115,7 +120,7 @@ jobs:
 
                       release_classification = subsection_text(release, "Release classification")
                       if not re.search(r"\b(patch|minor|major)\b", release_classification):
-                          errors.append("Release-worthy master PRs must classify the version bump as patch, minor, or major.")
+                          errors.append("Release-worthy main PRs must classify the version bump as patch, minor, or major.")
 
                       for heading in [
                           "What changed",
@@ -127,8 +132,10 @@ jobs:
                           if not has_bullet_text(content):
                               errors.append(f"Release notes must include at least one bullet for '{heading}'.")
 
-                      if not has_checked_item(release, "Create and push an annotated SemVer tag after merge to `master`."):
-                          errors.append("Release-worthy master PRs must confirm the post-merge annotated tag plan.")
+                      if not has_checked_item(release, "Create and push an annotated SemVer tag after merge to `main`."):
+                          errors.append("Release-worthy main PRs must confirm the post-merge annotated tag plan.")
+                      if not has_checked_item(release, "Sync the resulting `main` merge commit back into `develop`."):
+                          errors.append("Release-worthy main PRs must confirm the post-merge main-to-develop sync-back plan.")
 
           if errors:
               print("PR policy failed:")

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   pull_request:
-    branches: [develop, master]
+    branches: [develop, main]
   push:
-    branches: [develop, master]
+    branches: [develop, main]
 
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,11 +36,15 @@ Repository skills in `.agents/skills` are Lineage guardrails, not generic engine
 
 ## Branch Policy
 
-- `master` is the stable branch.
-- `develop` is the active development branch.
-- Feature and fix branches should target `develop`.
-- Changes reach `master` only after they have been reviewed and are ready for a stable release point.
-- Protected branches should require tests to pass and owner approval before merge.
+- `main` is the stable release branch.
+- `develop` is the active integration branch and default PR target.
+- Feature and fix branches target `develop`.
+- Stable releases are promoted through a pull request from `develop` to `main`.
+- Release promotions use a merge commit rather than squash merging.
+- After a release promotion lands, `main` is synchronized back into `develop`
+  before normal development continues.
+- Hotfixes that land on `main` must also be synchronized back into `develop`.
+- Protected branches require tests and the configured review policy before merge.
 
 ## Lean Planning
 

--- a/docs/branch-policy.md
+++ b/docs/branch-policy.md
@@ -2,8 +2,18 @@
 
 Lineage uses two protected long-lived branches:
 
-- `master`: stable branch.
-- `develop`: active development branch and default PR target.
+- `main`: stable release branch.
+- `develop`: active integration branch and default PR target.
+
+```text
+feature/* --PR--> develop
+                    |
+                    | release PR
+                    v
+                  main
+                    |
+                    +-- sync back --> develop
+```
 
 ## Required Flow
 
@@ -14,11 +24,22 @@ Lineage uses two protected long-lived branches:
 5. Link the assigned issue in the PR.
 6. Wait for tests and owner review before merge.
 
+Feature and fix PRs target `develop`. Squash merging is allowed for these PRs
+when it keeps the history readable.
+
+Stable promotions are PRs from `develop` to `main`. They must use a merge commit,
+not squash merge or rebase, so the release commit can be synchronized back into
+`develop` and preserved in branch ancestry.
+
+Hotfix PRs may target `main` only when the stable branch needs an immediate fix.
+After a hotfix lands, synchronize `main` back into `develop` before normal
+development continues.
+
 PRs without a linked assigned issue should not be reviewed except for maintainer-only housekeeping.
 
 ## Recommended GitHub Protection
 
-Apply these protections to both `master` and `develop`:
+Apply these protections to both `main` and `develop`:
 
 - Require a pull request before merging.
 - Require at least one approving review.
@@ -31,11 +52,16 @@ Apply these protections to both `master` and `develop`:
 - Restrict deletions.
 - Require conversation resolution before merging.
 
-The test workflow runs for pull requests targeting `develop` and pushes to `develop` or `master`.
+The test workflow runs for pull requests targeting `develop` or `main` and
+pushes to `develop` or `main`.
 
-Release tags should point at commits that are already on `master`. See
+Release tags should point at commits that are already on `main`. See
 [Release And Versioning Policy](release-versioning.md) for the tagging,
 release-note, and stable-promotion rules.
+
+Every commit introduced into `main` must eventually become an ancestor of
+`develop`. After every release or hotfix, verify that `main` has zero unique
+commits missing from `develop`.
 
 ## Planning Model
 

--- a/docs/release-versioning.md
+++ b/docs/release-versioning.md
@@ -6,11 +6,11 @@ Lineage's own release tags.
 
 ## Stable Branch
 
-`master` is the stable public baseline. A commit promoted to `master` should be
+`main` is the stable public baseline. A commit promoted to `main` should be
 something a user can install, run, and cite in a bug report.
 
 Development happens on `develop`. Feature and fix work should merge to
-`develop` first, then `develop` is promoted to `master` when the current stable
+`develop` first, then `develop` is promoted to `main` when the current stable
 goal is coherent enough to release.
 
 ## Version Scheme
@@ -38,7 +38,7 @@ package, inspect it, enable it, and run it through a local provider workflow.
 
 ## Tagging
 
-Every meaningful stable promotion to `master` should have an annotated tag:
+Every meaningful stable promotion to `main` should have an annotated tag:
 
 ```bash
 git tag -a v0.x.y -m "Lineage v0.x.y"
@@ -52,6 +52,22 @@ publishes the GitHub Release.
 Release automation may later build artifacts from tags, publish checksums, and
 draft GitHub release notes, but automation should not choose the version number
 or decide that a milestone is complete.
+
+## Release Flow
+
+Stable releases follow this sequence:
+
+```text
+develop -> main release PR
+        -> merge commit
+        -> tag merged main commit
+        -> publish GitHub Release and artifacts
+        -> sync main back into develop
+```
+
+Do not squash-merge or rebase a release promotion. The merge commit on `main`
+is part of the release record and must become an ancestor of `develop` during
+the sync-back step.
 
 ## Release Roles
 
@@ -78,22 +94,25 @@ release scope.
 
 ## Required Checks
 
-Before promoting to `master` or tagging a release:
+Before promoting to `main` or tagging a release:
 
 - All release-scope issues are closed or explicitly deferred.
-- The PR from `develop` to `master` passes the `Go` test workflow and release
+- The PR from `develop` to `main` passes the `Go` test workflow and release
   tracking check.
 - The PR declares the planned SemVer tag, release classification, release notes,
   and post-merge annotated tag plan.
+- The release promotion uses a merge commit rather than squash merge or rebase.
 - Branch protection requires review, passing status checks, conversation
   resolution, and no force pushes or branch deletion.
 - The release notes identify any skipped automated tests or manual validation.
+- After the release PR lands, synchronize `main` back into `develop` and verify
+  that `main` has zero commits not represented in `develop`.
 
-Release tags should point at commits that are already on `master`.
+Release tags should point at commits that are already on `main`.
 
 ## Non-Release Housekeeping
 
-A PR to `master` may skip release tagging only when it is explicitly marked as
+A PR to `main` may skip release tagging only when it is explicitly marked as
 non-release housekeeping and explains why no user-facing release is needed.
 Examples include release-doc typo fixes, workflow metadata cleanup, or
 administrative repository maintenance.


### PR DESCRIPTION
## Summary

Maintainer housekeeping: align repository release infrastructure around `main` as the release branch and `develop` as the integration branch.

- Replace stale `master` references in CI, contribution guidance, release docs, and the PR template.
- Require release-worthy PRs targeting `main` to originate from `develop`.
- Document merge-commit release promotions and the required `main -> develop` sync-back.

## Linked Issue

This is explicit maintainer housekeeping; no product issue is closed.

## Package Impact

- [x] Documentation only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- No production behavior changed; this PR changes CI policy, templates, and documentation only.

```text
git diff --check
go test ./...
go vet ./...
```

If this PR does not need automated tests, explain why:

- The change adds no runtime code or testable package behavior. Repository CI should still run the full Go test matrix.

## Notes For Reviewers

Please review the policy wording carefully: release-worthy `main` promotions must be `develop -> main` merge commits, followed by a `main -> develop` sync-back.