### PR TITLE
feat(packages): declare and validate MCP dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lineage
 
-Package and share Claude Code, Codex, Windsurf, Aider, and Cline workflow environments.
+Package and share Claude Code and Codex workflow environments.
 
 A reusable agent workflow usually depends on more than one prompt or skill:
 skills, workflow steps, agents, policies, references, setup files, declared
@@ -32,15 +32,12 @@ Use Lineage when you want to:
   deterministic `.tgz` archive.
 - Let receivers inspect package contents and declared capabilities before
   enabling the workflow locally.
-- Run the packaged workflow through Claude Code, Codex, Windsurf, Aider, or Cline
-  without rebuilding the environment by hand in each project.
+- Run the packaged workflow through Claude Code or Codex without rebuilding the
+  environment by hand in each project.
 
 Lineage is provider-adjacent, not provider-owned. It prepares local files for
 the agent provider the receiver already uses; it does not replace Claude Code,
-Codex, Windsurf, Aider, Cline, or the user's agent account. Windsurf and Cline
-support is project-scoped and config/materialization-only: their `lineage run`
-and workflow forms stage project files and exit without resolving or launching
-their native GUIs.
+Codex, or the user's agent account.
 
 ## Install
 
@@ -79,9 +76,6 @@ lineage package validate ./resume-workflow
 lineage enable ./resume-workflow
 lineage run claude --dry-run
 lineage run codex --dry-run
-lineage run windsurf --dry-run
-lineage run aider --dry-run
-lineage run cline --dry-run
 ```
 
 Publish it to the Lineage registry:
@@ -183,6 +177,37 @@ package/
 These folders are intentionally plain. A receiver should be able to open the
 package and see what it contains before enabling it.
 
+### MCP dependencies
+
+Packages can declare an MCP server requirement under `dependencies.mcp`. The
+declaration is inspectable before enablement; it contains connection metadata,
+not credentials. Remote MCP hosts must also be declared in `capabilities.network`.
+
+```yaml
+dependencies:
+  mcp:
+    - name: github
+      transport: stdio
+      command: npx
+      args: ["-y", "@modelcontextprotocol/server-github"]
+      auth: receiver
+    - name: docs
+      transport: streamable-http
+      url: https://mcp.example.com/mcp
+      auth: receiver
+capabilities:
+  network: [mcp.example.com]
+```
+
+Supported transports are `stdio`, `streamable-http`, and `sse`. Lineage does
+not accept tokens, passwords, headers, or environment values in this package
+surface; receivers configure authentication locally.
+
+The current Claude and Codex adapters do not yet materialize MCP configuration.
+`lineage run` therefore stops with a clear error rather than silently omitting
+a declared server; native configuration merging belongs in the follow-up adapter
+work.
+
 ## How Lineage Fits Claude, Codex, And Other Agents
 
 Lineage keeps provider-specific behavior behind adapter boundaries and previews
@@ -190,18 +215,12 @@ what it would materialize before writing.
 
 - `lineage run claude --dry-run` previews Claude materialization.
 - `lineage run codex --dry-run` previews Codex materialization.
-- `lineage run auggie --dry-run` previews Auggie materialization.
-- `lineage run cline --dry-run` previews Cline materialization.
-- `lineage run aider --dry-run` previews Aider materialization.
-- `lineage run windsurf --dry-run` previews Windsurf project materialization
-  without resolving a Windsurf binary.
-- `lineage workflow run <workflow-name> <claude|codex|auggie|windsurf|aider|cline> --dry-run`
-  narrows the plan to one exported workflow; Windsurf and Cline remain
-  materialization-only.
+- `lineage workflow run <workflow-name> <claude|codex> --dry-run` narrows the
+  launch plan to one exported workflow.
 
-The current adapters focus on Claude, Codex, Auggie, Windsurf, Aider, and
-Cline. The package shape stays plain so future adapters can use the same
-manifest, skills, workflows, agents, policies, references, and setup material.
+The current adapters focus on Claude and Codex. The package shape stays plain so
+future adapters can use the same manifest, skills, workflows, agents, policies,
+references, and setup material.
 
 For the contributor-facing work to compile an existing agent workspace into
 those portable artifacts, see
@@ -219,21 +238,7 @@ providers:
     binary: /path/to/real/claude
   codex:
     binary: /path/to/real/codex
-  auggie:
-    binary: /path/to/real/auggie
-  aider:
-    binary: /path/to/real/aider
 ```
-
-Cline is project-scoped and materialization-only. It writes `.clinerules/` and
-`.clinerules/lineage.md`, does not require a configured or PATH-resolved Cline
-binary, does not launch a Cline CLI or GUI, does not install a `cline` shim, and
-does not write global MCP settings.
-
-Windsurf support is also project-scoped and config/materialization-only. Lineage
-stages skills under `.windsurf/rules/` and writes its generated context to the
-legacy-compatible project-local `.windsurfrules` file. It does not launch the
-Windsurf GUI or write Windsurf's global MCP configuration.
 
 The first time `lineage run` would stage files for a provider, it shows what it
 is about to create or change and asks for confirmation. Pass `--yes`/`-y` to
