### PR TITLE
chore: clarify PR merge policy and template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,14 @@
 ## Summary
 
-What changed, and why?
+Briefly explain what changed and why this PR is needed.
 
 ## Linked Issue
 
-Closes #
+Closes #123
+
+For maintainer-only housekeeping with no issue, write:
+
+Maintainer housekeeping: <reason>
 
 - [ ] The linked issue is assigned to me.
 - [ ] This PR targets `develop`, or it is a release-tracked promotion into `main`.
@@ -19,6 +23,12 @@ Closes #
 - [ ] Documentation only
 - [ ] Tests only
 
+## Merge Method
+
+- [ ] Squash merge for an ordinary PR into `develop`.
+- [ ] Merge commit for a release promotion into `main`.
+- [ ] Merge commit for a `main` to `develop` sync-back.
+
 ## Safety
 
 - [ ] This change does not export secrets, credentials, private prompts, or machine-local state.
@@ -32,7 +42,7 @@ List the relevant test cases added or updated, then paste the commands or checks
 
 Relevant test cases:
 
-- 
+- None yet.
 
 ```text
 go test ./...
@@ -40,7 +50,7 @@ go test ./...
 
 If this PR does not need automated tests, explain why:
 
-- 
+- Automated tests apply unless this is documentation-only or maintainer housekeeping.
 
 ## Release Tracking
 
@@ -83,7 +93,7 @@ Post-merge tag plan:
 
 Non-release housekeeping reason:
 
--
+- Not applicable.
 
 ## Notes For Reviewers
 

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -47,14 +47,22 @@ jobs:
               body,
           )
           tests_text = relevant_tests.group(1).strip() if relevant_tests else ""
-          has_test_case = bool(re.search(r"(?m)^-\s+\S+", tests_text))
 
           no_test_reason = re.search(
               r"(?is)If this PR does not need automated tests, explain why:\s*(.+?)(?:## Release Tracking|## Notes For Reviewers|\Z)",
               body,
           )
           reason_text = no_test_reason.group(1).strip() if no_test_reason else ""
-          has_no_test_reason = bool(re.search(r"(?m)^-\s+\S+", reason_text))
+
+          def meaningful_bullet_text(text):
+              for match in re.finditer(r"(?m)^-\s+(.+?)\s*$", text):
+                  value = match.group(1).strip().lower().rstrip(".")
+                  if value and value not in {"none", "none yet", "n/a", "not applicable", "tbd"}:
+                      return True
+              return False
+
+          has_test_case = meaningful_bullet_text(tests_text)
+          has_no_test_reason = meaningful_bullet_text(reason_text)
 
           command_block = re.search(r"(?is)```text\s*(.+?)```", body)
           commands = command_block.group(1).strip() if command_block else ""
@@ -81,6 +89,26 @@ jobs:
 
           def has_bullet_text(text):
               return bool(re.search(r"(?m)^-\s+\S+", text))
+
+          merge_method = section_text("Merge Method")
+          if not merge_method:
+              errors.append("PR must include a Merge Method section.")
+          else:
+              ordinary_squash = has_checked_item(merge_method, "Squash merge for an ordinary PR into `develop`.")
+              release_merge = has_checked_item(merge_method, "Merge commit for a release promotion into `main`.")
+              sync_merge = has_checked_item(merge_method, "Merge commit for a `main` to `develop` sync-back.")
+              checked_merge_methods = sum([ordinary_squash, release_merge, sync_merge])
+
+              if checked_merge_methods != 1:
+                  errors.append("PR must check exactly one Merge Method option.")
+              elif base == "develop":
+                  if head == "chore/sync-main-into-develop":
+                      if not sync_merge:
+                          errors.append("main-to-develop sync PRs must choose the merge-commit sync-back option.")
+                  elif not ordinary_squash:
+                      errors.append("Ordinary PRs targeting develop must choose squash merge.")
+              elif base == "main" and not release_merge:
+                  errors.append("PRs targeting main must choose the release-promotion merge commit option.")
 
           if base == "main":
               release = section_text("Release Tracking")

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -1,0 +1,152 @@
+name: Sync Main To Develop
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Open sync PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Open or update sync PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SYNC_BRANCH: chore/sync-main-into-develop
+        run: |
+          set -euo pipefail
+
+          git fetch origin main develop
+
+          if git merge-base --is-ancestor origin/main origin/develop; then
+            echo "develop already contains main; no sync PR needed."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "$SYNC_BRANCH" origin/main
+          git push --force-with-lease origin "$SYNC_BRANCH"
+
+          title="chore: sync main back into develop"
+          body="$(cat <<'BODY'
+          ## Summary
+
+          Maintainer housekeeping: synchronize `main` back into `develop` after a stable-branch update.
+
+          This PR carries the current `main` history back to `develop` so future work includes the exact stable release or hotfix boundary. It is opened by automation, but still relies on normal branch protection, required checks, and human review.
+
+          ## Linked Issue
+
+          Maintainer housekeeping: automated stable-branch sync-back.
+
+          ## Package Impact
+
+          - [x] Documentation only
+
+          ## Merge Method
+
+          - [ ] Squash merge for an ordinary PR into `develop`.
+          - [ ] Merge commit for a release promotion into `main`.
+          - [x] Merge commit for a `main` to `develop` sync-back.
+
+          ## Safety
+
+          - [x] This change does not export secrets, credentials, private prompts, or machine-local state.
+          - [x] Package inputs are treated as untrusted.
+          - [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
+          - [x] Provider-specific logic stays behind an explicit boundary.
+
+          ## Verification
+
+          Relevant test cases:
+
+          - Main-to-develop ancestry check before opening this PR.
+
+          ```text
+          go test ./...
+          ```
+
+          If this PR does not need automated tests, explain why:
+
+          - This PR may contain zero file changes when it preserves a release merge commit in branch history; required checks still run before merge.
+
+          ## Release Tracking
+
+          Complete this section only for PRs targeting `main`.
+
+          - [ ] Release-worthy main promotion
+          - [ ] Non-release housekeeping
+
+          Planned version:
+
+          `v0.0.0`
+
+          Release classification:
+
+          `patch | minor | major`
+
+          Release notes:
+
+          What changed:
+
+          - Not applicable.
+
+          What is experimental:
+
+          - Not applicable.
+
+          What is outside scope:
+
+          - Not applicable.
+
+          Safety and compatibility notes:
+
+          - Not applicable.
+
+          Post-merge tag plan:
+
+          - [ ] Create and push an annotated SemVer tag after merge to `main`.
+          - [ ] Publish the matching GitHub Release and artifacts.
+          - [ ] Sync the resulting `main` merge commit back into `develop`.
+
+          Non-release housekeeping reason:
+
+          - Not applicable.
+
+          ## Notes For Reviewers
+
+          Use a merge commit for this PR so `main` remains an ancestor of `develop`.
+          BODY
+          )"
+
+          existing="$(gh pr list \
+            --repo "$REPO" \
+            --base develop \
+            --head "$SYNC_BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')"
+
+          if [ -n "$existing" ]; then
+            gh pr edit "$existing" --repo "$REPO" --title "$title" --body "$body"
+          else
+            gh pr create \
+              --repo "$REPO" \
+              --base develop \
+              --head "$SYNC_BRANCH" \
+              --title "$title" \
+              --body "$body"
+          fi

--- a/docs/branch-policy.md
+++ b/docs/branch-policy.md
@@ -24,18 +24,36 @@ feature/* --PR--> develop
 5. Link the assigned issue in the PR.
 6. Wait for tests and owner review before merge.
 
-Feature and fix PRs target `develop`. Squash merging is allowed for these PRs
-when it keeps the history readable.
+Feature, fix, documentation, and test PRs target `develop`. Squash merge is the
+standard for these PRs: one reviewed PR should land as one meaningful commit on
+`develop`, even when the branch itself contains exploratory or agent-generated
+iteration commits.
 
 Stable promotions are PRs from `develop` to `main`. They must use a merge commit,
 not squash merge or rebase, so the release commit can be synchronized back into
 `develop` and preserved in branch ancestry.
+
+Sync-back PRs from `main` to `develop` must also use a merge commit, not squash
+merge or rebase. Their purpose is to preserve the exact stable release commit in
+`develop` history.
 
 Hotfix PRs may target `main` only when the stable branch needs an immediate fix.
 After a hotfix lands, synchronize `main` back into `develop` before normal
 development continues.
 
 PRs without a linked assigned issue should not be reviewed except for maintainer-only housekeeping.
+
+## Merge Method
+
+- Use **squash merge** for ordinary PRs into `develop`.
+- Use **merge commit** for release promotions from `develop` into `main`.
+- Use **merge commit** for `main` to `develop` sync-back PRs.
+- Do not use rebase merge for protected branches.
+
+GitHub repository settings should keep squash merge enabled. Merge commits may
+remain enabled only because release promotions and sync-back PRs need preserved
+branch ancestry. Reviewers should check the PR template's merge-method section
+before approval, and maintainers should choose the matching merge button.
 
 ## Recommended GitHub Protection
 
@@ -62,6 +80,10 @@ release-note, and stable-promotion rules.
 Every commit introduced into `main` must eventually become an ancestor of
 `develop`. After every release or hotfix, verify that `main` has zero unique
 commits missing from `develop`.
+
+An automated workflow opens or updates a dedicated `main` to `develop` sync PR
+after pushes to `main`. It does not push directly to `develop`; branch protection,
+required checks, and human review still apply.
 
 ## Planning Model
 


### PR DESCRIPTION
## Summary

Maintainer housekeeping: make squash merge the standard for ordinary PRs while preserving merge commits for release promotions and `main` to `develop` sync-backs.

This also updates the PR template to avoid blank-placeholder policy failures and adds an automated sync workflow that opens or updates a protected-branch PR after pushes to `main`.

## Linked Issue

Maintainer housekeeping: repository policy and release-process hardening.

- [ ] The linked issue is assigned to me.
- [x] This PR targets `develop`, or it is a release-tracked promotion into `main`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [x] Documentation only
- [x] Tests only

## Merge Method

- [x] Squash merge for an ordinary PR into `develop`.
- [ ] Merge commit for a release promotion into `main`.
- [ ] Merge commit for a `main` to `develop` sync-back.

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- PR policy simulation for ordinary PRs into `develop`.
- PR policy simulation for release promotions into `main`.
- PR policy simulation for `main` to `develop` sync-back PRs.
- YAML parse check for all workflows.
- Shell syntax check for the sync workflow body.

```text
git diff --check
python3 -c "import yaml, pathlib; [yaml.safe_load(pathlib.Path(p).read_text()) for p in ['.github/workflows/pr-policy.yml','.github/workflows/test.yml','.github/workflows/sync-main-to-develop.yml']]; print('workflow YAML parsed')"
python3 <local PR policy simulations>
python3 <local sync workflow bash -n check>
go test ./...
```

If this PR does not need automated tests, explain why:

- Automated and policy checks apply; the Go suite was run for repository safety even though this change is workflow/template/documentation focused.

## Release Tracking

Complete this section only for PRs targeting `main`.

- [ ] Release-worthy main promotion
- [ ] Non-release housekeeping

Planned version:

`v0.0.0`

Release classification:

`patch | minor | major`

Release notes:

What changed:

- Not applicable.

What is experimental:

- Not applicable.

What is outside scope:

- Not applicable.

Safety and compatibility notes:

- Not applicable.

Post-merge tag plan:

- [ ] Create and push an annotated SemVer tag after merge to `main`.
- [ ] Publish the matching GitHub Release and artifacts.
- [ ] Sync the resulting `main` merge commit back into `develop`.

Non-release housekeeping reason:

- Not applicable.

## Notes For Reviewers

This PR documents squash as the standard without disabling merge commits entirely, because release promotion and sync-back PRs need preserved ancestry.