### PR TITLE
feat(snapshot): harden content-addressed object writes

### DIFF
--- a/internal/snapshot/cas_hardening_test.go
+++ b/internal/snapshot/cas_hardening_test.go
@@ -1,0 +1,110 @@
+package snapshot
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/agentic-lineage/lineage/internal/config"
+)
+
+func TestReadObjectRejectsMalformedObjectID(t *testing.T) {
+	ids := []ObjectID{
+		"sha256:abc",
+		"sha256:GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
+		"sha512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/../escape",
+	}
+	for _, id := range ids {
+		if _, err := ReadObject(t.TempDir(), id); err == nil {
+			t.Fatalf("ReadObject(%q) error = nil, want invalid ID error", id)
+		}
+	}
+}
+
+func TestWriteObjectRefusesToReplaceCorruptExistingObject(t *testing.T) {
+	home := t.TempDir()
+	data := []byte("payload")
+	id := hashID(data)
+	path, err := blobPath(config.ObjectsDir(home), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("tampered"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WriteObject(home, data); err == nil {
+		t.Fatal("WriteObject() error = nil, want corrupt existing object error")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "tampered" {
+		t.Fatalf("WriteObject() replaced corrupt object with %q", got)
+	}
+}
+
+func TestConcurrentWriteObjectConvergesOnVerifiedObject(t *testing.T) {
+	home := t.TempDir()
+	data := []byte("concurrent payload")
+	const writers = 16
+	ids := make(chan ObjectID, writers)
+	errs := make(chan error, writers)
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			id, err := WriteObject(home, data)
+			if err != nil {
+				errs <- err
+				return
+			}
+			ids <- id
+		}()
+	}
+	wg.Wait()
+	close(ids)
+	close(errs)
+	for err := range errs {
+		t.Errorf("WriteObject() error = %v", err)
+	}
+	want := hashID(data)
+	for id := range ids {
+		if id != want {
+			t.Errorf("WriteObject() id = %s, want %s", id, want)
+		}
+	}
+	if err := VerifyObject(home, want); err != nil {
+		t.Fatalf("VerifyObject() error = %v", err)
+	}
+}
+
+func TestHasObjectDistinguishesMissingAndCorrupt(t *testing.T) {
+	home := t.TempDir()
+	missing := ObjectID("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	got, err := HasObject(home, missing)
+	if err != nil || got {
+		t.Fatalf("HasObject(missing) = %v, %v; want false, nil", got, err)
+	}
+
+	id, err := WriteObject(home, []byte("payload"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	path, err := blobPath(config.ObjectsDir(home), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("corrupt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := HasObject(home, id); err == nil || got {
+		t.Fatalf("HasObject(corrupt) = %v, %v; want false, non-nil", got, err)
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -1,12 +1,4 @@
-// Package snapshot is a content-addressed, immutable object store for
-// package snapshots: individual file objects are stored and addressed by
-// the sha256 hash of their own content, and a snapshot manifest — itself
-// just another content-addressed object, in a separate namespace — records
-// which object each file in a package resolves to. Because an object's
-// identity is entirely a function of its bytes, identical content always
-// maps to the same object ID, storage is naturally deduplicated, and
-// tampering is detectable: reading an object re-verifies its content
-// against the ID used to look it up (see docs/decisions/0014).
+// Package snapshot is a content-addressed, immutable object store for package snapshots.
 package snapshot
 
 import (
@@ -16,39 +8,28 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 
 	"github.com/agentic-lineage/lineage/internal/config"
 	"github.com/agentic-lineage/lineage/internal/packages"
 )
 
-// ObjectID identifies an immutable object (a file's content, or a
-// manifest's own serialized bytes) by content hash, formatted the same way
-// packages.ComputeDigest formats package digests: "sha256:<hex>".
 type ObjectID string
 
-// CurrentManifestSchema is the current snapshot manifest format version,
-// following the same defaulting convention as packages.Manifest's Schema
-// field (ADR 0005): a manifest with Schema 0 is treated as version 1.
+var objectIDPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
 const CurrentManifestSchema = 1
 
-// Manifest is a deterministic, hashable description of one package
-// snapshot: the package's identity, plus every file it contains mapped to
-// the ObjectID holding that file's content. Because Manifest is a struct
-// (not a map) and Files is kept sorted by Path, marshaling it always
-// produces identical bytes for identical content — the manifest's own
-// ObjectID (see Create) is the hash of exactly those bytes.
 type Manifest struct {
-	Schema  int            `json:"schema"`
-	Name    string         `json:"name"`
-	Version string         `json:"version"`
-	Files   []ManifestFile `json:"files"`
+	Schema int `json:"schema"`
+	Name string `json:"name"`
+	Version string `json:"version"`
+	Files []ManifestFile `json:"files"`
 }
 
-// ManifestFile maps one path within a package (relative to the package
-// root, forward-slashed) to the object holding its content.
 type ManifestFile struct {
-	Path   string   `json:"path"`
+	Path string `json:"path"`
 	Object ObjectID `json:"object"`
 }
 
@@ -57,26 +38,14 @@ func hashID(data []byte) ObjectID {
 	return ObjectID("sha256:" + hex.EncodeToString(sum[:]))
 }
 
-// blobPath returns where an object with the given ID lives under root,
-// fanned out into a two-character subdirectory (git-style) so a large
-// number of objects doesn't produce one enormous flat directory.
 func blobPath(root string, id ObjectID) (string, error) {
-	const prefix = "sha256:"
-	s := string(id)
-	if len(s) <= len(prefix) || s[:len(prefix)] != prefix {
+	if !objectIDPattern.MatchString(string(id)) {
 		return "", fmt.Errorf("invalid object id %q", id)
 	}
-	hexPart := s[len(prefix):]
-	if len(hexPart) < 3 {
-		return "", fmt.Errorf("invalid object id %q", id)
-	}
+	hexPart := string(id)[len("sha256:"):]
 	return filepath.Join(root, hexPart[:2], hexPart[2:]), nil
 }
 
-// putBlob writes data as a content-addressed object under root and returns
-// its ID. Writing the same content twice is a no-op the second time
-// (dedup): the destination path is entirely a function of the content
-// itself, so an existing file at that path is already exactly this data.
 func putBlob(root string, data []byte) (ObjectID, error) {
 	id := hashID(data)
 	path, err := blobPath(root, id)
@@ -84,6 +53,9 @@ func putBlob(root string, data []byte) (ObjectID, error) {
 		return "", err
 	}
 	if _, err := os.Stat(path); err == nil {
+		if _, err := getBlob(root, id); err != nil {
+			return "", fmt.Errorf("verify existing object %s: %w", id, err)
+		}
 		return id, nil
 	} else if !os.IsNotExist(err) {
 		return "", err
@@ -91,16 +63,39 @@ func putBlob(root string, data []byte) (ObjectID, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return "", err
 	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".lineage-object-*")
+	if err != nil {
 		return "", err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(0o644); err != nil {
+		tmp.Close()
+		return "", err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return "", err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		return "", err
+	}
+	if err := os.Link(tmpName, path); err != nil {
+		if _, verifyErr := getBlob(root, id); verifyErr == nil {
+			return id, nil
+		} else if os.IsExist(err) {
+			return "", fmt.Errorf("verify existing object %s: %w", id, verifyErr)
+		} else {
+			return "", fmt.Errorf("commit object %s: %w", id, err)
+		}
 	}
 	return id, nil
 }
 
-// getBlob reads the object with the given ID from under root and verifies
-// its content still hashes to that ID before returning it — a corrupt or
-// tampered object is rejected here rather than handed to a caller that
-// might reconstruct a package from it (see docs/decisions/0014).
 func getBlob(root string, id ObjectID) ([]byte, error) {
 	path, err := blobPath(root, id)
 	if err != nil {
@@ -116,53 +111,43 @@ func getBlob(root string, id ObjectID) ([]byte, error) {
 	return data, nil
 }
 
-// WriteObject stores data as a content-addressed file object and returns
-// its ID. Identical content, written any number of times, always returns
-// the same ID.
 func WriteObject(home string, data []byte) (ObjectID, error) {
 	return putBlob(config.ObjectsDir(home), data)
 }
 
-// ReadObject returns the content of the object with the given ID,
-// verifying it against the ID before returning it.
 func ReadObject(home string, id ObjectID) ([]byte, error) {
 	return getBlob(config.ObjectsDir(home), id)
 }
 
-// VerifyObject reports whether the object with the given ID is present and
-// its stored content still hashes to that ID.
 func VerifyObject(home string, id ObjectID) error {
 	_, err := ReadObject(home, id)
 	return err
 }
 
-// manifestBytes returns m's canonical, deterministic serialization: the
-// exact bytes Create hashes to produce m's own ObjectID, and the exact
-// bytes LoadManifest expects to read back.
-func manifestBytes(m Manifest) ([]byte, error) {
-	return json.MarshalIndent(m, "", "  ")
+func HasObject(home string, id ObjectID) (bool, error) {
+	_, err := ReadObject(home, id)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
 }
 
-// Create builds an immutable snapshot of the package directory at dir:
-// every file under its standard content directories, plus its manifest
-// file (packages.ManifestFileName), is written as a content-addressed
-// object, and a Manifest listing them (sorted by path, so the result is
-// deterministic across repeated calls against unchanged content) is
-// written as its own object in a separate namespace. Create returns the
-// Manifest and its ObjectID.
+func manifestBytes(m Manifest) ([]byte, error) { return json.MarshalIndent(m, "", "  ") }
+
 func Create(home, dir string) (Manifest, ObjectID, error) {
 	manifest, err := packages.LoadManifest(dir)
 	if err != nil {
 		return Manifest{}, "", err
 	}
-
 	relPaths, err := packages.ContentFiles(dir)
 	if err != nil {
 		return Manifest{}, "", err
 	}
 	relPaths = append(relPaths, packages.ManifestFileName)
 	sort.Strings(relPaths)
-
 	files := make([]ManifestFile, 0, len(relPaths))
 	for _, rel := range relPaths {
 		data, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(rel)))
@@ -175,14 +160,7 @@ func Create(home, dir string) (Manifest, ObjectID, error) {
 		}
 		files = append(files, ManifestFile{Path: rel, Object: id})
 	}
-
-	snapshotManifest := Manifest{
-		Schema:  CurrentManifestSchema,
-		Name:    manifest.Name,
-		Version: manifest.Version,
-		Files:   files,
-	}
-
+	snapshotManifest := Manifest{Schema: CurrentManifestSchema, Name: manifest.Name, Version: manifest.Version, Files: files}
 	data, err := manifestBytes(snapshotManifest)
 	if err != nil {
 		return Manifest{}, "", fmt.Errorf("encode snapshot manifest: %w", err)
@@ -194,8 +172,6 @@ func Create(home, dir string) (Manifest, ObjectID, error) {
 	return snapshotManifest, id, nil
 }
 
-// LoadManifest reads and verifies the snapshot manifest with the given ID,
-// then decodes it.
 func LoadManifest(home string, id ObjectID) (Manifest, error) {
 	data, err := getBlob(config.SnapshotsDir(home), id)
 	if err != nil {
@@ -208,11 +184,6 @@ func LoadManifest(home string, id ObjectID) (Manifest, error) {
 	return m, nil
 }
 
-// Materialize reconstructs m's files under destDir. Every object m
-// references is verified before anything is written to destDir: a single
-// corrupt object fails the whole call, and destDir is left untouched,
-// rather than reconstructing a package with silently missing or wrong
-// content (see docs/decisions/0014).
 func Materialize(home string, m Manifest, destDir string) error {
 	contents := make(map[string][]byte, len(m.Files))
 	for _, f := range m.Files {
@@ -222,7 +193,6 @@ func Materialize(home string, m Manifest, destDir string) error {
 		}
 		contents[f.Path] = data
 	}
-
 	for _, f := range m.Files {
 		dest, err := packages.SafeJoin(destDir, f.Path)
 		if err != nil {


### PR DESCRIPTION
## Summary

Superseded by continued work under #266. This partial PR cannot satisfy the repository policy honestly because it does not complete or close the issue.

## Linked Issue

Maintainer housekeeping: closing this incomplete implementation slice so #266 remains represented by one final, policy-compliant PR.

## Package Impact

- [ ] Package format or manifest behavior
- [ ] Package discovery or enablement
- [ ] Provider launch/shim behavior
- [ ] Setup or permission flow
- [ ] Documentation only
- [ ] Tests only

## Merge Method

- [x] Squash merge for an ordinary PR into `develop`.

## Safety

- [x] This change does not export secrets, credentials, private prompts, or machine-local state.
- [x] Package inputs are treated as untrusted.
- [x] Path handling prevents traversal outside the intended workspace/package root where applicable.
- [x] Provider-specific logic stays behind an explicit boundary.

## Verification

Relevant test cases:

- Not applicable; this PR is being closed without merge.

```text
go test ./...
```

If this PR does not need automated tests, explain why:

- This PR will not be merged.