@@ -261,37 +266,13 @@ lineage enable <package-path-or-id> [--yes]
 lineage disable <package-path-or-id> [--yes]
 lineage list
 lineage inspect <package-path-or-id> [--yaml]
-lineage run <claude|codex|auggie|windsurf|aider|cline> [--dry-run] [--yes] [-- provider args...]
-lineage workflow run <workflow-name> <claude|codex|auggie|windsurf|aider|cline> [--dry-run] [--yes] [-- provider args...]
+lineage run <claude|codex> [--dry-run] [--yes] [-- provider args...]
+lineage workflow run <workflow-name> <claude|codex> [--dry-run] [--yes] [-- provider args...]
 
-lineage install-shims                 # launchable providers only; not Windsurf/Cline
+lineage install-shims
 lineage doctor
 lineage version
 ```
-
-### Auggie setup and limitations
-
-Auggie is installed and authenticated separately on the receiving machine. It
-currently requires Node.js 22 or later:
-
-```bash
-npm install -g @augmentcode/auggie
-auggie login
-lineage run auggie --dry-run
-```
-
-The adapter finds `auggie` on `PATH`, or uses `providers.auggie.binary` when
-configured. When approved, Lineage stages package skills in
-`.augment/skills/`, updates its generated section in the project's `AGENTS.md`,
-and launches Auggie with the supplied provider arguments.
-
-Lineage does not read, package, or materialize Augment credentials, login or
-session state, settings, user rules, MCP configuration, or other machine-local
-files under `~/.augment`. Configure those features locally with Auggie. Auggie
-is currently beta, so its own platform and terminal limitations still apply.
-
-Use `lineage run windsurf --dry-run` or `lineage run cline --dry-run` to inspect
-the plan before applying it.
 
 Useful day-to-day checks:
 
@@ -302,8 +283,8 @@ lineage doctor
 lineage workflow run resume-review claude --dry-run
 ```
 
-Install local shims when you want launchable provider commands such as `claude`,
-`codex`, `auggie`, or `aider` to enter Lineage first:
+Install local shims when you want commands such as `claude` or `codex` to enter
+Lineage first:
 
 ```bash
 lineage install-shims

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lineage
 
-Package and share Claude Code and Codex workflow environments.
+Package and share Claude Code, Codex, Windsurf, Aider, and Cline workflow environments.
 
 A reusable agent workflow usually depends on more than one prompt or skill:
 skills, workflow steps, agents, policies, references, setup files, declared
@@ -32,12 +32,15 @@ Use Lineage when you want to:
   deterministic `.tgz` archive.
 - Let receivers inspect package contents and declared capabilities before
   enabling the workflow locally.
-- Run the packaged workflow through Claude Code or Codex without rebuilding the
-  environment by hand in each project.
+- Run the packaged workflow through Claude Code, Codex, Windsurf, Aider, or Cline
+  without rebuilding the environment by hand in each project.
 
 Lineage is provider-adjacent, not provider-owned. It prepares local files for
 the agent provider the receiver already uses; it does not replace Claude Code,
-Codex, or the user's agent account.
+Codex, Windsurf, Aider, Cline, or the user's agent account. Windsurf and Cline
+support is project-scoped and config/materialization-only: their `lineage run`
+and workflow forms stage project files and exit without resolving or launching
+their native GUIs.
 
 ## Install
 
@@ -76,6 +79,9 @@ lineage package validate ./resume-workflow
 lineage enable ./resume-workflow
 lineage run claude --dry-run
 lineage run codex --dry-run
+lineage run windsurf --dry-run
+lineage run aider --dry-run
+lineage run cline --dry-run
 ```
 
 Publish it to the Lineage registry:
@@ -215,12 +221,18 @@ what it would materialize before writing.
 
 - `lineage run claude --dry-run` previews Claude materialization.
 - `lineage run codex --dry-run` previews Codex materialization.
-- `lineage workflow run <workflow-name> <claude|codex> --dry-run` narrows the
-  launch plan to one exported workflow.
+- `lineage run auggie --dry-run` previews Auggie materialization.
+- `lineage run cline --dry-run` previews Cline materialization.
+- `lineage run aider --dry-run` previews Aider materialization.
+- `lineage run windsurf --dry-run` previews Windsurf project materialization
+  without resolving a Windsurf binary.
+- `lineage workflow run <workflow-name> <claude|codex|auggie|windsurf|aider|cline> --dry-run`
+  narrows the plan to one exported workflow; Windsurf and Cline remain
+  materialization-only.
 
-The current adapters focus on Claude and Codex. The package shape stays plain so
-future adapters can use the same manifest, skills, workflows, agents, policies,
-references, and setup material.
+The current adapters focus on Claude, Codex, Auggie, Windsurf, Aider, and
+Cline. The package shape stays plain so future adapters can use the same
+manifest, skills, workflows, agents, policies, references, and setup material.
 
 For the contributor-facing work to compile an existing agent workspace into
 those portable artifacts, see
