### PR TITLE
chore: promote sync Git authentication fix to main

### DIFF
--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -43,8 +43,8 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git checkout -B "$SYNC_BRANCH" origin/main
-          git -c "http.extraheader=AUTHORIZATION: bearer ${GH_TOKEN}" \
-            push --force-with-lease origin "$SYNC_BRANCH"
+          gh auth setup-git
+          git push --force-with-lease origin "$SYNC_BRANCH"
 
           title="chore: sync main back into develop"
           body="$(cat <<'BODY'


### PR DESCRIPTION
## Summary

Maintainer housekeeping: promote the Git authentication correction for the `main` to `develop` sync workflow.

The genuine post-#255 workflow run confirmed that `LINEAGE_SYNC_PR_TOKEN` reached the job, but the custom bearer extra-header was not accepted for Git push authentication. This promotion carries the focused #256 fix: configure Git through `gh auth setup-git`, then push with the existing force-with-lease safeguard.

## Linked Issue

Maintainer housekeeping following #253, #255, and #256.

## Package Impact

- [x] Documentation only
- [x] Tests only

## Merge Method

- [ ] Squash merge for an ordinary PR into `develop`.
- [x] Merge commit for a release promotion into `main`.
- [ ] Merge commit for a `main` to `develop` sync-back.

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] The PAT remains sourced only from `LINEAGE_SYNC_PR_TOKEN`.
- [x] The token is not embedded in a remote URL or printed.
- [x] The default `GITHUB_TOKEN` remains read-only.
- [x] The sync branch update remains protected by `--force-with-lease`.

## Verification

Relevant test cases:

- Existing workflow policy and supported Go matrix checks.
- Prior end-to-end run confirmed secret injection and isolated the Git transport failure.

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- Automated checks apply; the next genuine push to `main` provides the end-to-end workflow verification.

## Release Tracking

- [ ] Release-worthy main promotion
- [x] Non-release housekeeping

Planned version:

`Not applicable`

Release classification:

`Not applicable`

Release notes:

- Not applicable; this changes repository automation only.

Post-merge plan:

- [ ] Let this genuine push to `main` exercise the corrected workflow.
- [ ] Verify the automation creates or updates the `main` to `develop` sync PR.
- [ ] Merge that PR with a merge commit.

Non-release housekeeping reason:

- Corrects repository-only Git authentication and does not change shipped package or runtime behavior.

## Notes For Reviewers

Merge with a merge commit. Do not tag or publish a release.