### PR TITLE
fix: reject duplicate skill exports across enabled packages

### DIFF
--- a/internal/packages/dependencies.go
+++ b/internal/packages/dependencies.go
@@ -1,26 +1,70 @@
 package packages
 
-import "fmt"
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+)
 
 // ValidateDependencies checks that every package's Requires.Skills is
-// satisfied somewhere across pkgs — its own skills, or another package's.
+// satisfied somewhere across pkgs — its own skills, or another package's —
+// and that no skill name is exported by more than one enabled package.
 // It's meant to run against the full set of packages that will be enabled
 // together (not one package in isolation), since a required skill can
 // legitimately be provided by a different enabled package.
+//
+// A skill exported by two enabled packages is ambiguous: whichever
+// definition wins later resolution order would silently satisfy the
+// dependency, so validation fails instead of choosing (#246).
 func ValidateDependencies(pkgs []Package) error {
-	available := map[string]bool{}
+	providers := map[string][]string{}
 	for _, pkg := range pkgs {
 		for _, skill := range pkg.Skills {
-			available[skill] = true
+			if !slices.Contains(providers[skill], pkg.Manifest.Name) {
+				providers[skill] = append(providers[skill], pkg.Manifest.Name)
+			}
 		}
+	}
+
+	for _, skill := range sortedKeys(providers) {
+		pkgs := providers[skill]
+		if len(pkgs) < 2 {
+			continue
+		}
+		sort.Strings(pkgs)
+		if len(pkgs) == 2 {
+			return fmt.Errorf("cannot enable package set: skill %q is exported by both %q and %q", skill, pkgs[0], pkgs[1])
+		}
+		return fmt.Errorf("cannot enable package set: skill %q is exported by multiple packages: %s", skill, quotedJoin(pkgs))
 	}
 
 	for _, pkg := range pkgs {
 		for _, required := range pkg.Manifest.Requires.Skills {
-			if !available[required] {
+			if _, provided := providers[required]; !provided {
 				return fmt.Errorf("package %q requires skill %q, which is not provided by any enabled package", pkg.Manifest.Name, required)
 			}
 		}
 	}
 	return nil
+}
+
+// sortedKeys returns providers' skill names in sorted order so the first
+// conflict reported — and therefore the error message — is independent of
+// package/discovery iteration order.
+func sortedKeys(providers map[string][]string) []string {
+	skills := make([]string, 0, len(providers))
+	for skill := range providers {
+		skills = append(skills, skill)
+	}
+	sort.Strings(skills)
+	return skills
+}
+
+func quotedJoin(items []string) string {
+	quoted := make([]string, len(items))
+	for i, item := range items {
+		quoted[i] = fmt.Sprintf("%q", item)
+	}
+	return strings.Join(quoted, ", ")
 }

--- a/internal/packages/dependencies_test.go
+++ b/internal/packages/dependencies_test.go
@@ -34,3 +34,61 @@ func TestValidateDependenciesMissingSkillFails(t *testing.T) {
 		t.Fatal("ValidateDependencies() error = nil, want error for missing required skill")
 	}
 }
+
+func TestValidateDependenciesDuplicateExportFails(t *testing.T) {
+	foo := Package{
+		Manifest: Manifest{Name: "foo"},
+		Skills:   []string{"research"},
+	}
+	bar := Package{
+		Manifest: Manifest{Name: "bar"},
+		Skills:   []string{"research"},
+	}
+	err := ValidateDependencies([]Package{foo, bar})
+	if err == nil {
+		t.Fatal("ValidateDependencies() error = nil, want error for duplicate skill export")
+	}
+	want := `cannot enable package set: skill "research" is exported by both "bar" and "foo"`
+	if err.Error() != want {
+		t.Fatalf("ValidateDependencies() error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestValidateDependenciesDuplicateExportIndependentOfOrder(t *testing.T) {
+	foo := Package{Manifest: Manifest{Name: "foo"}, Skills: []string{"research"}}
+	bar := Package{Manifest: Manifest{Name: "bar"}, Skills: []string{"research"}}
+	first := ValidateDependencies([]Package{foo, bar})
+	second := ValidateDependencies([]Package{bar, foo})
+	if first == nil || second == nil {
+		t.Fatal("ValidateDependencies() error = nil, want error for duplicate skill export in both orders")
+	}
+	if first.Error() != second.Error() {
+		t.Fatalf("ValidateDependencies() error differs by iteration order: %q vs %q", first.Error(), second.Error())
+	}
+}
+
+func TestValidateDependenciesTripleExportNamesAllProviders(t *testing.T) {
+	pkgs := []Package{
+		{Manifest: Manifest{Name: "zeta"}, Skills: []string{"research"}},
+		{Manifest: Manifest{Name: "alpha"}, Skills: []string{"research"}},
+		{Manifest: Manifest{Name: "mid"}, Skills: []string{"research"}},
+	}
+	err := ValidateDependencies(pkgs)
+	if err == nil {
+		t.Fatal("ValidateDependencies() error = nil, want error for triple skill export")
+	}
+	want := `cannot enable package set: skill "research" is exported by multiple packages: "alpha", "mid", "zeta"`
+	if err.Error() != want {
+		t.Fatalf("ValidateDependencies() error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestValidateDependenciesSelfRequirementIsNotAConflict(t *testing.T) {
+	pkg := Package{
+		Manifest: Manifest{Name: "self-sufficient", Requires: Requires{Skills: []string{"review"}}},
+		Skills:   []string{"review"},
+	}
+	if err := ValidateDependencies([]Package{pkg}); err != nil {
+		t.Fatalf("ValidateDependencies() error = %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #246.

## What

`ValidateDependencies` now builds a map from exported skill name → providing packages and fails when two or more enabled packages export the same skill name, instead of letting later resolution order silently pick a winner.

## Error behavior

- Exactly two providers: `cannot enable package set: skill "research" is exported by both "bar" and "foo"`
- Three or more: `... is exported by multiple packages: "alpha", "mid", "zeta"`
- Skills and providers are sorted, so the first conflict reported — and the message itself — never depends on package/discovery iteration order.

## Compatibility

A valid enabled set with unique skill names validates exactly as before, and a package requiring a skill it exports alone still passes (no self-conflict).

## Verification

- `go test ./... -race -count=1`: all pass, including four new cases — duplicate export fails with both names, order-independence of the message, triple export lists all providers sorted, and the self-requirement non-conflict.

Assisted-by: Claude <noreply@anthropic.com>