@@ -238,7 +250,21 @@ providers:
     binary: /path/to/real/claude
   codex:
     binary: /path/to/real/codex
+  auggie:
+    binary: /path/to/real/auggie
+  aider:
+    binary: /path/to/real/aider
 ```
+
+Cline is project-scoped and materialization-only. It writes `.clinerules/` and
+`.clinerules/lineage.md`, does not require a configured or PATH-resolved Cline
+binary, does not launch a Cline CLI or GUI, does not install a `cline` shim, and
+does not write global MCP settings.
+
+Windsurf support is also project-scoped and config/materialization-only. Lineage
+stages skills under `.windsurf/rules/` and writes its generated context to the
+legacy-compatible project-local `.windsurfrules` file. It does not launch the
+Windsurf GUI or write Windsurf's global MCP configuration.
 
 The first time `lineage run` would stage files for a provider, it shows what it
 is about to create or change and asks for confirmation. Pass `--yes`/`-y` to
@@ -266,13 +292,37 @@ lineage enable <package-path-or-id> [--yes]
 lineage disable <package-path-or-id> [--yes]
 lineage list
 lineage inspect <package-path-or-id> [--yaml]
-lineage run <claude|codex> [--dry-run] [--yes] [-- provider args...]
-lineage workflow run <workflow-name> <claude|codex> [--dry-run] [--yes] [-- provider args...]
+lineage run <claude|codex|auggie|windsurf|aider|cline> [--dry-run] [--yes] [-- provider args...]
+lineage workflow run <workflow-name> <claude|codex|auggie|windsurf|aider|cline> [--dry-run] [--yes] [-- provider args...]
 
-lineage install-shims
+lineage install-shims                 # launchable providers only; not Windsurf/Cline
 lineage doctor
 lineage version
 ```
+
+### Auggie setup and limitations
+
+Auggie is installed and authenticated separately on the receiving machine. It
+currently requires Node.js 22 or later:
+
+```bash
+npm install -g @augmentcode/auggie
+auggie login
+lineage run auggie --dry-run
+```
+
+The adapter finds `auggie` on `PATH`, or uses `providers.auggie.binary` when
+configured. When approved, Lineage stages package skills in
+`.augment/skills/`, updates its generated section in the project's `AGENTS.md`,
+and launches Auggie with the supplied provider arguments.
+
+Lineage does not read, package, or materialize Augment credentials, login or
+session state, settings, user rules, MCP configuration, or other machine-local
+files under `~/.augment`. Configure those features locally with Auggie. Auggie
+is currently beta, so its own platform and terminal limitations still apply.
+
+Use `lineage run windsurf --dry-run` or `lineage run cline --dry-run` to inspect
+the plan before applying it.
 
 Useful day-to-day checks:
 
@@ -283,8 +333,8 @@ lineage doctor
 lineage workflow run resume-review claude --dry-run
 ```
 
-Install local shims when you want commands such as `claude` or `codex` to enter
-Lineage first:
+Install local shims when you want launchable provider commands such as `claude`,
+`codex`, `auggie`, or `aider` to enter Lineage first:
 
 ```bash
 lineage install-shims

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -490,6 +490,7 @@ func runPackageValidate(dir string, yamlOutput bool, stdout, stderr io.Writer) e
 	fmt.Fprintf(stdout, "capabilities:\n")
 	fmt.Fprintf(stdout, "  filesystem.read: %s\n", listValue(report.Manifest.Capabilities.Filesystem.Read))
 	fmt.Fprintf(stdout, "  network: %s\n", listValue(report.Manifest.Capabilities.Network))
