### PR TITLE
docs: clarify maintainer issue triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,6 +8,8 @@ body:
       value: |
         Thanks for helping make Lineage more reliable. Please do not include secrets, private prompts, customer data, or API keys.
 
+        Maintainers set priority, readiness, blockers, and milestones during triage.
+
         Before opening a PR for this issue, assign the issue to yourself. PRs should link an assigned issue.
   - type: textarea
     id: summary

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,6 +8,8 @@ body:
       value: |
         Keep proposals focused on local agent package distribution. Please avoid including private workflow content.
 
+        Maintainers set priority, readiness, blockers, and milestones during triage.
+
         Before opening a PR for this issue, assign the issue to yourself. PRs should link an assigned issue.
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/package_safety.yml
+++ b/.github/ISSUE_TEMPLATE/package_safety.yml
@@ -1,12 +1,14 @@
 name: Package safety issue
 description: Report a problem with package contents, setup actions, or secret-safe sharing.
 title: "[Safety]: "
-labels: ["safety", "needs-triage"]
+labels: ["security", "needs-triage"]
 body:
   - type: markdown
     attributes:
       value: |
         Use this for package validation, import/setup prompts, secret detection, file reconstruction, or provider boundary concerns.
+
+        Maintainers set priority, readiness, blockers, and milestones during triage.
 
         Before opening a PR for this issue, assign the issue to yourself. PRs should link an assigned issue.
   - type: textarea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,19 @@ Lineage uses goal-based milestones rather than date-based milestones. A mileston
 
 Keep labels minimal. Use labels for important signals like `bug`, `enhancement`, `documentation`, `security`, `critical`, or `needs:decision`; use milestones and the project board for planning.
 
+## Maintainer Triage
+
+New contributor issues should enter with `needs-triage`. Contributors do not set priority.
+
+When a maintainer assesses an issue, remove `needs-triage` and record planning state in the project board:
+
+- `Priority`: `P0` for release, security, or correctness blockers; `P1` for active near-term product direction; `P2` for accepted roadmap work that should not compete with P1; leave blank or backlog for valid work that is not sequenced.
+- `Readiness`: note whether the issue is ready, blocked, deferred, or still needs a maintainer decision.
+- `Dependencies/blockers`: link blocking issues or PRs directly in the issue body or comments.
+- `Milestone`: attach the issue to the relevant goal milestone when it belongs to a focused product goal.
+
+Use `good first issue` only for bounded, low-context, low-blast-radius work. Use `help wanted` only when the issue is ready for external contribution and is not already owned or blocked.
+
 ## Pull Requests
 
 Use the pull request template and include verification output. Every PR must link an assigned issue. PRs without a linked issue should not be reviewed except for maintainer-only housekeeping changes.

--- a/docs/lean-development.md
+++ b/docs/lean-development.md
@@ -52,6 +52,19 @@ Labels should stay minimal:
 
 Avoid creating many area labels. The milestone should explain the goal, and the project board should show workflow status.
 
+## Triage
+
+Maintainers own priority. Issue templates may add `needs-triage`, but contributors should not choose P0/P1/P2 themselves.
+
+After assessment, remove `needs-triage` and use the project board for:
+
+- `Priority`: `P0` release/security/correctness blocker, `P1` active near-term product direction, `P2` accepted roadmap work, or blank/backlog when valid but unsequenced.
+- `Readiness`: ready, blocked, deferred, or needs decision.
+- `Dependencies/blockers`: linked issues or PRs that must land first.
+- `Milestone`: the goal milestone the issue advances, when applicable.
+
+Keep P1 deliberately small so it reflects the work that should actually compete for maintainer attention.
+
 ## Pull Requests
 
 Every PR should:


### PR DESCRIPTION
## Summary

Clarifies the maintainer-owned issue triage convention without asking contributors to self-assign priority.

Changes:

- Document that new issues may enter with `needs-triage`, but maintainers own priority/readiness/blocker/milestone assessment.
- Define the P0/P1/P2/backlog priority semantics in contributor-facing maintainer docs.
- Tighten `good first issue` and `help wanted` usage expectations.
- Add a short maintainer-triage note to each issue template.
- Fix the package safety issue template to use the existing `security` label instead of the nonexistent `safety` label.

## Linked Issue

Closes #251

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`, or it is a release-tracked promotion into `main`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [ ] Package format or manifest behavior
- [ ] Package discovery or enablement
- [ ] Provider launch/shim behavior
- [ ] Setup or permission flow
- [x] Documentation only
- [ ] Tests only

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

List the relevant test cases added or updated, then paste the commands or checks you ran.

Relevant test cases:

- Documentation and issue-template only; no runtime test cases were added.

```text
go test ./...
git diff --check
```

If this PR does not need automated tests, explain why:

- The changed files are contributor docs and GitHub issue templates only; the normal Go suite was still run as a regression check.

## Merge Method

- [x] Squash merge for an ordinary PR into `develop`.
- [ ] Merge commit for a release promotion into `main`.
- [ ] Merge commit for a `main` to `develop` sync-back.

## Notes For Reviewers

This intentionally does not add a contributor-facing priority field. Priority should remain maintainer/project-board state so `needs-triage` has a clear lifecycle.