### PR TITLE
ci: add stable Go required check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,3 +44,16 @@ jobs:
         with:
           name: coverage-${{ matrix.os }}
           path: coverage.out
+
+  # Keep a stable check name for branch protection while preserving the
+  # per-platform matrix results above for diagnostics.
+  go-required:
+    name: Go
+    needs: go
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all Go matrix jobs to pass
+        env:
+          MATRIX_RESULT: ${{ needs.go.result }}
+        run: test "$MATRIX_RESULT" = "success"


### PR DESCRIPTION
## Summary

maintainer housekeeping

Add a stable aggregate `Go` status check for branch protection. It succeeds only after the existing Linux and Windows Go test matrix succeeds, while retaining the individual platform checks for diagnostics.

## Linked Issue

No product issue is closed; this is release-gate infrastructure maintenance.

## Verification

Relevant test cases:

- The aggregate job consumes the existing cross-platform Go matrix result and fails unless that matrix succeeds.

```text
git diff --check
go test ./...
go vet ./...
```

If this PR does not need automated tests, explain why:

- CI configuration only; the pull request itself runs the updated workflow and verifies the aggregate status.

## Notes for reviewers

This preserves the existing required-test intent while restoring the exact check name (`Go`) expected by the protected `main` branch.