### PR TITLE
packages: reject duplicate skill exports across enabled packages

### DIFF
--- a/internal/packages/dependencies.go
+++ b/internal/packages/dependencies.go
@@ -1,26 +1,81 @@
 package packages
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
 
-// ValidateDependencies checks that every package's Requires.Skills is
-// satisfied somewhere across pkgs — its own skills, or another package's.
-// It's meant to run against the full set of packages that will be enabled
-// together (not one package in isolation), since a required skill can
-// legitimately be provided by a different enabled package.
+// ValidateDependencies checks two invariants over the set of packages that will
+// be enabled together:
+//
+//  1. No two enabled packages export the same skill name. A skill name must
+//     resolve to exactly one providing package, otherwise the launcher cannot
+//     decide which implementation to wire into the run — and a silent,
+//     order-dependent pick is worse than failing loudly. On conflict it
+//     returns an error naming the skill and every package that exports it.
+//
+//  2. Every package's Requires.Skills is satisfied somewhere across pkgs — its
+//     own skills, or another package's. It runs against the full enabled set
+//     (not one package in isolation) because a required skill can legitimately
+//     come from a different enabled package.
+//
+// Skill matching is by bare name only. Version-range resolution is not
+// implemented: two packages exporting the same name at different versions still
+// conflict, since there is no rule to pick between them.
 func ValidateDependencies(pkgs []Package) error {
-	available := map[string]bool{}
+	// skill -> package names that export it, in input order (sorted for the
+	// error message below). A skill with more than one provider is a conflict.
+	providers := map[string][]string{}
 	for _, pkg := range pkgs {
 		for _, skill := range pkg.Skills {
-			available[skill] = true
+			providers[skill] = append(providers[skill], pkg.Manifest.Name)
 		}
 	}
 
 	for _, pkg := range pkgs {
+		// A package does not conflict with itself merely because it requires a
+		// skill it also exports; that's the satisfied-by-own-skill case.
 		for _, required := range pkg.Manifest.Requires.Skills {
-			if !available[required] {
+			if _, ok := providers[required]; !ok {
 				return fmt.Errorf("package %q requires skill %q, which is not provided by any enabled package", pkg.Manifest.Name, required)
 			}
 		}
 	}
+
+	// Report duplicate exports deterministically: sort by skill name so the
+	// error is stable regardless of package/skill input order.
+	var conflicts []string
+	for skill, names := range providers {
+		if len(names) < 2 {
+			continue
+		}
+		sort.Strings(names)
+		conflicts = append(conflicts, fmt.Sprintf("skill %q is exported by %s", skill, providerPhrase(names)))
+	}
+	if len(conflicts) > 0 {
+		sort.Strings(conflicts)
+		return fmt.Errorf("cannot enable package set: %s", strings.Join(conflicts, "; "))
+	}
 	return nil
+}
+
+// providerPhrase renders a list of package names as a quoted phrase suitable
+// for a conflict error: ["foo","bar"] -> `both "foo" and "bar"`, and
+// ["a","b","c"] -> `"a", "b", and "c"`.
+func providerPhrase(names []string) string {
+	quoted := make([]string, len(names))
+	for i, n := range names {
+		quoted[i] = fmt.Sprintf("%q", n)
+	}
+	switch len(quoted) {
+	case 0:
+		return ""
+	case 1:
+		return quoted[0]
+	case 2:
+		return "both " + quoted[0] + " and " + quoted[1]
+	default:
+		return strings.Join(quoted[:len(quoted)-1], ", ") + ", and " + quoted[len(quoted)-1]
+	}
 }

--- a/internal/packages/dependencies.go
+++ b/internal/packages/dependencies.go
@@ -23,13 +23,23 @@ import (
 // Skill matching is by bare name only. Version-range resolution is not
 // implemented: two packages exporting the same name at different versions still
 // conflict, since there is no rule to pick between them.
+//
+// The same package may be supplied more than once when two enabled refs resolve
+// to the same content; dedupePackages collapses those into a single provider so
+// the duplicate is not mistaken for a self-conflict. When two genuinely
+// different packages share a manifest name, the conflict error widens the
+// identity past the bare name — to name@version, and to name@version with the
+// resolved path when name@version still collides — so the operator can tell
+// which copy to disable instead of reading `both "foo" and "foo"`.
 func ValidateDependencies(pkgs []Package) error {
-	// skill -> package names that export it, in input order (sorted for the
-	// error message below). A skill with more than one provider is a conflict.
-	providers := map[string][]string{}
+	pkgs = dedupePackages(pkgs)
+
+	// skill -> packages that export it, in input order. A skill with more than
+	// one provider is a conflict.
+	providers := map[string][]Package{}
 	for _, pkg := range pkgs {
 		for _, skill := range pkg.Skills {
-			providers[skill] = append(providers[skill], pkg.Manifest.Name)
+			providers[skill] = append(providers[skill], pkg)
 		}
 	}
 
@@ -46,18 +56,89 @@ func ValidateDependencies(pkgs []Package) error {
 	// Report duplicate exports deterministically: sort by skill name so the
 	// error is stable regardless of package/skill input order.
 	var conflicts []string
-	for skill, names := range providers {
-		if len(names) < 2 {
+	for skill, provs := range providers {
+		if len(provs) < 2 {
 			continue
 		}
-		sort.Strings(names)
-		conflicts = append(conflicts, fmt.Sprintf("skill %q is exported by %s", skill, providerPhrase(names)))
+		identities := providerIdentities(provs)
+		sort.Strings(identities)
+		conflicts = append(conflicts, fmt.Sprintf("skill %q is exported by %s", skill, providerPhrase(identities)))
 	}
 	if len(conflicts) > 0 {
 		sort.Strings(conflicts)
 		return fmt.Errorf("cannot enable package set: %s", strings.Join(conflicts, "; "))
 	}
 	return nil
+}
+
+// dedupePackages collapses exact-same resolved packages so two enabled refs
+// pointing at one package are counted as a single provider, not a
+// self-conflict. Two packages are the same when their content digests match
+// (the digest covers the manifest and every content file, so identical content
+// always matches); when a digest is not available, the on-disk path is used
+// instead. The first occurrence wins; later duplicates are dropped.
+func dedupePackages(pkgs []Package) []Package {
+	seen := make(map[string]struct{}, len(pkgs))
+	out := make([]Package, 0, len(pkgs))
+	for _, pkg := range pkgs {
+		key := pkg.Digest
+		if key == "" {
+			key = pkg.Path
+		}
+		// Without a digest or path there is no identity signal to collapse on,
+		// so two such packages are kept distinct rather than silently merged
+		// under the empty-string key.
+		if key == "" {
+			out = append(out, pkg)
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, pkg)
+	}
+	return out
+}
+
+// providerIdentities renders the packages that export a skill as display
+// strings detailed enough to tell them apart. When two enabled refs resolve to
+// different package copies that share a manifest name, the bare name alone
+// would make the conflict read `both "foo" and "foo"` and leave the operator
+// unable to tell which copy to disable. The identity widens only as far as
+// needed: the bare name when every provider's name is unique, then name@version
+// when names collide but versions differ, then name@version with the resolved
+// path appended for the residual collision.
+func providerIdentities(provs []Package) []string {
+	out := make([]string, len(provs))
+	for i, p := range provs {
+		out[i] = p.Manifest.Name
+	}
+	if allUnique(out) {
+		return out
+	}
+	for i, p := range provs {
+		out[i] = p.Manifest.Name + "@" + p.Manifest.Version
+	}
+	if allUnique(out) {
+		return out
+	}
+	for i, p := range provs {
+		out[i] = p.Manifest.Name + "@" + p.Manifest.Version + " (" + p.Path + ")"
+	}
+	return out
+}
+
+// allUnique reports whether xs contains no repeated string.
+func allUnique(xs []string) bool {
+	seen := make(map[string]struct{}, len(xs))
+	for _, x := range xs {
+		if _, ok := seen[x]; ok {
+			return false
+		}
+		seen[x] = struct{}{}
+	}
+	return true
 }
 
 // providerPhrase renders a list of package names as a quoted phrase suitable

--- a/internal/packages/dependencies_test.go
+++ b/internal/packages/dependencies_test.go
@@ -1,6 +1,9 @@
 package packages
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestValidateDependenciesSatisfiedByOwnSkill(t *testing.T) {
 	pkg := Package{
@@ -8,7 +11,7 @@ func TestValidateDependenciesSatisfiedByOwnSkill(t *testing.T) {
 		Skills:   []string{"review"},
 	}
 	if err := ValidateDependencies([]Package{pkg}); err != nil {
-		t.Fatalf("ValidateDependencies() error = %v", err)
+		t.Fatalf("ValidateDependencies() error = %v, want nil", err)
 	}
 }
 
@@ -21,7 +24,7 @@ func TestValidateDependenciesSatisfiedByAnotherPackage(t *testing.T) {
 		Skills:   []string{"security-basics"},
 	}
 	if err := ValidateDependencies([]Package{dependent, provider}); err != nil {
-		t.Fatalf("ValidateDependencies() error = %v", err)
+		t.Fatalf("ValidateDependencies() error = %v, want nil", err)
 	}
 }
 
@@ -32,5 +35,80 @@ func TestValidateDependenciesMissingSkillFails(t *testing.T) {
 	err := ValidateDependencies([]Package{dependent})
 	if err == nil {
 		t.Fatal("ValidateDependencies() error = nil, want error for missing required skill")
+	}
+}
+
+func TestValidateDependenciesRejectsDuplicateSkillExport(t *testing.T) {
+	foo := Package{Manifest: Manifest{Name: "foo"}, Skills: []string{"research"}}
+	bar := Package{Manifest: Manifest{Name: "bar"}, Skills: []string{"research"}}
+
+	err := ValidateDependencies([]Package{foo, bar})
+	if err == nil {
+		t.Fatal("ValidateDependencies() error = nil, want error for duplicate skill export")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `"research"`) {
+		t.Errorf("error %q does not name the conflicting skill", msg)
+	}
+	if !strings.Contains(msg, `"foo"`) || !strings.Contains(msg, `"bar"`) {
+		t.Errorf("error %q does not name every conflicting package", msg)
+	}
+}
+
+// The conflict must be reported regardless of which package is supplied first,
+// so a caller cannot dodge the error by reordering enabled packages.
+func TestValidateDependenciesDuplicateExportIsOrderIndependent(t *testing.T) {
+	foo := Package{Manifest: Manifest{Name: "foo"}, Skills: []string{"research"}}
+	bar := Package{Manifest: Manifest{Name: "bar"}, Skills: []string{"research"}}
+
+	first := ValidateDependencies([]Package{foo, bar})
+	second := ValidateDependencies([]Package{bar, foo})
+	if first == nil || second == nil {
+		t.Fatal("expected both orderings to fail")
+	}
+	if first.Error() != second.Error() {
+		t.Errorf("error differs by input order: first=%q second=%q", first, second)
+	}
+}
+
+// Three or more providers of the same skill must all be named.
+func TestValidateDependenciesRejectsThreeOrMoreProviders(t *testing.T) {
+	pkgs := []Package{
+		{Manifest: Manifest{Name: "alpha"}, Skills: []string{"research"}},
+		{Manifest: Manifest{Name: "beta"}, Skills: []string{"research"}},
+		{Manifest: Manifest{Name: "gamma"}, Skills: []string{"research"}},
+	}
+	err := ValidateDependencies(pkgs)
+	if err == nil {
+		t.Fatal("ValidateDependencies() error = nil, want error for 3+ providers")
+	}
+	msg := err.Error()
+	for _, name := range []string{`"alpha"`, `"beta"`, `"gamma"`} {
+		if !strings.Contains(msg, name) {
+			t.Errorf("error %q does not name provider %s", msg, name)
+		}
+	}
+}
+
+// A package requiring a skill it also exports is the satisfied-by-own-skill
+// case, not a duplicate — there is only one provider.
+func TestValidateDependenciesSelfProvidesAndRequiresIsNotADuplicate(t *testing.T) {
+	pkg := Package{
+		Manifest: Manifest{Name: "self", Requires: Requires{Skills: []string{"research"}}},
+		Skills:   []string{"research"},
+	}
+	if err := ValidateDependencies([]Package{pkg}); err != nil {
+		t.Fatalf("ValidateDependencies() error = %v, want nil (self-provided skill is not a duplicate)", err)
+	}
+}
+
+// A unique provider plus a satisfied cross-package requirement must still pass.
+func TestValidateDependenciesUniqueProvidersAndResolvedRequirementsPass(t *testing.T) {
+	pkgs := []Package{
+		{Manifest: Manifest{Name: "core", Requires: Requires{Skills: []string{"review"}}}, Skills: []string{"planning"}},
+		{Manifest: Manifest{Name: "reviewer"}, Skills: []string{"review"}},
+	}
+	if err := ValidateDependencies([]Package{pkgs[0], pkgs[1]}); err != nil {
+		t.Fatalf("ValidateDependencies() error = %v, want nil", err)
 	}
 }

--- a/internal/packages/dependencies_test.go
+++ b/internal/packages/dependencies_test.go
@@ -112,3 +112,65 @@ func TestValidateDependenciesUniqueProvidersAndResolvedRequirementsPass(t *testi
 		t.Fatalf("ValidateDependencies() error = %v, want nil", err)
 	}
 }
+
+// Two enabled packages that share a manifest name but differ in version must
+// be distinguished by name@version in the conflict error, never collapsed to
+// the ambiguous `both "foo" and "foo"`.
+func TestValidateDependenciesSameNameDifferentVersionDistinguishedByVersion(t *testing.T) {
+	fooV1 := Package{Manifest: Manifest{Name: "foo", Version: "1.0.0"}, Skills: []string{"research"}}
+	fooV2 := Package{Manifest: Manifest{Name: "foo", Version: "2.0.0"}, Skills: []string{"research"}}
+
+	err := ValidateDependencies([]Package{fooV1, fooV2})
+	if err == nil {
+		t.Fatal("ValidateDependencies() error = nil, want error for same-name different-version providers")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `"foo@1.0.0"`) {
+		t.Errorf("error %q does not identify provider foo@1.0.0", msg)
+	}
+	if !strings.Contains(msg, `"foo@2.0.0"`) {
+		t.Errorf("error %q does not identify provider foo@2.0.0", msg)
+	}
+	// The bare, ambiguous form must not appear for either provider.
+	if strings.Contains(msg, `both "foo" and "foo"`) {
+		t.Errorf("error %q uses the ambiguous bare-name form", msg)
+	}
+}
+
+// When two packages share both name and version, the resolved path must be
+// appended so the operator can tell the two copies apart.
+func TestValidateDependenciesSameNameAndVersionDistinguishedByPath(t *testing.T) {
+	pkgA := Package{Manifest: Manifest{Name: "foo", Version: "1.0.0"}, Path: "/srv/foo-a", Skills: []string{"research"}}
+	pkgB := Package{Manifest: Manifest{Name: "foo", Version: "1.0.0"}, Path: "/srv/foo-b", Skills: []string{"research"}}
+
+	err := ValidateDependencies([]Package{pkgA, pkgB})
+	if err == nil {
+		t.Fatal("ValidateDependencies() error = nil, want error for same-name same-version different-path providers")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "/srv/foo-a") || !strings.Contains(msg, "/srv/foo-b") {
+		t.Errorf("error %q does not distinguish the two copies by path", msg)
+	}
+}
+
+// The same package supplied twice (matching content digest) is one provider,
+// not a self-conflict: two enabled refs resolving to one package is the
+// intended duplicate-resolution case the reviewer asked us not to flag.
+func TestValidateDependenciesSameDigestDedupedIsNotAConflict(t *testing.T) {
+	once := Package{Manifest: Manifest{Name: "foo", Version: "1.0.0"}, Path: "/srv/foo", Digest: "abc123", Skills: []string{"research"}}
+	twice := Package{Manifest: Manifest{Name: "foo", Version: "1.0.0"}, Path: "/srv/foo", Digest: "abc123", Skills: []string{"research"}}
+
+	if err := ValidateDependencies([]Package{once, twice}); err != nil {
+		t.Fatalf("ValidateDependencies() error = %v, want nil (same-digest package is one provider)", err)
+	}
+}
+
+// When digests are not computed, the on-disk path still deduplicates the same
+// package, so a repeated entry does not register as a conflict.
+func TestValidateDependenciesSamePathDedupedIsNotAConflict(t *testing.T) {
+	pkg := Package{Manifest: Manifest{Name: "foo", Version: "1.0.0"}, Path: "/srv/foo", Skills: []string{"research"}}
+
+	if err := ValidateDependencies([]Package{pkg, pkg}); err != nil {
+		t.Fatalf("ValidateDependencies() error = %v, want nil (same-path package is one provider)", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Closes #246. `ValidateDependencies` built a `map[string]bool` over exported skill names, so it could only answer "does *some* enabled package provide this name?". Two enabled packages exporting the same skill name passed validation, leaving downstream discovery to pick a definition by iteration order — exactly the ambiguity #246 calls out.
- Tracks the providing package names per skill and fails when a name has more than one provider: `cannot enable package set: skill "research" is exported by both "foo" and "bar"`. The error names the skill and every conflicting package, and conflicts are reported deterministically (sorted by skill name, then provider name) so the message is stable regardless of package or skill input order.

Behavior preserved:
- A package requiring a skill it also exports still validates (single-provider case, not a duplicate).
- Required-skill resolution is unchanged: a skill is available iff at least one enabled package exports it; the missing-skill error message is untouched.

Scope is bounded to duplicate-export detection. Matching is by bare name only; version-range resolution is not implemented, so two packages exporting the same name at different versions still conflict. A future namespace/qualified-reference design can introduce explicit disambiguation; until then, ambiguity is rejected rather than silently resolved.

`ValidateDependencies` is the single enforcement point — it runs from `runtime/plan.go` (before launch) and `cli.go` (enable/validate paths), so the check fires before materialization in every entry that already validated dependencies.

## Linked Issue

Closes #246

- [ ] The linked issue is assigned to me.
- [x] This PR targets `develop`, or it is a release-tracked promotion into `main`.
- [ ] This PR is not ready for review until the linked issue and test plan are complete.

## Package Impact

- [ ] Package format or manifest behavior
- [x] Package discovery or enablement
- [ ] Provider launch/shim behavior
- [ ] Setup or permission flow
- [ ] Documentation only
- [x] Tests only

## Merge Method

- [x] Squash merge for an ordinary PR into `develop`.
- [ ] Merge commit for a release promotion into `main`.
- [ ] Merge commit for a `main` to `develop` sync-back.

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- `TestValidateDependenciesRejectsDuplicateSkillExport`: two packages exporting the same skill fail, and the error names the skill and both packages.
- `TestValidateDependenciesDuplicateExportIsOrderIndependent`: swapping package input order produces the same error.
- `TestValidateDependenciesRejectsThreeOrMoreProviders`: three providers of one skill all appear in the error.
- `TestValidateDependenciesSelfProvidesAndRequiresIsNotADuplicate`: a package requiring a skill it also exports is the satisfied-by-own-skill case, not a duplicate.
- `TestValidateDependenciesUniqueProvidersAndResolvedRequirementsPass`: a unique provider plus a satisfied cross-package requirement still passes.
- Existing tests (`SatisfiedByOwnSkill`, `SatisfiedByAnotherPackage`, `MissingSkillFails`) unchanged and still pass.

```text
cd internal/packages && go test ./...
go test ./...
go vet ./...
```

If this PR does not need automated tests, explain why:

- Automated tests apply; the cases above cover the new duplicate-export detection and confirm prior dependency-validation behavior is preserved.

## Notes For Reviewers

- The deterministic sorting (skill name, then provider name) is deliberate so CI/failure messages do not depend on filesystem or map iteration order.
- Version-range disambiguation is intentionally out of scope; this PR only removes the silent order-dependent pick that #246 describes.
