### PR TITLE
docs: prepare v1.1.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to Lineage will be documented here.
 
 ## Unreleased
 
+## [1.1.1] - 2026-09-01
+
+### Fixed
+
+- Preserve executable file modes when packages are exported and imported.
+- Reject an explicit package schema version of zero instead of treating it as
+  an implicit default.
+- Normalize package references consistently when disabling from a subdirectory.
+- Restore restrictive permissions on the stored registry-auth token.
+- Add a timeout to registry pull requests so an unavailable registry does not
+  leave the CLI waiting indefinitely.
+- Normalize an empty enabled-package list when loading project configuration.
+- Require confirmation before publishing a package, with an explicit `--yes`
+  escape hatch for automation.
+- Extend secret scanning to detect ASIA-prefixed AWS credentials, GitHub
+  fine-grained personal access tokens, and Google API keys.
+
+### Documentation and verification
+
+- Add the canonical safety model, including current limits around PII and
+  instruction-risk detection, rollback pinning, and planned yank semantics.
+- Document `.lineage` container versioning and the accepted concurrent-write
+  limitation.
+- Run the Go test matrix on Windows and add receiver-flow coverage for
+  materialization and provider path behavior.
+- Establish `main` as the stable release branch, with release promotions from
+  `develop` and mandatory sync-back after stable releases or hotfixes.
+
+## Historical entries
+
+The entries below predate structured per-version headings. They remain as a
+record of earlier Lineage work and are not all part of v1.1.1.
+
 - Initial local agent package runtime scaffold.
 - Refreshed public-facing documentation for the current registry, `lineage add`,
   workflow, inspect/list/doctor, and bootstrap-prompt surfaces; added a public


### PR DESCRIPTION
## Summary

Prepare the frozen `v1.1.1` changelog entry on `develop` before the direct release promotion to `main`.

## Linked Issue

This is explicit maintainer housekeeping for release preparation; no product issue is closed.

## Verification

Relevant test cases:

- No production behavior changed; this PR adds the scoped release notes only.

```text
git diff --check
go test ./...
go vet ./...
```

If this PR does not need automated tests, explain why:

- The change affects documentation only. The repository CI matrix remains the merge gate.

## Notes For Reviewers

After this PR lands, the release promotion must be opened directly from `develop` to `main`; do not promote this branch directly.