### PR TITLE
docs: finalize v1.1.1 changelog scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@ All notable changes to Lineage will be documented here.
 
 ## Unreleased
 
-- Reject explicit schema zero in project configuration and materialization
-  state while preserving the legacy default for files with no schema field.
-
 ## [1.1.1] - 2026-09-01
 
 ### Added
@@ -17,6 +14,8 @@ All notable changes to Lineage will be documented here.
 
 ### Fixed
 
+- Reject explicit schema zero in project configuration and materialization
+  state while preserving the legacy default for files with no schema field.
 - Preserve executable file modes when packages are exported and imported.
 - Reject an explicit package schema version of zero instead of treating it as
   an implicit default.


### PR DESCRIPTION
## Summary

maintainer housekeeping

Finalize the frozen v1.1.1 changelog after #234: move the merged explicit-schema-zero validation fix from Unreleased into the patch release’s Fixed section.

## Linked Issue

No product issue is closed; this is release-note reconciliation.

## Verification

Relevant test cases:

- The underlying schema regression tests are included in #234 and passed in its Ubuntu and Windows CI matrix.

```text
git diff --check
go test ./...
go vet ./...
```

If this PR does not need automated tests, explain why:

- This changes release-note placement only; the product fix and its automated regression coverage are already merged.

## Notes for reviewers

No behavior changes. This ensures the shipped v1.1.1 changelog exactly matches the frozen develop-to-main release scope.