+	writeMCPDependencies(stdout, report.Manifest.Dependencies.MCP)
 	packages.WritePortabilityReport(stdout, packages.NewPortabilityReport(report))
 
 	if len(report.Notes) > 0 {
@@ -1132,10 +1133,29 @@ func runInspect(args []string, home string, stdout, stderr io.Writer) error {
 	fmt.Fprintf(stdout, "agents: %s\n", listValue(pkg.Agents))
 	fmt.Fprintf(stdout, "policies: %s\n", listValue(pkg.Policies))
 	fmt.Fprintf(stdout, "requires.skills: %s\n", listValue(pkg.Manifest.Requires.Skills))
+	writeMCPDependencies(stdout, pkg.Manifest.Dependencies.MCP)
 	fmt.Fprintf(stdout, "capabilities:\n")
 	fmt.Fprintf(stdout, "  filesystem.read: %s\n", listValue(pkg.Manifest.Capabilities.Filesystem.Read))
 	fmt.Fprintf(stdout, "  network: %s\n", listValue(pkg.Manifest.Capabilities.Network))
 	return nil
+}
+
+func writeMCPDependencies(stdout io.Writer, deps []packages.MCPDependency) {
+	fmt.Fprintln(stdout, "dependencies.mcp:")
+	if len(deps) == 0 {
+		fmt.Fprintln(stdout, "  none")
+		return
+	}
+	for _, dep := range deps {
+		fmt.Fprintf(stdout, "  - %s (%s", dep.Name, dep.Transport)
+		if dep.URL != "" {
+			fmt.Fprintf(stdout, ", %s", dep.URL)
+		}
+		if dep.Auth == "receiver" {
+			fmt.Fprint(stdout, ", receiver-provided authentication")
+		}
+		fmt.Fprintln(stdout, ")")
+	}
 }
 
 func runProvider(ctx context.Context, args []string, home string, stdin *bufio.Reader, stdout, stderr io.Writer) error {
@@ -1196,9 +1216,6 @@ func runProvider(ctx context.Context, args []string, home string, stdin *bufio.R
 	if err := materialize.Apply(plan.ProjectRoot, adapter, plan.Packages); err != nil {
 		fmt.Fprintln(stderr, err)
 		return err
-	}
-	if plan.ProviderPlan.MaterializeOnly {
-		return nil
 	}
 
 	if err := provider.Launch(plan.ProviderPlan); err != nil {
@@ -1284,9 +1301,6 @@ func runWorkflow(args []string, home string, stdin *bufio.Reader, stdout, stderr
 		fmt.Fprintln(stderr, err)
 		return err
 	}
-	if providerPlan.MaterializeOnly {
-		return nil
-	}
 
 	if err := provider.Launch(providerPlan); err != nil {
 		fmt.Fprintln(stderr, err)
@@ -1302,12 +1316,6 @@ func workflowPlanString(wf packages.Workflow, pkg packages.Package, providerName
 	fmt.Fprintf(&b, "package: %s@%s\n", pkg.Manifest.Name, pkg.Manifest.Version)
 	fmt.Fprintf(&b, "provider: %s\n", providerName)
 	fmt.Fprintf(&b, "real_binary: %s\n", emptyValue(providerPlan.Binary))
-	fmt.Fprintf(&b, "args: %s\n", strings.Join(providerPlan.Args, " "))
-	if providerPlan.MaterializeOnly {
-		fmt.Fprintf(&b, "launch: disabled (config/materialization only)\n")
-	} else {
-		fmt.Fprintf(&b, "launch: enabled\n")
-	}
 	fmt.Fprintf(&b, "steps:\n")
 	for i, step := range wf.Steps {
 		fmt.Fprintf(&b, "  %d. %s\n", i+1, step)
@@ -1445,8 +1453,8 @@ func pathIndexOf(pathEntries []string, dir string) int {
 
 func printUsage(w io.Writer) {
 	fmt.Fprintln(w, strings.TrimSpace(fmt.Sprintf(`
-Lineage - package a working agent setup, share it, and run it through a
-supported agent provider.
+Lineage - package a working agent setup, share it, and run it through your
+own Claude or Codex.
 
 Usage:
   lineage <command> [arguments]
@@ -1471,13 +1479,13 @@ Using a package:
   list                                    show enabled packages
   inspect <path-or-id> [--yaml]            show a package's contents
   graph list [--yaml]                      show what this project's state descends from
-  run <%s> [--dry-run] [--yes]  apply packages and launch where supported
+  run <%s> [--dry-run] [--yes]  launch a provider with packages applied
   workflow run <name> <%s>      run one declared workflow
 
 Setup:
   init user                               create the user package directory
   init workspace <name>                   create a shared workspace
-  install-shims                           put lineage in front of launchable providers on PATH
+  install-shims                           put lineage in front of claude/codex on PATH
   doctor                                  check config, PATH, and provider setup
 
   -h, --help                              show this help

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1217,6 +1217,9 @@ func runProvider(ctx context.Context, args []string, home string, stdin *bufio.R
 		fmt.Fprintln(stderr, err)
 		return err
 	}
+	if plan.ProviderPlan.MaterializeOnly {
+		return nil
+	}
 
 	if err := provider.Launch(plan.ProviderPlan); err != nil {
 		fmt.Fprintln(stderr, err)
@@ -1301,6 +1304,9 @@ func runWorkflow(args []string, home string, stdin *bufio.Reader, stdout, stderr
 		fmt.Fprintln(stderr, err)
 		return err
 	}
+	if providerPlan.MaterializeOnly {
+		return nil
+	}
 
 	if err := provider.Launch(providerPlan); err != nil {
 		fmt.Fprintln(stderr, err)
@@ -1316,6 +1322,12 @@ func workflowPlanString(wf packages.Workflow, pkg packages.Package, providerName
 	fmt.Fprintf(&b, "package: %s@%s\n", pkg.Manifest.Name, pkg.Manifest.Version)
 	fmt.Fprintf(&b, "provider: %s\n", providerName)
 	fmt.Fprintf(&b, "real_binary: %s\n", emptyValue(providerPlan.Binary))
+	fmt.Fprintf(&b, "args: %s\n", strings.Join(providerPlan.Args, " "))
+	if providerPlan.MaterializeOnly {
+		fmt.Fprintf(&b, "launch: disabled (config/materialization only)\n")
+	} else {
+		fmt.Fprintf(&b, "launch: enabled\n")
+	}
 	fmt.Fprintf(&b, "steps:\n")
 	for i, step := range wf.Steps {
 		fmt.Fprintf(&b, "  %d. %s\n", i+1, step)
@@ -1453,8 +1465,8 @@ func pathIndexOf(pathEntries []string, dir string) int {
 
 func printUsage(w io.Writer) {
 	fmt.Fprintln(w, strings.TrimSpace(fmt.Sprintf(`
-Lineage - package a working agent setup, share it, and run it through your
-own Claude or Codex.
+Lineage - package a working agent setup, share it, and run it through a
+supported agent provider.
 
 Usage:
   lineage <command> [arguments]
@@ -1479,13 +1491,13 @@ Using a package:
   list                                    show enabled packages
   inspect <path-or-id> [--yaml]            show a package's contents
   graph list [--yaml]                      show what this project's state descends from
-  run <%s> [--dry-run] [--yes]  launch a provider with packages applied
+  run <%s> [--dry-run] [--yes]  apply packages and launch where supported
   workflow run <name> <%s>      run one declared workflow
 
 Setup:
   init user                               create the user package directory
   init workspace <name>                   create a shared workspace
-  install-shims                           put lineage in front of claude/codex on PATH
+  install-shims                           put lineage in front of launchable providers on PATH
   doctor                                  check config, PATH, and provider setup
 
   -h, --help                              show this help

--- a/internal/cli/structured.go
+++ b/internal/cli/structured.go
@@ -29,6 +29,7 @@ type PackageReport struct {
 	Agents         []string                    `yaml:"agents,omitempty"`
 	Policies       []string                    `yaml:"policies,omitempty"`
 	RequiredSkills []string                    `yaml:"required_skills"`
+	MCPDependencies []packages.MCPDependency   `yaml:"mcp_dependencies"`
 	Providers      []string                    `yaml:"providers"`
 	Capabilities   PackageReportCapabilities   `yaml:"capabilities"`
 	Portability    *packages.PortabilityReport `yaml:"portability,omitempty"`
@@ -71,6 +72,7 @@ func inspectReport(pkg packages.Package) PackageReport {
 		Agents:         nonNil(pkg.Agents),
 		Policies:       nonNil(pkg.Policies),
 		RequiredSkills: nonNil(pkg.Manifest.Requires.Skills),
+		MCPDependencies: nonNilMCP(pkg.Manifest.Dependencies.MCP),
 		Providers:      nonNil(pkg.Manifest.Entrypoints.Providers()),
 		Capabilities: PackageReportCapabilities{
 			FilesystemRead: nonNil(pkg.Manifest.Capabilities.Filesystem.Read),
@@ -97,6 +99,7 @@ func validateReport(report packages.ValidateReport, discovered *packages.Package
 		Schema:         report.Manifest.Schema,
 		Digest:         report.Digest,
 		RequiredSkills: nonNil(report.Manifest.Requires.Skills),
+		MCPDependencies: nonNilMCP(report.Manifest.Dependencies.MCP),
 		Providers:      nonNil(report.Manifest.Entrypoints.Providers()),
 		Capabilities: PackageReportCapabilities{
 			FilesystemRead: nonNil(report.Manifest.Capabilities.Filesystem.Read),
@@ -116,6 +119,13 @@ func validateReport(report packages.ValidateReport, discovered *packages.Package
 		pr.Policies = nonNil(discovered.Policies)
 	}
 	return pr
+}
+
+func nonNilMCP(values []packages.MCPDependency) []packages.MCPDependency {
+	if values == nil {
+		return []packages.MCPDependency{}
+	}
+	return values
 }
 
 // writeYAML encodes report and writes it to stdout. yaml.v3's Encoder is

--- a/internal/packages/discovery.go
+++ b/internal/packages/discovery.go
@@ -41,6 +41,9 @@ func Discover(dir string) (Package, error) {
 	if err := validateEntrypoint(dir, "codex", manifest.Entrypoints.Codex); err != nil {
 		return Package{}, fmt.Errorf("%s: %w", dir, err)
 	}
+	if errors := ValidateMCPDependencies(manifest.Dependencies.MCP, manifest.Capabilities.Network); len(errors) > 0 {
+		return Package{}, fmt.Errorf("%s: %s", dir, errors[0])
+	}
 
 	workflows, err := applyExportAuthority("workflow", manifest.Exports.Workflows, discoverNamesWithFile(filepath.Join(dir, "workflows"), WorkflowFileName))
 	if err != nil {

--- a/internal/packages/manifest.go
+++ b/internal/packages/manifest.go
@@ -40,8 +40,28 @@ type Manifest struct {
 	Exports      Exports      `yaml:"exports"`
 	Requires     Requires     `yaml:"requires"`
 	Entrypoints  Entrypoints  `yaml:"entrypoints"`
+	Dependencies Dependencies `yaml:"dependencies" json:"dependencies"`
 	Capabilities Capabilities `yaml:"capabilities"`
 	Setup        Setup        `yaml:"setup"`
+}
+
+// Dependencies are runtime requirements that are part of a package's
+// behavior but are not package files. They are deliberately provider-neutral:
+// adapters decide whether and how they can materialize a declared dependency.
+type Dependencies struct {
+	MCP []MCPDependency `yaml:"mcp" json:"mcp"`
+}
+
+// MCPDependency declares one Model Context Protocol server. Auth is a
+// requirement label, never a credential: receivers supply authentication in
+// their own environment or provider configuration.
+type MCPDependency struct {
+	Name      string   `yaml:"name" json:"name"`
+	Transport string   `yaml:"transport" json:"transport"` // stdio, streamable-http, sse
+	Command   string   `yaml:"command,omitempty" json:"command,omitempty"`
+	Args      []string `yaml:"args,omitempty" json:"args,omitempty"`
+	URL       string   `yaml:"url,omitempty" json:"url,omitempty"`
+	Auth      string   `yaml:"auth,omitempty" json:"auth,omitempty"` // none, receiver
 }
 
 // Setup declares local resources a package's workflow expects to exist -
@@ -129,6 +149,7 @@ func DefaultManifest(name string) Manifest {
 			Skills: []string{},
 		},
 		Entrypoints: Entrypoints{},
+		Dependencies: Dependencies{MCP: []MCPDependency{}},
 		Capabilities: Capabilities{
 			Filesystem: FilesystemCapabilities{Read: []string{}},
 			Network:    []string{},
@@ -149,6 +170,9 @@ func LoadManifest(dir string) (Manifest, error) {
 
 	var manifest Manifest
 	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		return Manifest{}, fmt.Errorf("parse manifest %s: %w", path, err)
+	}
+	if err := validateMCPManifestFields(data); err != nil {
 		return Manifest{}, fmt.Errorf("parse manifest %s: %w", path, err)
 	}
 	if manifest.Name == "" {

--- a/internal/packages/manifest_test.go
+++ b/internal/packages/manifest_test.go
@@ -67,6 +67,25 @@ func TestLoadManifestAcceptsSemverStyleVersion(t *testing.T) {
 	}
 }
 
+func TestLoadManifestRejectsMCPFieldsOutsidePortableContract(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ManifestFileName), `
+name: safe-pack
+version: 1.0.0
+dependencies:
+  mcp:
+    - name: docs
+      transport: streamable-http
+      url: https://mcp.example.com/mcp
+      headers:
+        Authorization: Bearer not-a-real-token
+`)
+
+	if _, err := LoadManifest(dir); err == nil {
+		t.Fatal("LoadManifest() error = nil, want unsupported MCP headers to be rejected")
+	}
+}
+
 func TestDefaultManifestRoundTripsCapabilities(t *testing.T) {
 	dir := t.TempDir()
 	manifest := DefaultManifest("cap-pack")

--- a/internal/packages/mcp.go
+++ b/internal/packages/mcp.go
@@ -1,0 +1,105 @@
+package packages
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+var allowedMCPFields = map[string]bool{
+	"name": true, "transport": true, "command": true, "args": true, "url": true, "auth": true,
+}
+
+// validateMCPManifestFields rejects unmodelled MCP fields before the typed
+// manifest decoder can discard them. In particular, this prevents a package
+// from smuggling credential-bearing headers, tokens, or environment values
+// into a surface that promises not to distribute them.
+func validateMCPManifestFields(data []byte) error {
+	var raw struct {
+		Dependencies struct {
+			MCP []map[string]interface{} `yaml:"mcp"`
+		} `yaml:"dependencies"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	for i, server := range raw.Dependencies.MCP {
+		for field := range server {
+			if !allowedMCPFields[field] {
+				return fmt.Errorf("dependencies.mcp[%d].%s is not supported; credentials and provider-specific configuration must stay receiver-local", i, field)
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateMCPDependencies validates package-level MCP declarations without
+// contacting a server or executing a command. Credentials are intentionally
+// not representable in MCPDependency; auth can only say that the receiver must
+// supply it.
+func ValidateMCPDependencies(deps []MCPDependency, networkCapabilities []string) []string {
+	var errors []string
+	seen := map[string]bool{}
+	for i, dep := range deps {
+		prefix := fmt.Sprintf("dependencies.mcp[%d]", i)
+		if err := validateIdentifier("name", "lineage.yaml", dep.Name); err != nil {
+			errors = append(errors, prefix+": "+err.Error())
+			continue
+		}
+		if seen[dep.Name] {
+			errors = append(errors, fmt.Sprintf("%s: duplicate MCP server name %q", prefix, dep.Name))
+		}
+		seen[dep.Name] = true
+
+		switch dep.Transport {
+		case "stdio":
+			if strings.TrimSpace(dep.Command) == "" {
+				errors = append(errors, prefix+": stdio transport requires command")
+			}
+			if dep.URL != "" {
+				errors = append(errors, prefix+": stdio transport must not declare url")
+			}
+		case "streamable-http", "sse":
+			if strings.TrimSpace(dep.Command) != "" || len(dep.Args) > 0 {
+				errors = append(errors, prefix+": remote transport must not declare command or args")
+			}
+			u, err := url.Parse(dep.URL)
+			if err != nil || u.Scheme != "https" || u.Host == "" || u.User != nil {
+				errors = append(errors, prefix+": remote transport requires an absolute https url without embedded credentials")
+			} else if !networkCapabilityAllows(networkCapabilities, u.Hostname()) {
+				errors = append(errors, fmt.Sprintf("%s: remote host %q must be declared in capabilities.network", prefix, u.Hostname()))
+			}
+		default:
+			errors = append(errors, fmt.Sprintf("%s: transport %q is unsupported (use stdio, streamable-http, or sse)", prefix, dep.Transport))
+		}
+		if dep.Auth != "" && dep.Auth != "none" && dep.Auth != "receiver" {
+			errors = append(errors, fmt.Sprintf("%s: auth %q is unsupported (use none or receiver)", prefix, dep.Auth))
+		}
+	}
+	return errors
+}
+
+func networkCapabilityAllows(capabilities []string, host string) bool {
+	for _, capability := range capabilities {
+		if capability == "*" || strings.EqualFold(capability, host) {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateMCPProviderSupport prevents a declared server from being silently
+// dropped. The current Claude and Codex adapters only materialize package
+// assets; neither owns a safe merge boundary for native MCP configuration yet.
+// Until that adapter work exists, a package remains inspectable but cannot run
+// through Lineage with MCP dependencies enabled.
+func ValidateMCPProviderSupport(providerName string, pkgs []Package) error {
+	for _, pkg := range pkgs {
+		if len(pkg.Manifest.Dependencies.MCP) > 0 {
+			return fmt.Errorf("provider %q does not yet support MCP materialization required by package %q; refusing to silently drop %d declared MCP server(s)", providerName, pkg.Manifest.Name, len(pkg.Manifest.Dependencies.MCP))
+		}
+	}
+	return nil
+}

--- a/internal/packages/mcp_test.go
+++ b/internal/packages/mcp_test.go
@@ -1,0 +1,38 @@
+package packages
+
+import "testing"
+
+func TestValidateMCPDependencies(t *testing.T) {
+	tests := []struct {
+		name    string
+		dep     MCPDependency
+		network []string
+		wantErr bool
+	}{
+		{"stdio", MCPDependency{Name: "github", Transport: "stdio", Command: "npx", Args: []string{"-y", "server"}, Auth: "receiver"}, nil, false},
+		{"remote", MCPDependency{Name: "docs", Transport: "streamable-http", URL: "https://mcp.example.com/mcp", Auth: "receiver"}, []string{"mcp.example.com"}, false},
+		{"remote requires capability", MCPDependency{Name: "docs", Transport: "sse", URL: "https://mcp.example.com/sse"}, nil, true},
+		{"embedded credential", MCPDependency{Name: "bad", Transport: "sse", URL: "https://token@example.com/sse"}, []string{"example.com"}, true},
+		{"stdio needs command", MCPDependency{Name: "bad", Transport: "stdio"}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ValidateMCPDependencies([]MCPDependency{tt.dep}, tt.network)
+			if (len(got) > 0) != tt.wantErr {
+				t.Fatalf("errors = %v, wantErr %v", got, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateMCPProviderSupportRefusesSilentDrop(t *testing.T) {
+	pkg := Package{Manifest: Manifest{
+		Name: "mcp-pack",
+		Dependencies: Dependencies{MCP: []MCPDependency{{
+			Name: "docs", Transport: "stdio", Command: "npx",
+		}}},
+	}}
+	if err := ValidateMCPProviderSupport("claude", []Package{pkg}); err == nil {
+		t.Fatal("ValidateMCPProviderSupport() error = nil, want unsupported adapter error")
+	}
+}

--- a/internal/packages/validate.go
+++ b/internal/packages/validate.go
@@ -54,6 +54,7 @@ func Validate(dir string) (ValidateReport, error) {
 	if err := validateEntrypoint(dir, "codex", manifest.Entrypoints.Codex); err != nil {
 		report.Errors = append(report.Errors, err.Error())
 	}
+	report.Errors = append(report.Errors, ValidateMCPDependencies(manifest.Dependencies.MCP, manifest.Capabilities.Network)...)
 
 	// Setup paths are receiver-project-relative at apply time, but their
 	// safety (not absolute, can't escape via "..") doesn't depend on which

--- a/internal/packages/validate_test.go
+++ b/internal/packages/validate_test.go
@@ -124,6 +124,31 @@ func TestValidateNotesUnsatisfiedRequiredSkillWithoutFailing(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsMCPServerOutsideDeclaredNetworkCapability(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "mcp-pack")
+	if err := InitPackage(root, "mcp-pack"); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := LoadManifest(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest.Dependencies.MCP = []MCPDependency{{
+		Name: "docs", Transport: "streamable-http", URL: "https://mcp.example.com/mcp", Auth: "receiver",
+	}}
+	if err := SaveManifest(root, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := Validate(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Passed() {
+		t.Fatal("report.Passed() = true, want false for an undeclared remote MCP host")
+	}
+}
+
 func TestValidateFailsForUnloadableManifest(t *testing.T) {
 	root := t.TempDir()
 	mustWrite(t, filepath.Join(root, ManifestFileName), "schema: 99\nname: future\nversion: 1.0.0\n")

--- a/internal/runtime/plan.go
+++ b/internal/runtime/plan.go
@@ -37,6 +37,9 @@ func BuildPlan(providerName, cwd, home string, args []string) (Plan, error) {
 	if err := packages.ValidateDependencies(resolved); err != nil {
 		return Plan{}, err
 	}
+	if err := packages.ValidateMCPProviderSupport(providerName, resolved); err != nil {
+		return Plan{}, err
+	}
 
 	providerPlan, err := provider.Resolve(providerName, home, found.Config, args)
 	if err != nil {
@@ -64,11 +67,6 @@ func (p Plan) DryRunString() string {
 	fmt.Fprintf(&b, "lineage: %s\n", p.Lineage)
 	fmt.Fprintf(&b, "real_binary: %s\n", emptyValue(p.ProviderPlan.Binary))
 	fmt.Fprintf(&b, "args: %s\n", strings.Join(p.ProviderPlan.Args, " "))
-	if p.ProviderPlan.MaterializeOnly {
-		fmt.Fprintf(&b, "launch: disabled (config/materialization only)\n")
-	} else {
-		fmt.Fprintf(&b, "launch: enabled\n")
-	}
 	fmt.Fprintf(&b, "packages:\n")
 	if len(p.Packages) == 0 {
 		fmt.Fprintf(&b, "  none\n")
@@ -81,6 +79,12 @@ func (p Plan) DryRunString() string {
 		fmt.Fprintf(&b, "    workflows: %s\n", listValue(pkg.Workflows))
 		fmt.Fprintf(&b, "    agents: %s\n", listValue(pkg.Agents))
 		fmt.Fprintf(&b, "    policies: %s\n", listValue(pkg.Policies))
+		if len(pkg.Manifest.Dependencies.MCP) > 0 {
+			fmt.Fprintln(&b, "    mcp_dependencies:")
+			for _, dep := range pkg.Manifest.Dependencies.MCP {
+				fmt.Fprintf(&b, "      - %s (%s)\n", dep.Name, dep.Transport)
+			}
+		}
 		fmt.Fprintf(&b, "    capabilities:\n")
 		fmt.Fprintf(&b, "      filesystem.read: %s\n", listValue(pkg.Manifest.Capabilities.Filesystem.Read))
 		fmt.Fprintf(&b, "      network: %s\n", listValue(pkg.Manifest.Capabilities.Network))

--- a/internal/runtime/plan.go
+++ b/internal/runtime/plan.go
@@ -67,6 +67,11 @@ func (p Plan) DryRunString() string {
 	fmt.Fprintf(&b, "lineage: %s\n", p.Lineage)
 	fmt.Fprintf(&b, "real_binary: %s\n", emptyValue(p.ProviderPlan.Binary))
 	fmt.Fprintf(&b, "args: %s\n", strings.Join(p.ProviderPlan.Args, " "))
+	if p.ProviderPlan.MaterializeOnly {
+		fmt.Fprintf(&b, "launch: disabled (config/materialization only)\n")
+	} else {
+		fmt.Fprintf(&b, "launch: enabled\n")
+	}
 	fmt.Fprintf(&b, "packages:\n")
 	if len(p.Packages) == 0 {
 		fmt.Fprintf(&b, "  none\n")


### PR DESCRIPTION
## Summary

Add a portable, inspectable MCP dependency contract to Lineage packages. The manifest can declare stdio, streamable-http, and sse servers; validation rejects unsafe/unmodelled configuration and exposes required network capability before enablement.

## Linked Issue

Closes #245

- [x] The linked issue is assigned to me.
- [x] This PR targets `develop`, or it is a release-tracked promotion into `main`.
- [x] This PR is ready for review: the linked issue and test plan are complete.

## Package Impact

- [x] Package format or manifest behavior
- [x] Package discovery or enablement
- [x] Provider launch/shim behavior
- [ ] Setup or permission flow
- [ ] Documentation only
- [ ] Tests only

## Merge Method

- [x] Squash merge for an ordinary PR into `develop`.
- [ ] Merge commit for a release promotion into `main`.
- [ ] Merge commit for a `main` to `develop` sync-back.

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- Valid stdio and remote MCP declarations, including required declared network capability.
- Invalid transport shapes, embedded URL credentials, unsupported MCP fields, duplicate server names, and missing stdio commands.
- Inspect and structured-report visibility.
- Provider launch refusal when materialization is unsupported, preventing silent omission.

```text
git diff --check
go test ./...
```

The first command passed. `go test ./...` is required and will run in the GitHub Actions Linux/Windows matrix; the initial run exposed a stale-base error and this branch has now been rebuilt on current `develop`.

## Notes For Reviewers

- This deliberately defines the package contract and safety boundary, not native provider MCP configuration merging.
- Claude, Codex, and the other adapters fail explicitly when a package declares MCP dependencies they cannot materialize. A follow-up needs provider-specific merge/reconciliation state before materialization can be added safely.