### PR TITLE
ci: use dedicated token for sync PR workflow

### DIFF
--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -6,8 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   sync:
@@ -18,14 +17,20 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Open or update sync PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.LINEAGE_SYNC_PR_TOKEN }}
           REPO: ${{ github.repository }}
           SYNC_BRANCH: chore/sync-main-into-develop
         run: |
           set -euo pipefail
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::Repository secret LINEAGE_SYNC_PR_TOKEN is required to push the sync branch and open/update the sync PR."
+            exit 1
+          fi
 
           git fetch origin main develop
 
@@ -38,7 +43,8 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git checkout -B "$SYNC_BRANCH" origin/main
-          git push --force-with-lease origin "$SYNC_BRANCH"
+          git -c "http.extraheader=AUTHORIZATION: bearer ${GH_TOKEN}" \
+            push --force-with-lease origin "$SYNC_BRANCH"
 
           title="chore: sync main back into develop"
           body="$(cat <<'BODY'

--- a/docs/branch-policy.md
+++ b/docs/branch-policy.md
@@ -83,7 +83,10 @@ commits missing from `develop`.
 
 An automated workflow opens or updates a dedicated `main` to `develop` sync PR
 after pushes to `main`. It does not push directly to `develop`; branch protection,
-required checks, and human review still apply.
+required checks, and human review still apply. The workflow uses the repository
+secret `LINEAGE_SYNC_PR_TOKEN` instead of broad write permissions on the built-in
+Actions token. Use a fine-grained token with access limited to this repository
+and the minimum permissions needed to write contents and pull requests.
 
 ## Planning Model
 


### PR DESCRIPTION
## Summary

Maintainer housekeeping: update the `main` to `develop` sync workflow to use a dedicated repository secret named `LINEAGE_SYNC_PR_TOKEN` instead of broad write permissions on the built-in Actions token.

This keeps the sync automation narrow: the workflow can push/update `chore/sync-main-into-develop` and create/update the sync PR using the dedicated credential, while the repository's default `GITHUB_TOKEN` can remain read-only.

## Linked Issue

Maintainer housekeeping: configure a least-privilege credential path for the sync PR automation.

- [ ] The linked issue is assigned to me.
- [x] This PR targets `develop`, or it is a release-tracked promotion into `main`.
- [x] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [x] Documentation only
- [x] Tests only

## Merge Method

- [x] Squash merge for an ordinary PR into `develop`.
- [ ] Merge commit for a release promotion into `main`.
- [ ] Merge commit for a `main` to `develop` sync-back.

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- Workflow YAML parse check.
- Sync workflow shell syntax check.
- Repository Go test suite.

```text
python3 -c "import yaml, pathlib; [yaml.safe_load(pathlib.Path(p).read_text()) for p in ['.github/workflows/pr-policy.yml','.github/workflows/test.yml','.github/workflows/sync-main-to-develop.yml']]; print('workflow YAML parsed')"
python3 <local sync workflow bash -n check>
go test ./...
```

If this PR does not need automated tests, explain why:

- Automated checks apply; this is workflow/documentation-only but the Go suite was run for repository safety.

## Release Tracking

Complete this section only for PRs targeting `main`.

- [ ] Release-worthy main promotion
- [ ] Non-release housekeeping

Planned version:

`v0.0.0`

Release classification:

`patch | minor | major`

Release notes:

What changed:

- Not applicable.

What is experimental:

- Not applicable.

What is outside scope:

- Not applicable.

Safety and compatibility notes:

- Not applicable.

Post-merge tag plan:

- [ ] Create and push an annotated SemVer tag after merge to `main`.
- [ ] Publish the matching GitHub Release and artifacts.
- [ ] Sync the resulting `main` merge commit back into `develop`.

Non-release housekeeping reason:

- Not applicable.

## Notes For Reviewers

Before relying on the automation, add repository secret `LINEAGE_SYNC_PR_TOKEN`. Use a fine-grained PAT limited to `agentic-lineage/lineage` with contents read/write and pull requests read/write. The workflow fails explicitly if the secret is missing.