### PR TITLE
chore: promote sync workflow credential fix to main

### DIFF
--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -6,8 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   sync:
@@ -18,14 +17,20 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Open or update sync PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.LINEAGE_SYNC_PR_TOKEN }}
           REPO: ${{ github.repository }}
           SYNC_BRANCH: chore/sync-main-into-develop
         run: |
           set -euo pipefail
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::Repository secret LINEAGE_SYNC_PR_TOKEN is required to push the sync branch and open/update the sync PR."
+            exit 1
+          fi
 
           git fetch origin main develop
 
@@ -38,7 +43,8 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git checkout -B "$SYNC_BRANCH" origin/main
-          git push --force-with-lease origin "$SYNC_BRANCH"
+          git -c "http.extraheader=AUTHORIZATION: bearer ${GH_TOKEN}" \
+            push --force-with-lease origin "$SYNC_BRANCH"
 
           title="chore: sync main back into develop"
           body="$(cat <<'BODY'

--- a/docs/branch-policy.md
+++ b/docs/branch-policy.md
@@ -83,7 +83,10 @@ commits missing from `develop`.
 
 An automated workflow opens or updates a dedicated `main` to `develop` sync PR
 after pushes to `main`. It does not push directly to `develop`; branch protection,
-required checks, and human review still apply.
+required checks, and human review still apply. The workflow uses the repository
+secret `LINEAGE_SYNC_PR_TOKEN` instead of broad write permissions on the built-in
+Actions token. Use a fine-grained token with access limited to this repository
+and the minimum permissions needed to write contents and pull requests.
 
 ## Planning Model
 


### PR DESCRIPTION
## Summary

Maintainer housekeeping: promote the dedicated credential fix for the `main` to `develop` sync workflow.

This carries the `LINEAGE_SYNC_PR_TOKEN` workflow change from `develop` to `main`. The repository-scoped secret is configured, allowing the sync workflow to create or update its branch and pull request while the default `GITHUB_TOKEN` remains read-only.

## Linked Issue

Maintainer housekeeping following #253.

## Package Impact

- [x] Documentation only
- [x] Tests only

## Merge Method

- [ ] Squash merge for an ordinary PR into `develop`.
- [x] Merge commit for a release promotion into `main`.
- [ ] Merge commit for a `main` to `develop` sync-back.

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] The dedicated token is supplied only through the repository Actions secret `LINEAGE_SYNC_PR_TOKEN`.
- [x] The default `GITHUB_TOKEN` remains read-only.
- [x] The fine-grained PAT is restricted to this repository with Contents and Pull requests read/write.

## Verification

Relevant test cases:

- Existing workflow policy and supported Go matrix checks.

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- Automated checks apply to this workflow-only promotion.

## Release Tracking

- [ ] Release-worthy main promotion
- [x] Non-release housekeeping

Planned version:

`Not applicable`

Release classification:

`Not applicable`

Release notes:

- Not applicable; this changes repository automation only and does not change package or runtime behavior.

Post-merge plan:

- [ ] Let the genuine push to `main` exercise the repaired sync workflow.
- [ ] Verify it creates or updates the `main` to `develop` sync PR.
- [ ] Merge that sync PR with a merge commit so `main` is again an ancestor of `develop`.

Non-release housekeeping reason:

- Restores the supported protected-branch synchronization path without changing shipped behavior or requiring a SemVer tag.

## Notes For Reviewers

This promotion includes the focused squash commit from #253. Do not tag or publish a release for this PR. After merge, use the naturally triggered sync workflow as the one meaningful end-to-end verification.