### PR TITLE
ci: fix sync branch Git authentication

### DIFF
--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -43,8 +43,8 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git checkout -B "$SYNC_BRANCH" origin/main
-          git -c "http.extraheader=AUTHORIZATION: bearer ${GH_TOKEN}" \
-            push --force-with-lease origin "$SYNC_BRANCH"
+          gh auth setup-git
+          git push --force-with-lease origin "$SYNC_BRANCH"
 
           title="chore: sync main back into develop"
           body="$(cat <<'BODY'


### PR DESCRIPTION
## Summary

Fix the sync workflow's Git authentication after the genuine post-#255 run confirmed that the custom bearer extra-header was not accepted for the branch push.

The workflow now runs `gh auth setup-git` using the existing `GH_TOKEN` environment value, then performs the same force-with-lease push through Git's configured credential helper.

## Linked Issue

Maintainer housekeeping follow-up to #253 and the failed Sync Main To Develop run `33540008775`.

## Package Impact

- [x] Documentation only
- [x] Tests only

## Merge Method

- [x] Squash merge for an ordinary PR into `develop`.
- [ ] Merge commit for a release promotion into `main`.
- [ ] Merge commit for a `main` to `develop` sync-back.

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] The PAT remains sourced only from `LINEAGE_SYNC_PR_TOKEN`.
- [x] The token is not embedded in a remote URL or printed.
- [x] The branch update remains protected by `--force-with-lease`.

## Verification

Relevant test cases:

- Workflow YAML parsing.
- Shell syntax validation for the workflow run block.
- Existing repository Go test suite.

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- Automated checks apply; the actual end-to-end verification will occur on the next genuine push to `main`.

## Release Tracking

Complete this section only for PRs targeting `main`.

- [ ] Release-worthy main promotion
- [ ] Non-release housekeeping

Planned version:

`v0.0.0`

Release classification:

`patch | minor | major`

Release notes:

What changed:

- Not applicable.

What is experimental:

- Not applicable.

What is outside scope:

- Not applicable.

Safety and compatibility notes:

- Not applicable.

Post-merge tag plan:

- [ ] Create and push an annotated SemVer tag after merge to `main`.
- [ ] Publish the matching GitHub Release and artifacts.
- [ ] Sync the resulting `main` merge commit back into `develop`.

Non-release housekeeping reason:

- Not applicable.

## Notes For Reviewers

The failed run proves the secret exists and reaches the job. This change repairs only Git credential transport; GitHub CLI PR authentication already uses the same token.